### PR TITLE
Allows setting of initial value in code editor, and uploading to server

### DIFF
--- a/examples/code-editor.ps1
+++ b/examples/code-editor.ps1
@@ -1,0 +1,18 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer -StatusPageExceptions Show {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Code Editor' -Logo '/pode.web/images/icon.png' -Theme Dark
+
+
+    $codeEditor = New-PodeWebCodeEditor -Language Html -Name 'Code Editor' -AsCard -Value '<p style="color:white;">well</p>' -Upload {
+        $WebEvent.Data | Out-Default
+    }
+    Set-PodeWebHomePage -NoAuth -Layouts $codeEditor -NoTitle
+}

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -373,16 +373,19 @@ function hideSpinner(sender) {
     }
 }
 
+var _editors = {};
+
 function bindCodeEditors() {
-    if ($('.code-editor').length == 0) {
+    if ($('.pode-code-editor').length == 0) {
         return;
     }
 
     var src = $('script[role="monaco"]').attr('src');
     require.config({ paths: { 'vs': src.substring(0, src.lastIndexOf('/')) }});
 
+    // create the editors
     require(["vs/editor/editor.main"], function() {
-        $('.code-editor').each((i, e) => {
+        $('.pode-code-editor .code-editor').each((i, e) => {
             var theme = $(e).attr('pode-theme');
             if (!theme) {
                 var bodyTheme = getPodeTheme();
@@ -402,12 +405,31 @@ function bindCodeEditors() {
                 }
             }
 
-
             var editor = monaco.editor.create(e, {
-                value: '',
+                value: $(e).attr('pode-value'),
                 language: $(e).attr('pode-language'),
-                theme: theme
+                theme: theme,
+                readOnly: ($(e).attr('pode-read-only') == 'True')
             });
+
+            $(e).attr('pode-value', '');
+            _editors[$(e).attr('for')] = editor;
+        });
+    });
+
+    // bind upload buttons
+    $('.pode-code-editor .pode-upload').unbind('click').click(function(e) {
+        var button = getButton(e);
+        var editorId = button.attr('for');
+
+        var url = `/elements/code-editor/${editorId}/upload`;
+        var data = JSON.stringify({
+            language: $(`#${editorId} .code-editor`).attr('pode-language'),
+            value: _editors[editorId].getValue()
+        });
+
+        sendAjaxReq(url, data, null, true, null, {
+            contentType: 'application/json; charset=UTF-8'
         });
     });
 }

--- a/src/Templates/Views/elements/code-editor.pode
+++ b/src/Templates/Views/elements/code-editor.pode
@@ -1,1 +1,16 @@
-<div class="code-editor $($data.CssClasses)" pode-language="$($data.Language)" pode-theme="$($data.Theme)"></div>
+<div id="$($data.ID)" class="pode-code-editor $($data.CssClasses)">
+    $(if ($data.Uploadable) {
+        "<button class='btn btn-inbuilt-theme pode-upload mBottom1' type='button' title='Upload' data-toggle='tooltip' for='$($data.ID)'>
+            <span data-feather='upload' class='mRight02'></span>
+        </button>"
+    })
+
+    <div
+        class="code-editor"
+        for="$($data.ID)"
+        pode-language="$($data.Language)"
+        pode-theme="$($data.Theme)"
+        pode-read-only="$($data.ReadOnly)"
+        pode-value="$($data.Value)">
+    </div>
+</div>


### PR DESCRIPTION
### Description of the Change
Adds a new `-Value`, `-ReadOnly` and `-Upload` parameters to `New-PodeWebCodeEditor`.

* `-Value` sets a default value for the editor.
* `-ReadOnly` makes the editor read-only.
* `-Upload` is a scriptblock, that shows an upload button above the editor. When click, the language and editor value is posted, and available in the scriptblock as `$WebEvent.Data['language']` and `$WebEvent.Data['value']`

### Examples
```powershell
$codeEditor = New-PodeWebCodeEditor -Language Html -Name 'Code Editor' -AsCard -Value '<p style="color:white;">well</p>' -Upload {
    # Data will have language and value properties
    $WebEvent.Data | Out-Default
}
```
