### PR TITLE
Fix an issue with auto-wrapping table/chart output

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -611,3 +611,21 @@ function Remove-PodeWebRoute
         }
     }
 }
+
+function Test-PodeWebOutputWrapped
+{
+    param(
+        [Parameter()]
+        $Output
+    )
+
+    if ($null -eq $Output) {
+        return $false
+    }
+
+    if ($Output -is [array]) {
+        $Output = $Output[0]
+    }
+
+    return (($Output -is [hashtable]) -and ($Output.Operation -ieq 'Output') -and ![string]::IsNullOrWhiteSpace($Output.ElementType))
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1352,7 +1352,7 @@ function New-PodeWebChart
                 $result = @()
             }
 
-            if (!(($result -is [hashtable]) -and ($result.Operation -ieq 'Output') -and ($result.ElementType -ieq 'Chart'))) {
+            if (!(Test-PodeWebOutputWrapped -Output $result)) {
                 $result = ($result | Out-PodeWebChart -Id $using:Id)
             }
 
@@ -1577,7 +1577,7 @@ function New-PodeWebTable
                 $result = @()
             }
 
-            if (!(($result -is [hashtable]) -and ($result.Operation -ieq 'Output') -and ($result.ElementType -ieq 'Table'))) {
+            if (!(Test-PodeWebOutputWrapped -Output $result)) {
                 $paginate = $ElementData.Paging.Enabled
                 $result = ($result | Out-PodeWebTable -Id $using:Id -Columns $ElementData.Columns -Paginate:$paginate)
             }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1352,7 +1352,7 @@ function New-PodeWebChart
                 $result = @()
             }
 
-            if (($result.Length -gt 0) -and [string]::IsNullOrWhiteSpace($result[0].OutputType)) {
+            if (!(($result -is [hashtable]) -and ($result.Operation -ieq 'Output') -and ($result.ElementType -ieq 'Chart'))) {
                 $result = ($result | Out-PodeWebChart -Id $using:Id)
             }
 
@@ -1577,7 +1577,7 @@ function New-PodeWebTable
                 $result = @()
             }
 
-            if (($result.Length -gt 0) -and [string]::IsNullOrWhiteSpace($result[0].OutputType)) {
+            if (!(($result -is [hashtable]) -and ($result.Operation -ieq 'Output') -and ($result.ElementType -ieq 'Table'))) {
                 $paginate = $ElementData.Paging.Enabled
                 $result = ($result | Out-PodeWebTable -Id $using:Id -Columns $ElementData.Columns -Paginate:$paginate)
             }


### PR DESCRIPTION
### Description of the Change
Fix an issue with auto-wrapping table/chart output, as `OutputType` is no longer used.

### Related Issue
Resolves #27 
