### PR TITLE
Check for disposition header instead of content-length

### DIFF
--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1070,7 +1070,7 @@ function New-PodeWebButton
                 $result = @()
             }
 
-            if ($WebEvent.Response.ContentLength64 -eq 0) {
+            if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result
             }
 
@@ -1668,7 +1668,7 @@ function Add-PodeWebTableButton
                 $result = @()
             }
 
-            if ($WebEvent.Response.ContentLength64 -eq 0) {
+            if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result
             }
         }


### PR DESCRIPTION
### Description of the Change
Instead of checking for the ContentLength, check if the Content-Disposition header is on the response for any attachments.

### Related Issue
Resolves #30 
