### PR TITLE
Add support for custom themes

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -153,6 +153,32 @@ function Get-PodeWebAuthTheme
     return [string]::Empty
 }
 
+function Get-PodeWebInbuiltThemes
+{
+    return @('Auto', 'Light', 'Dark', 'Terminal', 'Custom')
+}
+
+function Test-PodeWebThemeCustom
+{
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
+
+    $inbuildThemes = Get-PodeWebInbuiltThemes
+    if ($Name -iin $inbuildThemes) {
+        return $false
+    }
+
+    $customThemes = Get-PodeWebState -Name 'custom-themes'
+    if ($customThemes.Themes.Keys -icontains $Name) {
+        return $true
+    }
+
+    return $false
+}
+
 function Test-PodeWebArrayEmpty
 {
     param(

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -15,7 +15,7 @@ function Use-PodeWebTemplates
         $FavIcon,
 
         [Parameter()]
-        [ValidateSet('Auto', 'Light', 'Dark', 'Terminal')]
+        [ValidateSet('Auto', 'Light', 'Dark', 'Terminal', 'Custom')]
         [string]
         $Theme = 'Auto'
     )
@@ -34,11 +34,16 @@ function Use-PodeWebTemplates
     Set-PodeWebState -Name 'title' -Value $Title
     Set-PodeWebState -Name 'logo' -Value $Logo
     Set-PodeWebState -Name 'favicon' -Value $FavIcon
-    Set-PodeWebState -Name 'theme' -Value $Theme.ToLowerInvariant()
-    Set-PodeWebState -Name 'social' -Value @{}
+    Set-PodeWebState -Name 'social' -Value ([ordered]@{})
     Set-PodeWebState -Name 'pages' -Value @()
     Set-PodeWebState -Name 'custom-css' -Value @()
     Set-PodeWebState -Name 'custom-js' -Value @()
+
+    Set-PodeWebState -Name 'theme' -Value $Theme.ToLowerInvariant()
+    Set-PodeWebState -Name 'custom-themes' -Value @{
+        Default = $null
+        Themes = [ordered]@{}
+    }
 
     $templatePath = Get-PodeWebTemplatePath
 
@@ -121,17 +126,77 @@ function Get-PodeWebTheme
         $IgnoreCookie
     )
 
+    $theme = [string]::Empty
+
+    # check cookies
     if (!$IgnoreCookie) {
         $theme = Get-PodeWebCookie -Name 'theme'
         if (($null -ne $theme) -and ![string]::IsNullOrWhiteSpace($theme.Value)) {
-            return $theme.Value.ToLowerInvariant()
+            $theme = $theme.Value
         }
     }
 
-    $theme = Get-PodeWebAuthTheme -AuthData (Get-PodeWebAuthData)
-    if (![string]::IsNullOrWhiteSpace($theme)) {
-        return $theme.ToLowerInvariant()
+    # check auth data
+    if ([string]::IsNullOrWhiteSpace($theme)) {
+        $theme = Get-PodeWebAuthTheme -AuthData (Get-PodeWebAuthData)
     }
 
-    return (Get-PodeWebState -Name 'theme').ToLowerInvariant()
+    # check state
+    if ([string]::IsNullOrWhiteSpace($theme)) {
+        $theme = (Get-PodeWebState -Name 'theme')
+    }
+
+    # if 'custom', set as default custom theme
+    if ($theme -ieq 'custom') {
+        $theme = (Get-PodeWebState -Name 'custom-themes').Default
+    }
+
+    if ([string]::IsNullOrWhiteSpace($theme)) {
+        $theme = 'Auto'
+    }
+
+    return $theme.ToLowerInvariant()
+}
+
+function Add-PodeWebCustomTheme
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Url
+    )
+
+    $Name = $Name.ToLowerInvariant()
+
+    # is the theme already inbuilt?
+    $inbuildThemes = Get-PodeWebInbuiltThemes
+    if ($Name -iin $inbuildThemes) {
+        throw "There is already an inbuilt theme for $($Name) defined"
+    }
+
+    # is the theme already defined?
+    $customThemes = Get-PodeWebState -Name 'custom-themes'
+    if ($customThemes.Themes.Keys -icontains $Name) {
+        throw "There is already a custom theme for $($Name) defined"
+    }
+
+    # add the custom theme
+    $customThemes.Themes[$Name] = @{
+        Url = $Url
+    }
+
+    # set as theme if first one
+    $currentTheme = Get-PodeWebState -Name 'theme'
+    if ($currentTheme -ieq 'custom') {
+        Set-PodeWebState -Name 'theme' -Value $Name
+    }
+
+    if ([string]::IsNullOrWhiteSpace($customThemes.Default)) {
+        $customThemes.Default = $Name
+    }
 }

--- a/src/Templates/Public/styles/default-light.css
+++ b/src/Templates/Public/styles/default-light.css
@@ -1,120 +1,118 @@
 nav#sidebarMenu {
-    background-color: #121d2f !important;
-    border-color: #214981 !important;
-    border-right-style: solid;
-    border-right-width: 1px
+    background-color: #f8f9fa !important;
+    border-color: #bbb !important;
 }
 
 .sidebar .nav-link {
-    color: #ccc !important;
+    color: #333 !important;
 }
 
 .welcome-msg {
-    color: #ccc !important;
+    color: rgba(255,255,255,.5) !important;
 }
 
 .welcome-msg img {
-    border-color: dodgerblue;
+    border-color: #bbb;
 }
 
 .media {
-    border-color: dodgerblue;
-    background-color: #121d2f;
+    border-color: #bbb;
+    background-color: #f5f5f5;
 }
 
 .media img {
-    border-color: dodgerblue;
+    border-color: #bbb;
 }
 
 .media .media-head {
-    border-bottom-color: dodgerblue;
+    border-bottom-color: #bbb;
 }
 
 body, main[role="main"], body#login-page, body#normal-page {
-    background-color: #161b22;
-    color: #aaa;
+    background-color: #f5f5f5;
+    color: #333;
 }
 
-.modal-content {
+/* .modal-content {
     border-color: #214981 !important;
     border-width: 2px !important;
-}
+} */
 
-.modal-header {
+/* .modal-header {
     background-color: #121d2f !important;
     border-bottom: 2px solid #214981 !important;
     color: #aaa !important;
-}
+} */
 
-.modal-header button.close {
+/* .modal-header button.close {
     color: #ccc !important;
     text-shadow: none;
-}
+} */
 
-.modal-body {
+/* .modal-body {
     background-color: #142440 !important;
     color: #aaa !important;
-}
+} */
 
-.modal-footer {
+/* .modal-footer {
     background-color: #121d2f !important;
     border-top: 2px solid #214981 !important;
     color: #aaa !important;
-}
+} */
 
 .btn-icon-only {
-    color: #ccc !important;
+    color: #f5f5f5 !important;
 }
 
-.btn-icon-only:hover {
+/* .btn-icon-only:hover {
     color: dodgerblue !important;
-}
+} */
 
-.toast-body {
+/* .toast-body {
     color: #444a50 !important;
-}
+} */
 
-nav.navbar {
+/* nav.navbar {
     box-shadow: 0 .5rem 2rem rgba(100, 100, 100, 0.15) !important;
     border-bottom: #214981 1px solid;
-}
+} */
 
-nav.navbar-dark {
+/* nav.navbar-dark {
     background-color: #142440 !important;
-}
+} */
 
-a.navbar-brand {
+/* a.navbar-brand {
     color: #fff !important;
-}
+} */
 
 .card {
-    background-color: #142440 !important;
-    border-color: #214981 !important;
-    color: #ccc !important;
+    /* background-color: #142440 !important; */
+    border-color: #bbb !important;
+    /* color: #ccc !important; */
 }
 
-.card .card-header {
+/* .card .card-header {
     background-color: #121d2f !important;
     border-bottom-color: #214981 !important;
-}
+} */
 
-.card .card-body {
+/* .card .card-body {
     background-color: #142440 !important;
-}
+} */
 
-cite {
+/* cite {
     color: #999 !important;
-}
+} */
 
-a {
+/* a {
     color: deepskyblue;
 }
 
 a:hover {
     color: dodgerblue;
-}
+} */
 
-.btn-outline-secondary {
+/* .btn-outline-secondary {
     border-color: #214981;
     border-width: 2px;
     background-color: #090d13 !important;
@@ -124,20 +122,20 @@ a:hover {
 .btn-outline-secondary:hover, .btn-outline-secondary:active {
     border-color: dodgerblue !important;
     color: dodgerblue !important;
-}
+} */
 
-.btn-outline-secondary:focus {
+/* .btn-outline-secondary:focus {
     box-shadow: 0 0 0 0.2rem rgba(30, 144, 255, 0.5);
-}
+} */
 
-.btn-secondary.pode-btn-solid {
+/* .btn-secondary.pode-btn-solid {
     border-width: 2px;
     background-color: #090d13 !important;
     border-color: dodgerblue;
     color: dodgerblue
-}
+} */
 
-.nav-tabs {
+/* .nav-tabs {
     border-bottom: 1px solid #214981 !important;
 }
 
@@ -145,9 +143,9 @@ a:hover {
     background-color: #142440 !important;
     border-color: #214981 !important;
     color: #ccc !important
-}
+} */
 
-.nav-tabs .nav-link {
+/* .nav-tabs .nav-link {
     color: #ccc !important
 }
 
@@ -155,137 +153,136 @@ a:hover {
     background-color: #142440 !important;
     border-color: #214981 !important;
     color: #ccc !important
-}
+} */
 
-input, textarea, select, .progress {
+/* input, textarea, select, .progress {
     background-color: #090d13 !important;
     border-color: #214981 !important;
     color: #999 !important;
-}
+} */
 
 pre code {
-    background-color: #090d13 !important;
-    border-color: #214981 !important;
-    color: #ccc !important;
+    background-color: #f0f0f0 !important;
+    border-color: #bbb !important;
 }
 
-.pode-code-copy {
+/* .pode-code-copy {
     color: #fff !important;
-}
+} */
 
-.input-group-prepend .input-group-text {
+/* .input-group-prepend .input-group-text {
     background-color: #121d2f !important;
     border-color: #214981 !important;
     color: #999 !important
-}
+} */
 
-#pode-page-title {
+/* #pode-page-title {
     border-color: #214981 !important;
-}
+} */
 
-body[pode-theme='dark'] .table {
+/* body[pode-theme='dark'] .table {
     color: #ccc !important;
 }
 
 body[pode-theme='dark'] .table thead th {
     background-color: #090d13 !important;
     color: #ccc !important;
-}
+} */
 
-body[pode-theme='dark'] .table.table-striped tbody tr:nth-of-type(odd) {
+/* body[pode-theme='dark'] .table.table-striped tbody tr:nth-of-type(odd) {
     background-color: #142440 !important;
 }
 
 body[pode-theme='dark'] .table.table-striped tbody tr:nth-of-type(even) {
     background-color: #121d2f !important;
-}
+} */
 
-body[pode-theme='dark'] .table td,
+/* body[pode-theme='dark'] .table td,
 body[pode-theme='dark'] .table th,
 body[pode-theme='dark'] .table thead th {
     border-color: #214981 !important;
-}
+} */
 
-body[pode-theme='dark'] .table.table-striped tbody tr:hover {
+/* body[pode-theme='dark'] .table.table-striped tbody tr:hover {
     background-color: #090d13 !important;
     color: #ccc;
-}
+} */
 
-.nav-item.nav-page-item a.nav-link.active {
+/* .nav-item.nav-page-item a.nav-link.active {
     color: dodgerblue !important;
-}
+} */
 
 .ui-autocomplete {
-    border-color: #214981 !important;
-    background-color: #121d2f !important;
-    color: #999 !important;
+    border-color: #bbb !important;
+    background-color: #f0f0f0 !important;
+    color: #333 !important;
 }
 
-nav .pagination .page-link {
+/* nav .pagination .page-link {
     border-color: #214981 !important;
     background-color: #121d2f !important;
     color: #ccc !important;
-}
+} */
 
-nav .pagination .page-link.active, nav .pagination .page-link:hover {
+/* nav .pagination .page-link.active, nav .pagination .page-link:hover {
     background-color: #214981 !important;
-}
+} */
 
 .jumbotron {
-    background-color: #214981;
-    border-color: dodgerblue;
-    color: #ccc;
+    /* background-color: #214981; */
+    border-color: #bbb;
+    /* color: #ccc; */
 }
 
-hr {
+/* hr {
     border-color: dodgerblue;
-}
+} */
 
 .footer.powered-by {
-    background-color: #142440;
-    border-color: #214981;
+    background-color: #f5f5f5;
+    border-color: #bbb;
 }
 
-.footer.powered-by .text-muted {
+/* .footer.powered-by .text-muted {
     color: #ccc !important;
-}
+} */
 
 .pode-container:not([pode-transparent='True']) {
-    background-color: #142440;
-    border-color: #214981;
+    background-color: #f5f5f5;
+    border-color: #bbb;
 }
 
 .pode-container {
-    color: #ccc;
+    color: #333;
 }
 
 .carousel {
-    background-color: #142440;
-    border-color: #214981;
-    color: #ccc;
+    background-color: #f5f5f5;
+    border-color: #bbb;
+    color: #333;
 }
 
 .carousel .carousel-caption {
-    color: #ccc;
+    color: #333;
 }
 
 .carousel .carousel-indicators li {
-    background-color: #ccc;
+    background-color: #333;
 }
 
-.carousel .carousel-indicators li.active {
+/* .carousel .carousel-indicators li.active {
     background-color: dodgerblue;
-}
+} */
 
 .step.active .bs-stepper-circle {
     background-color: dodgerblue;
 }
 
-.bs-stepper-line {
+/* .bs-stepper-line {
     background-color: #214981;
-}
+} */
 
-input[type=date]::-webkit-calendar-picker-indicator,
+/* input[type=date]::-webkit-calendar-picker-indicator,
 input[type=time]::-webkit-calendar-picker-indicator,
 input[type=datetime-local]::-webkit-calendar-picker-indicator {
     filter: invert(100%) brightness(60%);
@@ -295,4 +292,4 @@ input[type=date]::-webkit-calendar-picker-indicator:hover,
 input[type=time]::-webkit-calendar-picker-indicator:hover,
 input[type=datetime-local]::-webkit-calendar-picker-indicator:hover {
     filter: invert(100%) sepia() brightness(60%) saturate(10000%) hue-rotate(140deg);
-}
+} */

--- a/src/Templates/Public/styles/default-light.css
+++ b/src/Templates/Public/styles/default-light.css
@@ -33,184 +33,18 @@ body, main[role="main"], body#login-page, body#normal-page {
     color: #333;
 }
 
-/* .modal-content {
-    border-color: #214981 !important;
-    border-width: 2px !important;
-} */
-
-/* .modal-header {
-    background-color: #121d2f !important;
-    border-bottom: 2px solid #214981 !important;
-    color: #aaa !important;
-} */
-
-/* .modal-header button.close {
-    color: #ccc !important;
-    text-shadow: none;
-} */
-
-/* .modal-body {
-    background-color: #142440 !important;
-    color: #aaa !important;
-} */
-
-/* .modal-footer {
-    background-color: #121d2f !important;
-    border-top: 2px solid #214981 !important;
-    color: #aaa !important;
-} */
-
 .btn-icon-only {
     color: #f5f5f5 !important;
 }
 
-/* .btn-icon-only:hover {
-    color: dodgerblue !important;
-} */
-
-/* .toast-body {
-    color: #444a50 !important;
-} */
-
-/* nav.navbar {
-    box-shadow: 0 .5rem 2rem rgba(100, 100, 100, 0.15) !important;
-    border-bottom: #214981 1px solid;
-} */
-
-/* nav.navbar-dark {
-    background-color: #142440 !important;
-} */
-
-/* a.navbar-brand {
-    color: #fff !important;
-} */
-
 .card {
-    /* background-color: #142440 !important; */
     border-color: #bbb !important;
-    /* color: #ccc !important; */
 }
-
-/* .card .card-header {
-    background-color: #121d2f !important;
-    border-bottom-color: #214981 !important;
-} */
-
-/* .card .card-body {
-    background-color: #142440 !important;
-} */
-
-/* cite {
-    color: #999 !important;
-} */
-
-/* a {
-    color: deepskyblue;
-}
-
-a:hover {
-    color: dodgerblue;
-} */
-
-/* .btn-outline-secondary {
-    border-color: #214981;
-    border-width: 2px;
-    background-color: #090d13 !important;
-    color: #bbb;
-}
-
-.btn-outline-secondary:hover, .btn-outline-secondary:active {
-    border-color: dodgerblue !important;
-    color: dodgerblue !important;
-} */
-
-/* .btn-outline-secondary:focus {
-    box-shadow: 0 0 0 0.2rem rgba(30, 144, 255, 0.5);
-} */
-
-/* .btn-secondary.pode-btn-solid {
-    border-width: 2px;
-    background-color: #090d13 !important;
-    border-color: dodgerblue;
-    color: dodgerblue
-} */
-
-/* .nav-tabs {
-    border-bottom: 1px solid #214981 !important;
-}
-
-.nav-tabs .nav-link.active {
-    background-color: #142440 !important;
-    border-color: #214981 !important;
-    color: #ccc !important
-} */
-
-/* .nav-tabs .nav-link {
-    color: #ccc !important
-}
-
-.nav-tabs .nav-link:hover {
-    background-color: #142440 !important;
-    border-color: #214981 !important;
-    color: #ccc !important
-} */
-
-/* input, textarea, select, .progress {
-    background-color: #090d13 !important;
-    border-color: #214981 !important;
-    color: #999 !important;
-} */
 
 pre code {
     background-color: #f0f0f0 !important;
     border-color: #bbb !important;
 }
-
-/* .pode-code-copy {
-    color: #fff !important;
-} */
-
-/* .input-group-prepend .input-group-text {
-    background-color: #121d2f !important;
-    border-color: #214981 !important;
-    color: #999 !important
-} */
-
-/* #pode-page-title {
-    border-color: #214981 !important;
-} */
-
-/* body[pode-theme='dark'] .table {
-    color: #ccc !important;
-}
-
-body[pode-theme='dark'] .table thead th {
-    background-color: #090d13 !important;
-    color: #ccc !important;
-} */
-
-/* body[pode-theme='dark'] .table.table-striped tbody tr:nth-of-type(odd) {
-    background-color: #142440 !important;
-}
-
-body[pode-theme='dark'] .table.table-striped tbody tr:nth-of-type(even) {
-    background-color: #121d2f !important;
-} */
-
-/* body[pode-theme='dark'] .table td,
-body[pode-theme='dark'] .table th,
-body[pode-theme='dark'] .table thead th {
-    border-color: #214981 !important;
-} */
-
-/* body[pode-theme='dark'] .table.table-striped tbody tr:hover {
-    background-color: #090d13 !important;
-    color: #ccc;
-} */
-
-/* .nav-item.nav-page-item a.nav-link.active {
-    color: dodgerblue !important;
-} */
 
 .ui-autocomplete {
     border-color: #bbb !important;
@@ -218,34 +52,14 @@ body[pode-theme='dark'] .table thead th {
     color: #333 !important;
 }
 
-/* nav .pagination .page-link {
-    border-color: #214981 !important;
-    background-color: #121d2f !important;
-    color: #ccc !important;
-} */
-
-/* nav .pagination .page-link.active, nav .pagination .page-link:hover {
-    background-color: #214981 !important;
-} */
-
 .jumbotron {
-    /* background-color: #214981; */
     border-color: #bbb;
-    /* color: #ccc; */
 }
-
-/* hr {
-    border-color: dodgerblue;
-} */
 
 .footer.powered-by {
     background-color: #f5f5f5;
     border-color: #bbb;
 }
-
-/* .footer.powered-by .text-muted {
-    color: #ccc !important;
-} */
 
 .pode-container:not([pode-transparent='True']) {
     background-color: #f5f5f5;
@@ -270,26 +84,6 @@ body[pode-theme='dark'] .table thead th {
     background-color: #333;
 }
 
-/* .carousel .carousel-indicators li.active {
-    background-color: dodgerblue;
-} */
-
 .step.active .bs-stepper-circle {
     background-color: dodgerblue;
 }
-
-/* .bs-stepper-line {
-    background-color: #214981;
-} */
-
-/* input[type=date]::-webkit-calendar-picker-indicator,
-input[type=time]::-webkit-calendar-picker-indicator,
-input[type=datetime-local]::-webkit-calendar-picker-indicator {
-    filter: invert(100%) brightness(60%);
-}
-
-input[type=date]::-webkit-calendar-picker-indicator:hover,
-input[type=time]::-webkit-calendar-picker-indicator:hover,
-input[type=datetime-local]::-webkit-calendar-picker-indicator:hover {
-    filter: invert(100%) sepia() brightness(60%) saturate(10000%) hue-rotate(140deg);
-} */

--- a/src/Templates/Public/styles/default-terminal.css
+++ b/src/Templates/Public/styles/default-terminal.css
@@ -269,7 +269,7 @@ hr {
 
 .jumbotron {
     background-color: #33ff00;
-    border: darkgreen 1px solid;
+    border-color: darkgreen;
     color: #222;
 }
 

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -10,12 +10,10 @@ body#login-page {
     align-items: center;
     padding-top: 40px;
     padding-bottom: 40px;
-    background-color: #f5f5f5;
 }
 
 body#normal-page {
     font-size: .875rem !important;
-    background-color: #f5f5f5;
 }
 
 button#menu-toggle {
@@ -29,8 +27,8 @@ button#menu-toggle .feather {
 }
 
 .footer.powered-by {
-    background-color: #f5f5f5;
-    border: #bbb 1px solid;
+    border-width: 1px;
+    border-style: solid;
     border-radius: 0.25rem;
     margin-left: 5%;
     text-align: center;
@@ -40,33 +38,23 @@ button#menu-toggle .feather {
 }
 
 .pode-container:not([pode-transparent='True']) {
-    background-color: #f5f5f5;
-    border: #bbb 1px solid;
+    border-width: 1px;
+    border-style: solid;
     border-radius: 0.25rem;
 }
 
 .pode-container {
-    color: #333;
     padding: 1.25rem;
     margin-bottom: 2em;
 }
 
 .carousel {
     min-height: 10em;
-    background-color: #f5f5f5;
-    color: #333;
-    border: #bbb 1px solid;
+    border-width: 1px;
+    border-style: solid;
     border-radius: 0.25rem;
     padding: 1.25rem;
     margin-bottom: 2em;
-}
-
-.carousel .carousel-caption {
-    color: #333;
-}
-
-.carousel .carousel-indicators li {
-    background-color: #333;
 }
 
 .carousel .carousel-arrow:hover {
@@ -119,7 +107,8 @@ div#pode-social a:hover {
 }
 
 .jumbotron {
-    border: #bbb 1px solid;
+    border-width: 1px;
+    border-style: solid;
 }
 
 .modal-body {
@@ -141,8 +130,6 @@ div#pode-social a:hover {
 }
 
 .media {
-    border-color: #bbb;
-    background-color: #f5f5f5;
     border-width: 1px;
     border-style: solid;
     border-radius: 0.5em;
@@ -154,11 +141,13 @@ div#pode-social a:hover {
     width: 64px;
     height: 64px;
     border-radius: 0.4rem;
-    border: #bbb 2px solid;
+    border-width: 2px;
+    border-style: solid;
 }
 
 .media .media-head {
-    border-bottom: #bbb 1px dashed;
+    border-width: 1px;
+    border-bottom-style: dashed;
 }
 
 .media .media-head small {
@@ -173,17 +162,13 @@ div#pode-social a:hover {
 }
 
 .btn-icon-only {
-    color: #f5f5f5;
     margin-left: -1em;
 }
 
 .ui-autocomplete {
-    border-color: #bbb;
-    background-color: #f0f0f0;
     border-width: 2px;
     margin-top: -1px;
     border-radius: 5px;
-    color: #333;
 }
 
 table .btn-icon-only {
@@ -197,8 +182,6 @@ pre.code-block {
 }
 
 pre code {
-    background-color: #f0f0f0;
-    border-color: #bbb;
     border-radius: 1em;
     border-width: 1px;
     border-style: solid;
@@ -304,7 +287,6 @@ table tbody td {
 
 .card {
     margin-bottom: 2em;
-    border-color: #bbb;
 }
 
 .toast {
@@ -330,7 +312,6 @@ table tbody td {
     margin-bottom: 2px;
     border-style: solid;
     border-width: 3px;
-    border-color: #bbb;
 }
 
 .navbar-brand {
@@ -485,7 +466,7 @@ h6 .feather, .h6 .feather {
  */
 
 .sidebar {
-    position: fixed;
+    position: fixed !important;
     top: 0;
     bottom: 0;
     left: 0;
@@ -511,7 +492,6 @@ h6 .feather, .h6 .feather {
 
 .sidebar .nav-link {
     font-weight: 500;
-    color: #333;
     padding: 0;
 }
 

--- a/src/Templates/Views/shared/head.pode
+++ b/src/Templates/Views/shared/head.pode
@@ -17,12 +17,17 @@
             "<link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.4.1/build/styles/default.min.css'>"
         }
 
-        # main pode.web base theme - light
+        # main pode.web base styles
         "<link rel='stylesheet' href='/pode.web/styles/default.css'>"
 
         # pode.web theme
-        if ($data.Theme -ine 'light') {
-            "<link rel='stylesheet' href='/pode.web/styles/default-$($data.Theme).css'>"
+        if (Test-PodeWebThemeCustom -Name $data.Theme) {
+            "<link rel='stylesheet' href='$((Get-PodeWebState -Name 'custom-themes').Themes[$data.Theme].Url)'>"
+        }
+        else {
+            if ($data.Theme -inotin @('auto', 'custom')) {
+                "<link rel='stylesheet' href='/pode.web/styles/default-$($data.Theme).css'>"
+            }
         }
 
         # custom stylesheets


### PR DESCRIPTION
### Description of the Change
Adds support for custom themes. `-Theme` on `Use-PodeWebTemplates` now has a Custom option - the first Custom theme added will be used as the default.

You can also reference custom themes by their name in the pode.web.theme cookie and auth objects.

### Related Issue
Resolves #17 

### Examples
```powershell
Use-PodeWebTemplates -Title Example -Theme Custom

Add-PodeWebCustomTheme -Name Cyborg -Url 'https://cdn.jsdelivr.net/npm/bootswatch@4.6.0/dist/cyborg/bootstrap.min.css'
Add-PodeWebCustomTheme -Name Lux -Url 'https://cdn.jsdelivr.net/npm/bootswatch@4.6.0/dist/lux/bootstrap.min.css'
```