### PR TITLE
Add ClickScriptBlock for table rows, and hide page back arrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pode_modules/
 ps_modules/
 docs/[Ff]unctions/
 examples/state.json
+examples/issue-*
 pkg/
 
 

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -232,7 +232,10 @@ function Add-PodeWebPage
         $NoAuthentication,
 
         [switch]
-        $NoTitle
+        $NoTitle,
+
+        [switch]
+        $NoBackArrow
     )
 
     # ensure layouts are correct
@@ -255,6 +258,7 @@ function Add-PodeWebPage
         Name = $Name
         Title = $Title
         NoTitle = $NoTitle.IsPresent
+        NoBackArrow = $NoBackArrow.IsPresent
         Icon = $Icon
         Group = $Group
         Access = @{
@@ -279,7 +283,13 @@ function Add-PodeWebPage
     # add the page route
     Add-PodeRoute -Method Get -Path "/pages/$($Name)" -Authentication $auth -EndpointName $EndpointName -ScriptBlock {
         $global:PageData = $using:pageMeta
-        $global:PageData.ShowBack = (($null -ne $WebEvent.Query) -and ($WebEvent.Query.Count -gt 0))
+
+        if (!$global:PageData.NoBackArrow) {
+            $global:PageData.ShowBack = (($null -ne $WebEvent.Query) -and ($WebEvent.Query.Count -gt 0))
+        }
+        else {
+            $global:PageData.ShowBack = $false
+        }
 
         # get auth details of a user
         $authData = Get-PodeWebAuthData

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1133,7 +1133,7 @@ function updateTableRow(action) {
 function bindTableClickableRows(tableId) {
     $(`${tableId}.pode-table-click tbody tr`).unbind('click').click(function() {
         var rowId = $(this).attr('pode-data-value');
-        window.location = `${window.location.href}?value=${rowId}`;
+        window.location = `${window.location.origin}${window.location.pathname}?value=${rowId}`;
     });
 }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1133,7 +1133,16 @@ function updateTableRow(action) {
 function bindTableClickableRows(tableId) {
     $(`${tableId}.pode-table-click tbody tr`).unbind('click').click(function() {
         var rowId = $(this).attr('pode-data-value');
-        window.location = `${window.location.origin}${window.location.pathname}?value=${rowId}`;
+        var table = $(tableId);
+
+        if (table.attr('pode-click-dynamic') == 'True') {
+            var url = `/elements/table/${table.attr('id')}/click`;
+            var data = `value=${rowId}`;
+            sendAjaxReq(url, data, null, true);
+        }
+        else {
+            window.location = `${window.location.origin}${window.location.pathname}?value=${rowId}`;
+        }
     });
 }
 

--- a/src/Templates/Views/elements/table.pode
+++ b/src/Templates/Views/elements/table.pode
@@ -22,6 +22,7 @@ $(if ($data.Filter) {
                 name='$($data.Name)'
                 class='table table-striped table-hover $($click)'
                 pode-dynamic='$($data.IsDynamic)'
+                pode-click-dynamic='$($data.ClickIsDynamic)'
                 pode-data-column='$($data.DataColumn)'
                 pode-auto-refresh='$($data.AutoRefresh)'
                 pode-sort='$($data.Sort)'


### PR DESCRIPTION
### Description of the Change
Adds support for have a custom click event, on a table row, via a new `-ClickScriptBlock` on `New-PodeWebTable`. Also lets you hide the back arrow on pages via `-NoBackArrow` on `Add-PodeWebPage` which shows when a page has a query string.

### Related Issue
Resolves #28 

### Examples
For the custom table row click event:

```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address localhost -Protocol Http

    Use-PodeWebTemplates -Title Tools -Theme Dark

    Add-PodeWebPage -Name 'File' -Icon Activity -Layouts @(
        New-PodeWebTable -Name 'Explorer' -Id 'DriveExplorer' -AsCard -Click -DataColumn 'Name' -ScriptBlock {
            for ($i = 1; $i -lt 4; $i++) {
                [PSCustomObject]@{
                    Name  = "Name$i"
                    Date  = (Get-Date).ToString()
                }
            }
        } -ClickScriptBlock {
            if ($WebEvent.Data.Value -eq 'Name1') {
                Sync-PodeWebTable -Id 'DriveExplorer'
            }
            elseif ($WebEvent.Data.Value -eq 'Name2') {
                Move-PodeWebUrl -Url ($Request.UrlReferrer.ToString() + '?value=' + $WebEvent.Data.Value)
            }
            elseif ($WebEvent.Data.Value -eq 'Name3') {
                Show-PodeWebToast -Message $WebEvent.Data.Value
            }
        }
    )
}
```
