### PR TITLE
Can't see Date icon on Dark theme in Chrome 

### DIFF
--- a/src/Templates/Public/styles/default-dark.css
+++ b/src/Templates/Public/styles/default-dark.css
@@ -159,6 +159,10 @@ input, textarea, select, .progress {
     color: #999 !important;
 }
 
+input[type=date]::-webkit-calendar-picker-indicator {
+    filter: invert(1) brightness(0.5) !important;
+}
+
 pre code {
     background-color: #090d13 !important;
     border-color: #214981 !important;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6960531/103232434-193d0d00-4943-11eb-91ec-341214778da1.png)
After:
![image](https://user-images.githubusercontent.com/6960531/103232409-06c2d380-4943-11eb-8189-a1708f0a1eaa.png)

* Feel free to fix it in other way.
* The "Terminal" theme have the same problem but I don't know how to fix it to be green color in the CSS.