### PR TITLE
Adds breadcrumbs, plus a little more

### DIFF
--- a/examples/multi-table.ps1
+++ b/examples/multi-table.ps1
@@ -1,0 +1,48 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Basic Example' -Theme Dark
+
+    Add-PodeWebPage -Name Table -Icon Activity -NoBackArrow -ScriptBlock {
+        $value = $WebEvent.Query['value']
+        $base = $WebEvent.Query['base']
+        $path = (Join-PodeWebPath -Path $base -ChildPath $value -ReplaceSlashes)
+
+        $text = (@{
+            'File-1-0' = (New-PodeWebCodeBlock -Value 'Hello, world')
+            'Folder-1-0/Folder-2-0/File-3-0' = (New-PodeWebCodeBlock -Value 'Hello, there')
+        })[$path]
+
+        if ($null -ne $text) {
+            return (New-PodeWebCard -Name 'FileData' -NoTitle -Content $text)
+        }
+
+        New-PodeWebCard -Name 'TableData' -NoTitle -Content @(
+            New-PodeWebTable -Name 'Table' -Click -DataColumn Name -ScriptBlock {
+                $value = $WebEvent.Query['value']
+                $base = $WebEvent.Query['base']
+
+                if ([string]::IsNullOrWhiteSpace($value) -and [string]::IsNullOrWhiteSpace($base)) {
+                    return @(
+                        @{ Name = 'Folder-1-0'; Type = 'Folder' },
+                        @{ Name = 'File-1-0'; Type = 'File' }
+                    )
+                }
+
+                $path = (Join-PodeWebPath -Path $base -ChildPath $value -ReplaceSlashes)
+
+                return (@{
+                    'Folder-1-0' = @(@{ Name = 'Folder-2-0'; Type = 'Folder' })
+                    'Folder-1-0/Folder-2-0' = @(@{ Name = 'File-3-0'; Type = 'File' })
+                })[$path]
+            }
+        )
+    }
+
+}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -629,26 +629,3 @@ function Test-PodeWebOutputWrapped
 
     return (($Output -is [hashtable]) -and ($Output.Operation -ieq 'Output') -and ![string]::IsNullOrWhiteSpace($Output.ElementType))
 }
-
-function Use-PodeWebView
-{
-    param(
-        [Parameter()]
-        [hashtable]
-        $View
-    )
-
-    if (($null -eq $View) -or [string]::IsNullOrEmpty($View.ComponentType)) {
-        return
-    }
-
-    switch ($View.ComponentType.ToLowerInvariant()) {
-        'layout' {
-            Use-PodeWebPartialView -Path "layouts/$($View.LayoutType.ToLowerInvariant())" -Data $View
-        }
-
-        'element' {
-            Use-PodeWebPartialView -Path "elements/$($View.ElementType.ToLowerInvariant())" -Data $View
-        }
-    }
-}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1,7 +1,7 @@
 function Get-PodeWebTemplatePath
 {
     $path = Split-Path -Parent -Path ((Get-Module -Name 'Pode.Web').Path)
-    return (Join-Path $path 'Templates')
+    return (Join-PodeWebPath $path 'Templates')
 }
 
 function Get-PodeWebAuthData

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -629,3 +629,26 @@ function Test-PodeWebOutputWrapped
 
     return (($Output -is [hashtable]) -and ($Output.Operation -ieq 'Output') -and ![string]::IsNullOrWhiteSpace($Output.ElementType))
 }
+
+function Use-PodeWebView
+{
+    param(
+        [Parameter()]
+        [hashtable]
+        $View
+    )
+
+    if (($null -eq $View) -or [string]::IsNullOrEmpty($View.ComponentType)) {
+        return
+    }
+
+    switch ($View.ComponentType.ToLowerInvariant()) {
+        'layout' {
+            Use-PodeWebPartialView -Path "layouts/$($View.LayoutType.ToLowerInvariant())" -Data $View
+        }
+
+        'element' {
+            Use-PodeWebPartialView -Path "elements/$($View.ElementType.ToLowerInvariant())" -Data $View
+        }
+    }
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1144,7 +1144,11 @@ function New-PodeWebIcon
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [string]
+        $Title
     )
 
     if (![string]::IsNullOrWhiteSpace($Colour)) {
@@ -1158,6 +1162,7 @@ function New-PodeWebIcon
         Name = $Name
         Colour = $Colour
         CssClasses = ($CssClass -join ' ')
+        Title = $Title
     }
 }
 
@@ -1171,7 +1176,11 @@ function New-PodeWebSpinner
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [string]
+        $Title
     )
 
     if (![string]::IsNullOrWhiteSpace($Colour)) {
@@ -1184,6 +1193,7 @@ function New-PodeWebSpinner
         Parent = $ElementData
         Colour = $Colour
         CssClasses = ($CssClass -join ' ')
+        Title = $Title
     }
 }
 
@@ -1631,12 +1641,28 @@ function Initialize-PodeWebTableColumn
 
         [Parameter()]
         [int]
-        $Width = 0
+        $Width = 0,
+
+        [Parameter()]
+        [ValidateSet('Left', 'Right', 'Center')]
+        [string]
+        $Alignment = 'Left',
+
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Icon
     )
 
     return @{
         Key = $Key
         Width = $Width
+        Alignment = $Alignment.ToLowerInvariant()
+        Name = $Name
+        Icon = $Icon
     }
 }
 

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2004,3 +2004,57 @@ function New-PodeWebTimer
         CssClasses = ($CssClass -join ' ')
     }
 }
+
+function Set-PodeWebBreadcrumb
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [hashtable[]]
+        $Items = @()
+    )
+
+    if (($null -eq $Items)) {
+        $Items = @()
+    }
+
+    $foundActive = $false
+    foreach ($item in $Items) {
+        if ($foundActive -and $item.Active) {
+            throw "Cannot have two active breadcrumb items"
+        }
+
+        $foundActive = $item.Active
+    }
+
+    return @{
+        ComponentType = 'Element'
+        ElementType = 'Breadcrumb'
+        Items = $Items
+    }
+}
+
+function New-PodeWebBreadcrumbItem
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Url,
+
+        [switch]
+        $Active
+    )
+
+    return @{
+        ComponentType = 'Element'
+        ElementType = 'BreadcrumbItem'
+        Name = $Name
+        Url = $Url
+        Active = $Active.IsPresent
+    }
+}

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -203,6 +203,10 @@ function New-PodeWebModal
         $Content,
 
         [Parameter()]
+        [string]
+        $Icon,
+
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]
         $SubmitText = 'Submit',
@@ -277,6 +281,7 @@ function New-PodeWebModal
         LayoutType = 'Modal'
         Name = $Name
         ID = $Id
+        Icon = $Icon
         Content = $Content
         CloseText = [System.Net.WebUtility]::HtmlEncode($CloseText)
         SubmitText = [System.Net.WebUtility]::HtmlEncode($SubmitText)

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -96,17 +96,22 @@ function Out-PodeWebTable
 
 function Sync-PodeWebTable
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Id')]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
-        $Id
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
     )
 
     return @{
         Operation = 'Sync'
         ElementType = 'Table'
         ID = $Id
+        Name = $Name
     }
 }
 
@@ -445,11 +450,15 @@ function Out-PodeWebCheckbox
 
 function Show-PodeWebModal
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Id')]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
 
         [Parameter()]
         [string]
@@ -464,6 +473,7 @@ function Show-PodeWebModal
         Operation = 'Show'
         ElementType = 'Modal'
         ID = $Id
+        Name = $Name
         DataValue = $DataValue
         Actions = $Actions
     }
@@ -471,17 +481,38 @@ function Show-PodeWebModal
 
 function Hide-PodeWebModal
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Id')]
     param(
-        [Parameter()]
+        [Parameter(ParameterSetName='Id')]
         [string]
-        $Id
+        $Id,
+
+        [Parameter(ParameterSetName='Name')]
+        [string]
+        $Name
     )
 
     return @{
         Operation = 'Hide'
         ElementType = 'Modal'
         ID = $Id
+        Name = $Name
+    }
+}
+
+function Show-PodeWebError
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Message
+    )
+
+    return @{
+        Operation = 'Show'
+        ElementType = 'Error'
+        Message = $Message
     }
 }
 

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -615,3 +615,32 @@ function Reset-PodeWebPage
         ElementType = 'Page'
     }
 }
+
+function Out-PodeWebBreadcrumb
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [hashtable[]]
+        $Items = @()
+    )
+
+    if (($null -eq $Items)) {
+        $Items = @()
+    }
+
+    $foundActive = $false
+    foreach ($item in $Items) {
+        if ($foundActive -and $item.Active) {
+            throw "Cannot have two active breadcrumb items"
+        }
+
+        $foundActive = $item.Active
+    }
+
+    return @{
+        Operation = 'Output'
+        ElementType = 'Breadcrumb'
+        Items = $Items
+    }
+}

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -235,7 +235,10 @@ function Add-PodeWebPage
         $NoTitle,
 
         [switch]
-        $NoBackArrow
+        $NoBackArrow,
+
+        [switch]
+        $NoBreadcrumb
     )
 
     # ensure layouts are correct
@@ -259,6 +262,7 @@ function Add-PodeWebPage
         Title = $Title
         NoTitle = $NoTitle.IsPresent
         NoBackArrow = $NoBackArrow.IsPresent
+        NoBreadcrumb = $NoBreadcrumb.IsPresent
         Icon = $Icon
         Group = $Group
         Access = @{

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -326,11 +326,28 @@ function Add-PodeWebPage
                 $comps = $using:Layouts
             }
 
+            $breadcrumb = $null
+            $layouts = @()
+
+            foreach ($item in $comps) {
+                if ($item.ElementType -ieq 'breadcrumb') {
+                    $breadcrumb = $item
+                }
+                else {
+                    $layouts += $item
+                }
+            }
+
+            if ($null -eq $breadcrumb) {
+                $breadcrumb = Set-PodeWebBreadcrumb -Items @()
+            }
+
             Write-PodeWebViewResponse -Path 'index' -Data @{
                 Page = $global:PageData
                 Title = $using:Title
                 Theme = $Theme
-                Layouts = $comps
+                Breadcrumb = $breadcrumb
+                Layouts = $layouts
                 Auth = $authMeta
             }
         }

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -338,10 +338,6 @@ function Add-PodeWebPage
                 }
             }
 
-            if ($null -eq $breadcrumb) {
-                $breadcrumb = Set-PodeWebBreadcrumb -Items @()
-            }
-
             Write-PodeWebViewResponse -Path 'index' -Data @{
                 Page = $global:PageData
                 Title = $using:Title

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -52,8 +52,8 @@ function Use-PodeWebTemplates
 
     $templatePath = Get-PodeWebTemplatePath
 
-    Add-PodeStaticRoute -Path '/pode.web' -Source (Join-Path $templatePath 'Public')
-    Add-PodeViewFolder -Name 'pode.web.views' -Source (Join-Path $templatePath 'Views')
+    Add-PodeStaticRoute -Path '/pode.web' -Source (Join-PodeWebPath $templatePath 'Public')
+    Add-PodeViewFolder -Name 'pode.web.views' -Source (Join-PodeWebPath $templatePath 'Views')
 
     Add-PodeRoute -Method Get -Path '/' -EndpointName $EndpointName -ScriptBlock {
         $pages = @(Get-PodeWebState -Name 'pages')
@@ -204,4 +204,36 @@ function Add-PodeWebCustomTheme
     if ([string]::IsNullOrWhiteSpace($customThemes.Default)) {
         $customThemes.Default = $Name
     }
+}
+
+function Join-PodeWebPath
+{
+    param(
+        [Parameter()]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [string]
+        $ChildPath,
+
+        [switch]
+        $ReplaceSlashes
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $result = $ChildPath
+    }
+    elseif ([string]::IsNullOrWhiteSpace($ChildPath)) {
+        $result = $Path
+    }
+    else {
+        $result = (Join-Path $Path $ChildPath)
+    }
+
+    if ($ReplaceSlashes) {
+        $result = ($result -ireplace '\\', '/')
+    }
+
+    return $result
 }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -24,7 +24,7 @@ function Use-PodeWebTemplates
         $EndpointName
     )
 
-    $mod = (Get-Module -Name Pode -ErrorAction Ignore)
+    $mod = (Get-Module -Name Pode -ErrorAction Ignore | Sort-Object -Property Version -Descending | Select-Object -First 1)
     if (($null -eq $mod) -or ($mod.Version.Major -lt 2)) {
         throw "The Pode module is not loaded. You need at least Pode 2.0 to use the Pode.Web module."
     }

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -159,6 +159,14 @@ function serializeInputs(element) {
     return element.find('input, textarea, select').serialize();
 }
 
+function isEnterKey(event) {
+    if (!event) {
+        return false;
+    }
+
+    return (event.which == 13 && event.keyCode == 13)
+}
+
 var _steppers = {};
 
 function setupSteppers() {
@@ -168,7 +176,7 @@ function setupSteppers() {
 
         // override form enter-key
         stepper.find('form.pode-stepper-form').unbind('keypress').keypress(function(e) {
-            if (e.which != 13 && e.keyCode != 13) {
+            if (!isEnterKey(e)) {
                 return;
             }
 
@@ -296,9 +304,15 @@ function setValidationError(element) {
 function sendAjaxReq(url, data, sender, useActions, successCallback, opts) {
     // show the spinner
     showSpinner(sender);
+    $('.alert.pode-error').remove();
 
     // remove validation errors
     removeValidationErrors(sender);
+
+    // add current query string
+    if (window.location.search) {
+        url = `${url}${window.location.search}`;
+    }
 
     // set default opts
     opts = (opts ?? {});
@@ -320,6 +334,7 @@ function sendAjaxReq(url, data, sender, useActions, successCallback, opts) {
         success: function(res, status, xhr) {
             // attempt to hide any spinners
             hideSpinner(sender);
+            unfocus(sender);
 
             // attempt to get a filename, for downloading
             var filename = getAjaxFileName(xhr);
@@ -344,6 +359,7 @@ function sendAjaxReq(url, data, sender, useActions, successCallback, opts) {
         },
         error: function(err, msg, stack) {
             hideSpinner(sender);
+            unfocus(sender);
             console.log(err);
             console.log(stack);
         }
@@ -427,6 +443,14 @@ function hideSpinner(sender) {
     }
 }
 
+function unfocus(sender) {
+    if (!sender) {
+        return;
+    }
+
+    sender.blur();
+}
+
 var _editors = {};
 
 function bindCodeEditors() {
@@ -498,6 +522,7 @@ function bindCardCollapse() {
         button.find('.feather-eye-off').toggle();
 
         button.closest('.card').find('.card-body').slideToggle();
+        button.blur();
     });
 }
 
@@ -683,11 +708,6 @@ function loadTable(tableId, pageNumber, pageAmount) {
         url = form.attr('method');
     }
 
-    // add current query string
-    if (window.location.search) {
-        url = `${url}${window.location.search}`;
-    }
-
     // invoke and load table content
     sendAjaxReq(url, data, table, true);
 }
@@ -731,11 +751,6 @@ function loadChart(chartId) {
 
         data += form.serialize();
         url = form.attr('method');
-    }
-
-    // add current query string
-    if (window.location.search) {
-        url = `${url}${window.location.search}`;
     }
 
     sendAjaxReq(url, data, chart, true);
@@ -815,6 +830,10 @@ function invokeActions(actions, sender) {
 
             case 'page':
                 actionPage(action);
+                break;
+
+            case 'error':
+                actionError(action, sender);
                 break;
 
             default:
@@ -899,6 +918,20 @@ function bindFormSubmits() {
 }
 
 function bindModalSubmits() {
+    $("div.modal-content form.pode-form").unbind('keypress').keypress(function(e) {
+        if (!isEnterKey(e)) {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        var btn = $(this).closest('div.modal-content').find('div.modal-footer button.pode-modal-submit')
+        if (btn) {
+            btn.click();
+        }
+    });
+
     $("div.modal-footer button.pode-modal-submit").unbind('click').click(function(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -938,12 +971,6 @@ function bindModalSubmits() {
             }
 
             formData += `Value=${dataValue}`;
-        }
-
-        // show spinner
-        var spinner = button.find('span.spinner-border');
-        if (spinner) {
-            spinner.show();
         }
 
         // invoke url
@@ -995,11 +1022,6 @@ function bindButtons() {
             if (form) {
                 data = form.serialize();
             }
-        }
-
-        var spinner = button.find('span.spinner-border');
-        if (spinner) {
-            spinner.show();
         }
 
         var url = `/elements/button/${button.attr('id')}`;
@@ -1239,11 +1261,16 @@ function actionTable(action, sender) {
 }
 
 function syncTable(action) {
-    if (!action.ID) {
+    if (!action.ID && !action.Name) {
         return;
     }
 
-    loadTable(action.ID);
+    var id = action.ID;
+    if (!id) {
+        id = $(`table[name="${action.Name}"]`).attr('id');
+    }
+
+    loadTable(id);
 }
 
 function updateTable(action, sender) {
@@ -1291,9 +1318,27 @@ function updateTable(action, sender) {
     tableHead.empty();
 
     var _value = '<tr>';
+    var _col = null;
     keys.forEach((key) => {
-        if ((key in columns) && (columns[key].Width > 0)) {
-            _value += `<th style='width:${columns[key].Width}%'>${key}</th>`;
+        if (key in columns) {
+            _col = columns[key];
+            _value += `<th style='`;
+
+            if (_col.Width > 0) {
+                _value += `width:${_col.Width}%;`;
+            }
+
+            if (_col.Alignment) {
+                _value += `text-align:${_col.Alignment};`;
+            }
+
+            _value += `'>`;
+
+            if (_col.Icon) {
+                _value += `<span data-feather='${_col.Icon.toLowerCase()}' class='mRight02'></span>`;
+            }
+
+            _value += `${_col.Name ? _col.Name : key}</th>`;
         }
         else {
             _value += `<th>${key}</th>`;
@@ -1310,12 +1355,25 @@ function updateTable(action, sender) {
         _value = `<tr pode-data-value="${item[dataColumn]}">`;
 
         keys.forEach((key) => {
-            _value += `<td pode-column='${key}'>`;
+            var col = columns[key];
+            if (key in columns) {
+                _col = columns[key];
+                _value += `<td pode-column='${key}' style='`;
 
-            if ($.isArray(item[key]) || item[key].ElementType) {
-                _value += buildElements(item[key]);
+                if (col.Alignment) {
+                    _value += `text-align:${col.Alignment};`;
+                }
+
+                _value += `'>`;
             }
             else {
+                _value += `<td pode-column='${key}'>`;
+            }
+
+            if ($.isArray(item[key]) || (item[key] && item[key].ElementType)) {
+                _value += buildElements(item[key]);
+            }
+            else if (item[key]) {
                 _value += item[key];
             }
 
@@ -1455,7 +1513,20 @@ function actionForm(action) {
         return;
     }
 
-    form[0].reset();
+    resetForm(form);
+}
+
+function resetForm(form) {
+    if (!form) {
+        return
+    }
+
+    if (testTagName(form, 'form')) {
+        form[0].reset();
+    }
+    else {
+        resetForm(form.find('form'));
+    }
 }
 
 function actionModal(action, sender) {
@@ -1471,7 +1542,10 @@ function actionModal(action, sender) {
 }
 
 function showModal(action) {
-    var modal = $(`div#${action.ID}.modal`);
+    var modal = action.ID
+        ? $(`div#${action.ID}.modal`)
+        : $(`div.modal[name="${action.Name}"]`);
+
     if (!modal) {
         return;
     }
@@ -1479,6 +1553,9 @@ function showModal(action) {
     if (action.DataValue) {
         modal.attr('pode-data-value', action.DataValue);
     }
+
+    resetForm(modal);
+    removeValidationErrors(modal);
 
     invokeActions(action.Actions);
     modal.modal('show');
@@ -1489,6 +1566,9 @@ function hideModal(action, sender) {
     if (action.ID) {
         modal = $(`div#${action.ID}.modal`);
     }
+    else if (action.Name) {
+        modal = $(`div.modal[name="${action.Name}"]`);
+    }
     else {
         modal = sender.closest('div.modal');
     }
@@ -1496,6 +1576,9 @@ function hideModal(action, sender) {
     if (!modal) {
         return;
     }
+
+    resetForm(modal);
+    removeValidationErrors(modal);
 
     modal.modal('hide');
 }
@@ -1993,7 +2076,12 @@ function buildIcon(element) {
         colour = `style="color:${element.Colour};"`
     }
 
-    return `<span data-feather='${element.Name.toLowerCase()}' ${colour}></span>`;
+    var title = '';
+    if (element.Title) {
+        title = `title='${element.Title}' data-toggle='tooltip'`;
+    }
+
+    return `<span data-feather='${element.Name.toLowerCase()}' ${colour} ${title}></span>`;
 }
 
 function buildBadge(element) {
@@ -2006,7 +2094,12 @@ function buildSpinner(element) {
         colour = `style="color:${element.Colour};"`
     }
 
-    return `<span class="spinner-border spinner-border-sm" role="status" ${colour}></span>`;
+    var title = '';
+    if (element.Title) {
+        title = `title='${element.Title}' data-toggle='tooltip'`;
+    }
+
+    return `<span class="spinner-border spinner-border-sm" role="status" ${colour} ${title}></span>`;
 }
 
 function buildLink(element) {
@@ -2102,6 +2195,23 @@ function actionPage(action) {
 
 function refreshPage() {
     window.location.reload();
+}
+
+function actionError(action, sender) {
+    if (!action || !sender) {
+        return;
+    }
+
+    sender.append(`<div class="alert alert-danger pode-error" role="alert">
+        <h6 class='pode-alert-header'>
+            <span data-feather="alert-circle"></span>
+            <strong>Error</strong>
+        </h6>
+
+        <div class='pode-alert-body pode-text'>
+            ${action.Message}
+        </div>
+    </div>`);
 }
 
 function getPageTitle() {

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -46,6 +46,7 @@ button#menu-toggle .feather {
 .pode-container {
     padding: 1.25rem;
     margin-bottom: 2em;
+    max-width: 100%;
 }
 
 .carousel {

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -83,6 +83,10 @@ nav[role="pagination"] {
     float: right;
 }
 
+.breadcrumb {
+    background-color: transparent;
+}
+
 div#pode-social .feather {
     height: 22px;
     width: 22px;

--- a/src/Templates/Views/elements/breadcrumb.pode
+++ b/src/Templates/Views/elements/breadcrumb.pode
@@ -1,0 +1,12 @@
+<nav aria-label='breadcrumb'>
+    <ol class='breadcrumb' pode-dynamic="$($null -ne $data)">
+        $(foreach ($item in $data.Items) {
+            if ($item.Active) {
+                "<li class='breadcrumb-item active' aria-current='page'>$($item.Name)</li>"
+            }
+            else {
+                "<li class='breadcrumb-item'><a href='$($item.Url)'>$($item.Name)</a></li>"
+            }
+        })
+    </ol>
+</nav>

--- a/src/Templates/Views/elements/icon.pode
+++ b/src/Templates/Views/elements/icon.pode
@@ -4,5 +4,10 @@ $(
         $colour = "style='color:$($data.Colour);'"
     }
 
-    "<span data-feather='$($data.Name)' class='$($data.CssClasses)' $($colour)></span>"
+    $title = [string]::Empty
+    if (![string]::IsNullOrWhiteSpace($data.Title)) {
+        $title = "title='$($data.Title)' data-toggle='tooltip'"
+    }
+
+    "<span data-feather='$($data.Name)' class='$($data.CssClasses)' $($colour) $($title)></span>"
 )

--- a/src/Templates/Views/elements/spinner.pode
+++ b/src/Templates/Views/elements/spinner.pode
@@ -4,5 +4,10 @@ $(
         $colour = "style='color:$($data.Colour);'"
     }
 
-    "<span class='spinner-border spinner-border-sm $($data.CssClasses)' role='status' $($colour)></span>"
+    $title = [string]::Empty
+    if (![string]::IsNullOrWhiteSpace($data.Title)) {
+        $title = "title='$($data.Title)' data-toggle='tooltip'"
+    }
+
+    "<span class='spinner-border spinner-border-sm $($data.CssClasses)' role='status' $($colour) $($title)></span>"
 )

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -153,8 +153,6 @@
                         </div>
                         <nav aria-label='breadcrumb'>
                             <ol class='breadcrumb'>
-                                <li class='breadcrumb-item active' aria-current='page'>Home</li>
-                                <li class='breadcrumb-item'><a href='#'>File</a></li>
                             </ol>
                         </nav>"
                     }

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -81,6 +81,7 @@
                             </span>
                         </div>
                     </footer>
+
                     <div class="sidebar-sticky pt-0">
                         <ul id="sidebar-list" class="nav flex-column">
                             <li class="nav-item nav-page-item">
@@ -151,15 +152,13 @@
                                 $data.Page.Title
                             "</h1>
                         </div>"
-                        if (!$data.Page.NoBreadcrumb) {
-                            "<nav aria-label='breadcrumb'>
-                                <ol class='breadcrumb'>
-                                </ol>
-                            </nav>"
-                        }
                     }
                     else {
                         "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2'></div>"
+                    }
+
+                    if (!$data.Page.NoBreadcrumb) {
+                        Use-PodeWebView -View $data.Breadcrumb
                     })
 
                     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Layouts })

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -150,7 +150,13 @@
                                 }
                                 $data.Page.Title
                             "</h1>
-                        </div>"
+                        </div>
+                        <nav aria-label='breadcrumb'>
+                            <ol class='breadcrumb'>
+                                <li class='breadcrumb-item active' aria-current='page'>Home</li>
+                                <li class='breadcrumb-item'><a href='#'>File</a></li>
+                            </ol>
+                        </nav>"
                     }
                     else {
                         "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2'></div>"

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -150,11 +150,13 @@
                                 }
                                 $data.Page.Title
                             "</h1>
-                        </div>
-                        <nav aria-label='breadcrumb'>
-                            <ol class='breadcrumb'>
-                            </ol>
-                        </nav>"
+                        </div>"
+                        if (!$data.Page.NoBreadcrumb) {
+                            "<nav aria-label='breadcrumb'>
+                                <ol class='breadcrumb'>
+                                </ol>
+                            </nav>"
+                        }
                     }
                     else {
                         "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2'></div>"

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -158,7 +158,7 @@
                     }
 
                     if (!$data.Page.NoBreadcrumb) {
-                        Use-PodeWebView -View $data.Breadcrumb
+                        Use-PodeWebPartialView -Path "elements/breadcrumb" -Data $data.Breadcrumb
                     })
 
                     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Layouts })

--- a/src/Templates/Views/layouts/modal.pode
+++ b/src/Templates/Views/layouts/modal.pode
@@ -1,9 +1,14 @@
-<div class="modal fade $($data.CssClasses)" id="$($data.ID)" tabindex="-1" aria-labelledby="$($data.ID)_lbl" aria-hidden="true" pode-data-value="">
+<div class="modal fade $($data.CssClasses)" id="$($data.ID)" name="$($data.Name)" tabindex="-1" aria-labelledby="$($data.ID)_lbl" aria-hidden="true" pode-data-value="">
     <div class="modal-dialog modal-dialog-scrollable pode-modal-$($data.Size.ToLowerInvariant())">
         <div class="modal-content">
 
             <div class="modal-header">
-                <h5 class="modal-title" id="$($data.ID)_lbl">$($data.Name)</h5>
+                <h5 class="modal-title" id="$($data.ID)_lbl">
+                    $(if (![string]::IsNullOrWhiteSpace($data.Icon)) {
+                        "<span data-feather='$($data.Icon.ToLowerInvariant())' class='mRight02'></span>"
+                    })
+                    $($data.Name)
+                </h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/src/Templates/Views/shared/_load.pode
+++ b/src/Templates/Views/shared/_load.pode
@@ -1,3 +1,15 @@
 $(foreach ($item in $data.Content) {
-    Use-PodeWebView -View $item
+    if (($null -eq $item) -or [string]::IsNullOrEmpty($item.ComponentType)) {
+        return
+    }
+
+    switch ($item.ComponentType.ToLowerInvariant()) {
+        'layout' {
+            Use-PodeWebPartialView -Path "layouts/$($item.LayoutType.ToLowerInvariant())" -Data $item
+        }
+
+        'element' {
+            Use-PodeWebPartialView -Path "elements/$($item.ElementType.ToLowerInvariant())" -Data $item
+        }
+    }
 })

--- a/src/Templates/Views/shared/_load.pode
+++ b/src/Templates/Views/shared/_load.pode
@@ -1,11 +1,3 @@
 $(foreach ($item in $data.Content) {
-    switch ($item.ComponentType.ToLowerInvariant()) {
-        'layout' {
-            Use-PodeWebPartialView -Path "layouts/$($item.LayoutType.ToLowerInvariant())" -Data $item
-        }
-
-        'element' {
-            Use-PodeWebPartialView -Path "elements/$($item.ElementType.ToLowerInvariant())" -Data $item
-        }
-    }
+    Use-PodeWebView -View $item
 })


### PR DESCRIPTION
The main feature being added is breadcrumbs - these will auto generate for tables, unless a specific breadcrumb has been defined.

To supply a custom breadcrumb, you can use `Set-PodeWebBreadcrumb` with `New-PodeWebBreadcrumbItem`.

Also be added is:
* Support for icons in modal headers
* Support for a title tooltip on icons and spinners
* Support for alignment of table columns, plus icons in column headers, and an override name that should be displayed
* Support on Sync-PodeWebTable and Hide/Show-PodeWebModal to use the `-Name` of the element for ease
* Support for a new "Show-PodeWebError", which will render an alert error box beneath the sending control