### PR TITLE
Fix removing alert header, and encoding html

### DIFF
--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1425,7 +1425,16 @@ function actionText(action) {
         return;
     }
 
-    text.text(action.Value);
+    text = text.find('.pode-text') ?? text;
+    text.text(decodeHTML(action.Value));
+}
+
+function decodeHTML(value) {
+    var textArea = document.createElement('textarea');
+    textArea.innerHTML = value;
+    value = textArea.value;
+    textArea.remove();
+    return value;
 }
 
 function actionCheckbox(action) {

--- a/src/Templates/Views/elements/alert.pode
+++ b/src/Templates/Views/elements/alert.pode
@@ -4,7 +4,7 @@
         <strong>$($data.Type)</strong>
     </h6>
 
-    <div class='pode-alert-body'>
+    <div class='pode-alert-body pode-text'>
         $(
             if (![string]::IsNullOrWhiteSpace($data.Value)) {
                 $data.Value

--- a/src/Templates/Views/elements/quote.pode
+++ b/src/Templates/Views/elements/quote.pode
@@ -2,7 +2,7 @@ $(
     $value = $data.Value
 
     $quote = "<blockquote class='blockquote text-$($data.Alignment) $($data.CssClasses)' id='$($data.ID)'>
-        <p class='mb-0'>$($value)</p>"
+        <p class='pode-text mb-0'>$($value)</p>"
 
     if (![string]::IsNullOrWhiteSpace($data.Source)) {
         $src = $data.Source


### PR DESCRIPTION
### Description of the Change
Fix issue where `Out-PodeWebText` removed alert headers, and didn't decode encoded characters.

### Related Issue
Resolves #24 
