### PR TITLE
Adds link and dropdown support to the navbar

### DIFF
--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -34,6 +34,23 @@ Start-PodeServer -StatusPageExceptions Show {
     Use-PodeWebTemplates -Title Test -Logo '/pode.web/images/icon.png' -Theme Dark
     Set-PodeWebLoginPage -Authentication Example
 
+    $link1 = New-PodeWebNavLink -Name 'Home' -Url '/'
+    $link2 = New-PodeWebNavLink -Name 'Google' -Url 'https://google.com'
+    $div1 = New-PodeWebNavDivider
+    $link3 = New-PodeWebNavLink -Name 'Disabled' -Url '/' -Disabled
+    $dd1 = New-PodeWebNavDropdown -Name 'Dropdown' -Items @(
+        New-PodeWebNavLink -Name 'Twitter' -Url 'https://twitter.com'
+        New-PodeWebNavLink -Name 'Facebook' -Url 'https://facebook.com' -Disabled
+        New-PodeWebNavDivider
+        New-PodeWebNavLink -Name 'YouTube' -Url 'https://youtube.com'
+        New-PodeWebNavDropdown -Name 'InnerDrop' -Items @(
+            New-PodeWebNavLink -Name 'Twitch' -Url 'https://twitch.tv'
+            New-PodeWebNavLink -Name 'Pode' -Url 'https://github.com/Badgerati/Pode'
+        )
+    )
+
+    Set-PodeWebNavDefault -Items $link1, $link2, $div1, $link3, $dd1
+
 
     $timer1 = New-PodeWebTimer -Name 'Timer1' -Interval 10 -NoAuth -ScriptBlock {
         $rand = Get-Random -Minimum 0 -Maximum 3
@@ -226,7 +243,9 @@ Start-PodeServer -StatusPageExceptions Show {
         Set-PodeResponseAttachment -Path '/download/test.csv'
     }
 
-    Add-PodeWebPage -Name Services -Icon Settings -Group Tools -Layouts $modal, $table -ScriptBlock {
+    $homeLink1 = New-PodeWebNavLink -Name 'Home' -Url '/'
+
+    Add-PodeWebPage -Name Services -Icon Settings -Group Tools -Layouts $modal, $table -Navigation $homeLink1 -ScriptBlock {
         $name = $WebEvent.Query['value']
         if ([string]::IsNullOrWhiteSpace($name)) {
             return

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -34,11 +34,13 @@ Start-PodeServer -StatusPageExceptions Show {
     Use-PodeWebTemplates -Title Test -Logo '/pode.web/images/icon.png' -Theme Dark
     Set-PodeWebLoginPage -Authentication Example
 
-    $link1 = New-PodeWebNavLink -Name 'Home' -Url '/'
-    $link2 = New-PodeWebNavLink -Name 'Google' -Url 'https://google.com'
+    $link1 = New-PodeWebNavLink -Name 'Home' -Url '/' -Icon Home
+    $link2 = New-PodeWebNavLink -Name 'Dynamic' -Icon Settings -NoAuth -ScriptBlock {
+        Show-PodeWebToast -Message "I'm from a nav link!"
+    }
     $div1 = New-PodeWebNavDivider
     $link3 = New-PodeWebNavLink -Name 'Disabled' -Url '/' -Disabled
-    $dd1 = New-PodeWebNavDropdown -Name 'Dropdown' -Items @(
+    $dd1 = New-PodeWebNavDropdown -Name 'Dropdown' -Icon 'maximize-2' -Items @(
         New-PodeWebNavLink -Name 'Twitter' -Url 'https://twitter.com'
         New-PodeWebNavLink -Name 'Facebook' -Url 'https://facebook.com' -Disabled
         New-PodeWebNavDivider

--- a/src/Public/Navigation.ps1
+++ b/src/Public/Navigation.ps1
@@ -1,0 +1,109 @@
+function New-PodeWebNavLink
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Url,
+
+        [switch]
+        $Disabled
+    )
+
+    return @{
+        ComponentType = 'Navigation'
+        NavType = 'Link'
+        Name = $Name
+        ID = (Get-PodeWebElementId -Tag 'Nav-Link' -Id $Id -Name $Name)
+        Url = $Url
+        Disabled = $Disabled.IsPresent
+        InDropdown = $false
+    }
+}
+
+function New-PodeWebNavDropdown
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]
+        $Items,
+
+        [switch]
+        $Disabled,
+
+        [switch]
+        $Hover
+    )
+
+    foreach ($item in $Items) {
+        $item.InDropdown = $true
+    }
+
+    return @{
+        ComponentType = 'Navigation'
+        NavType = 'Dropdown'
+        Name = $Name
+        ID = (Get-PodeWebElementId -Tag 'Nav-Dropdown' -Id $Id -Name $Name)
+        Items = $Items
+        Disabled = $Disabled.IsPresent
+        Hover = $Hover.IsPresent
+        InDropdown = $false
+    }
+}
+
+function New-PodeWebNavDivider
+{
+    [CmdletBinding()]
+    param()
+
+    return @{
+        ComponentType = 'Navigation'
+        NavType = 'Divider'
+        InDropdown = $false
+    }
+}
+
+function Set-PodeWebNavDefault
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]
+        $Items
+    )
+
+    Set-PodeWebState -Name 'default-nav' -Value $Items
+}
+
+function Get-PodeWebNavDefault
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [hashtable[]]
+        $Items
+    )
+
+    if (($null -eq $Items) -or ($items.Length -eq 0)) {
+        return (Get-PodeWebState -Name 'default-nav')
+    }
+    
+    return $Items
+}

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -40,6 +40,7 @@ function Use-PodeWebTemplates
     Set-PodeWebState -Name 'favicon' -Value $FavIcon
     Set-PodeWebState -Name 'social' -Value ([ordered]@{})
     Set-PodeWebState -Name 'pages' -Value @()
+    Set-PodeWebState -Name 'default-nav' -Value $null
     Set-PodeWebState -Name 'endpoint-name' -Value $EndpointName
     Set-PodeWebState -Name 'custom-css' -Value @()
     Set-PodeWebState -Name 'custom-js' -Value @()

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -35,6 +35,7 @@ $(document).ready(() => {
 
     bindSidebarFilter();
     bindMenuToggle();
+    bindNavLinks();
 
     bindFormSubmits();
     bindButtons();
@@ -567,8 +568,8 @@ function bindMenuToggle() {
         $('nav#sidebarMenu').toggleClass('hide');
         $('main[role="main"]').toggleClass('fullscreen');
     });
+    
 }
-
 function bindTablePagination() {
     $('nav .pagination a.page-link').unbind('click').click(function(e) {
         e.preventDefault();
@@ -1034,6 +1035,16 @@ function bindButtons() {
 
         var url = `/elements/button/${button.attr('id')}`;
         sendAjaxReq(url, data, button, true);
+    });
+}
+
+function bindNavLinks() {
+    $("a.pode-nav-link").unbind('click').click(function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var url = `/nav/link/${$(this).attr('id')}`;
+        sendAjaxReq(url, null, null, true);
     });
 }
 

--- a/src/Templates/Public/styles/default-dark.css
+++ b/src/Templates/Public/styles/default-dark.css
@@ -163,6 +163,41 @@ input, textarea, select, .progress {
     color: #999 !important;
 }
 
+div#pode-nav-social a,
+div#pode-nav-items a.nav-link:not(.disabled) {
+    color: #ccc;
+}
+
+div#pode-nav-social a:hover,
+div#pode-nav-items a.nav-link:hover {
+    color: dodgerblue;
+    text-decoration: none;
+}
+
+ul.dropdown-menu {
+    background-color: #142440;
+    border: 0.1rem solid dodgerblue;
+}
+
+hr.dropdown-divider {
+    border-color: dodgerblue;
+}
+
+ul.dropdown-menu a.dropdown-item:not(.disabled) {
+    color: #ccc;
+}
+
+ul.dropdown-menu a.dropdown-item.disabled {
+    color: #777;
+}
+
+ul.dropdown-menu a.dropdown-item:hover,
+ul.dropdown-menu a.dropdown-item:active,
+ul.dropdown-menu a.dropdown-item:focus {
+    background-color: dodgerblue;
+    color: #eee;
+}
+
 pre code {
     background-color: #090d13 !important;
     border-color: #214981 !important;

--- a/src/Templates/Public/styles/default-terminal.css
+++ b/src/Templates/Public/styles/default-terminal.css
@@ -326,12 +326,42 @@ hr {
     background-color: #33ff00;
 }
 
-div#pode-social a {
+div#pode-nav-social a,
+div#pode-nav-items a.nav-link:not(.disabled) {
     color: #33ff00;
 }
 
-div#pode-social a:hover {
+div#pode-nav-social a:hover,
+div#pode-nav-items a.nav-link:hover {
     color: #ffb000;
+}
+
+ul.dropdown-menu {
+    background-color: #111;
+    border: 0.1rem solid #33ff00;
+}
+
+hr.dropdown-divider {
+    border-color: #33ff00;
+}
+
+ul.dropdown-menu a.dropdown-item:not(.disabled) {
+    color: #33ff00;
+}
+
+ul.dropdown-menu a.dropdown-item.disabled {
+    color: #777;
+}
+
+ul.dropdown-menu a.dropdown-item:hover,
+ul.dropdown-menu a.dropdown-item:active,
+ul.dropdown-menu a.dropdown-item:focus {
+    background-color: #ffb000;
+    color: #111;
+}
+
+span.link-divider {
+    margin-top: 2px;
 }
 
 .footer.powered-by a {

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -88,19 +88,77 @@ nav[role="pagination"] {
     background-color: transparent;
 }
 
-div#pode-social .feather {
+div#pode-nav-social .feather {
     height: 22px;
     width: 22px;
     margin-right: 0.3rem;
 }
 
-div#pode-social a {
+div#pode-nav-social a,
+div#pode-nav-items a.nav-link:not(.disabled) {
     color: #bbb;
 }
 
-div#pode-social a:hover {
+div#pode-nav-social a:hover,
+div#pode-nav-items a.nav-link:hover {
     color: #007bff;
     text-decoration: none;
+}
+
+li.nav-item {
+    margin-right: 0.4rem;
+}
+
+ul.dropdown-menu {
+    border-radius: 0.3rem;
+    border: 0.1rem solid #ccc;
+}
+
+hr.dropdown-divider {
+    border-color: #ccc;
+}
+
+span.link-divider {
+    font-size: 1.3rem;
+    margin-left: 0.2rem;
+    margin-right: 0.4rem;
+    margin-top: 1px;
+}
+
+.dropdown-submenu {
+    position: relative;
+}
+
+.dropdown-submenu a::after {
+    transform: rotate(-90deg);
+    position: absolute;
+    right: 10px;
+    top: 44% !important;
+}
+
+.dropdown-submenu:hover .dropdown-menu, .dropdown-submenu:focus .dropdown-menu {
+    display: flex;
+    flex-direction: column;
+    position: absolute !important;
+    margin-top: -40px;
+    left: 100% !important;
+}
+
+@media (max-width: 992px) {
+    .dropdown-menu {
+        width: 50%;
+    }
+    .dropdown-menu .dropdown-submenu {
+        width: auto;
+    }
+}
+
+.dropdown[pode-hover='True']:hover > .dropdown-menu {
+    display: block;
+}
+
+.dropdown[pode-hover='True'] > .dropdown-toggle:active {
+    pointer-events: none;
 }
 
 .hide {
@@ -212,7 +270,15 @@ pre code {
     box-shadow: none !important;
 }
 
-div#pode-social {
+div#pode-nav-social {
+    margin-left: 1em;
+}
+
+div#pode-nav-items {
+    margin-left: 1em;
+}
+
+div#pode-nav {
     margin-right: auto;
     margin-left: 1em;
 }

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -125,6 +125,10 @@ span.link-divider {
     margin-top: 1px;
 }
 
+a.pode-nav-link[pode-dynamic='True'] {
+    cursor: pointer;
+}
+
 .dropdown-submenu {
     position: relative;
 }
@@ -661,6 +665,10 @@ h6 .feather, .h6 .feather {
     margin-right: 0.5em;
 }
 
+.mRight04 {
+    margin-right: 0.4em;
+}
+
 .mRight02 {
     margin-right: 0.2em;
 }
@@ -671,6 +679,10 @@ h6 .feather, .h6 .feather {
 
 .mTop-05 {
     margin-top: -0.5em;
+}
+
+.mTop-02 {
+    margin-top: -0.2em;
 }
 
 .mTop05 {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -5,7 +5,7 @@
     })
 
     <body id="normal-page" pode-theme="$($data.Theme)" pode-theme-target="$(Get-PodeWebTheme -IgnoreCookie)">
-        <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow">
+        <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow navbar-expand-lg">
             <button type='button' class='btn btn-icon-only' id='menu-toggle'>
                 <span data-feather='menu' class='mRight02'></span>
             </button>
@@ -27,17 +27,25 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
 
-            <div id='pode-social'>
-                $(
-                    $socials = Get-PodeWebState -Name 'social'
-                    foreach ($key in $socials.Keys) {
-                        $social = $socials[$key]
+            <div id='pode-nav'>
+                <div id='pode-nav-social'>
+                    $(
+                        $socials = Get-PodeWebState -Name 'social'
+                        foreach ($key in $socials.Keys) {
+                            $social = $socials[$key]
 
-                        "<a href='$($social.Url.ToLowerInvariant())' target='_blank' title='$($social.Tooltip)' data-toggle='tooltip'>
-                            <span data-feather='$($key.ToLowerInvariant())'></span>
-                        </a>"
-                    }
-                )
+                            "<a href='$($social.Url.ToLowerInvariant())' target='_blank' title='$($social.Tooltip)' data-toggle='tooltip'>
+                                <span data-feather='$($key.ToLowerInvariant())'></span>
+                            </a>"
+                        }
+                    )
+                </div>
+
+                <div id='pode-nav-items'>
+                    <ul class="navbar-nav mr-auto">
+                        $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Navigation })
+                    </ul>
+                </div>
             </div>
 
             $(if ($data.Auth.Enabled) {

--- a/src/Templates/Views/navigation/divider.pode
+++ b/src/Templates/Views/navigation/divider.pode
@@ -1,0 +1,10 @@
+$(
+    if ($data.InDropdown) {
+        "<li>
+            <hr class='dropdown-divider'>
+        </li>"
+    }
+    else {
+        "<span class='link-divider'>|</span>"
+    }
+)

--- a/src/Templates/Views/navigation/dropdown.pode
+++ b/src/Templates/Views/navigation/dropdown.pode
@@ -1,0 +1,32 @@
+$(
+    $disabled = [string]::Empty
+    $disabledAria = [string]::Empty
+
+    if ($data.Disabled) {
+        $disabled = 'disabled'
+        $disabledAria = 'tabindex="-1" aria-disabled="true"'
+    }
+
+    if ($data.InDropdown) {
+        "<li class='dropdown-submenu'>
+            <a class='dropdown-item dropdown-toggle $($disabled)' id='$($data.ID)' href='#' role='button' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' $($disabledAria)>
+                $($data.Name)
+            </a>"
+
+            "<ul class='dropdown-menu' aria-labelledby='$($data.ID)'>"
+                Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Items }
+            "</ul>
+        </li>"
+    }
+    else {
+        "<li class='nav-item dropdown' pode-hover='$($data.Hover)'>
+            <a class='nav-link dropdown-toggle $($disabled)' id='$($data.ID)' href='#' role='button' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' $($disabledAria)>
+                $($data.Name)
+            </a>"
+
+            "<ul class='dropdown-menu' aria-labelledby='$($data.ID)'>"
+                Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Items }
+            "</ul>
+        </li>"
+    }
+)

--- a/src/Templates/Views/navigation/dropdown.pode
+++ b/src/Templates/Views/navigation/dropdown.pode
@@ -7,10 +7,15 @@ $(
         $disabledAria = 'tabindex="-1" aria-disabled="true"'
     }
 
+    $icon = [string]::Empty
+    if (![string]::IsNullOrWhiteSpace($data.Icon)) {
+        $icon = "<span data-feather='$($data.Icon.ToLowerInvariant())' class='mRight04 mTop-02'></span>"
+    }
+
     if ($data.InDropdown) {
         "<li class='dropdown-submenu'>
             <a class='dropdown-item dropdown-toggle $($disabled)' id='$($data.ID)' href='#' role='button' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' $($disabledAria)>
-                $($data.Name)
+                $($icon)$($data.Name)
             </a>"
 
             "<ul class='dropdown-menu' aria-labelledby='$($data.ID)'>"
@@ -21,7 +26,7 @@ $(
     else {
         "<li class='nav-item dropdown' pode-hover='$($data.Hover)'>
             <a class='nav-link dropdown-toggle $($disabled)' id='$($data.ID)' href='#' role='button' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' $($disabledAria)>
-                $($data.Name)
+                $($icon)$($data.Name)
             </a>"
 
             "<ul class='dropdown-menu' aria-labelledby='$($data.ID)'>"

--- a/src/Templates/Views/navigation/link.pode
+++ b/src/Templates/Views/navigation/link.pode
@@ -7,14 +7,24 @@ $(
         $disabledAria = 'tabindex="-1" aria-disabled="true"'
     }
 
+    $icon = [string]::Empty
+    if (![string]::IsNullOrWhiteSpace($data.Icon)) {
+        $icon = "<span data-feather='$($data.Icon.ToLowerInvariant())' class='mRight04 mTop-02'></span>"
+    }
+
+    $href = [string]::Empty
+    if (!$data.IsDynamic) {
+        $href = "href='$($data.Url)'"
+    }
+
     if ($data.InDropdown) {
         "<li>
-            <a class='dropdown-item $($disabled)' id='$($data.ID)' href='$($data.Url)' $($disabledAria)>$($data.Name)</a>
+            <a class='dropdown-item pode-nav-link $($disabled)' id='$($data.ID)' $($href) pode-dynamic='$($data.IsDynamic)' $($disabledAria)>$($icon)$($data.Name)</a>
         <li>"
     }
     else {
         "<li class='nav-item'>
-            <a class='nav-link $($disabled)' id='$($data.ID)' href='$($data.Url)' $($disabledAria)>$($data.Name)</a>
+            <a class='nav-link pode-nav-link $($disabled)' id='$($data.ID)' $($href) pode-dynamic='$($data.IsDynamic)' $($disabledAria)>$($icon)$($data.Name)</a>
         </li>"
     }
 )

--- a/src/Templates/Views/navigation/link.pode
+++ b/src/Templates/Views/navigation/link.pode
@@ -1,0 +1,20 @@
+$(
+    $disabled = [string]::Empty
+    $disabledAria = [string]::Empty
+
+    if ($data.Disabled) {
+        $disabled = 'disabled'
+        $disabledAria = 'tabindex="-1" aria-disabled="true"'
+    }
+
+    if ($data.InDropdown) {
+        "<li>
+            <a class='dropdown-item $($disabled)' id='$($data.ID)' href='$($data.Url)' $($disabledAria)>$($data.Name)</a>
+        <li>"
+    }
+    else {
+        "<li class='nav-item'>
+            <a class='nav-link $($disabled)' id='$($data.ID)' href='$($data.Url)' $($disabledAria)>$($data.Name)</a>
+        </li>"
+    }
+)

--- a/src/Templates/Views/shared/_load.pode
+++ b/src/Templates/Views/shared/_load.pode
@@ -11,5 +11,9 @@ $(foreach ($item in $data.Content) {
         'element' {
             Use-PodeWebPartialView -Path "elements/$($item.ElementType.ToLowerInvariant())" -Data $item
         }
+
+        'navigation' {
+            Use-PodeWebPartialView -Path "navigation/$($item.NavType.ToLowerInvariant())" -Data $item
+        }
     }
 })


### PR DESCRIPTION
### Description of the Change
Adds in support to add links and dropdowns to the top navigation bar. Links can be URLs, or custom scriptblock's.

### Related Issue
Resolves #36 

### Examples
```powershell
$link1 = New-PodeWebNavLink -Name 'Home' -Url '/' -Icon Home

$link2 = New-PodeWebNavLink -Name 'Dynamic' -Icon Settings -NoAuth -ScriptBlock {
    Show-PodeWebToast -Message "I'm from a nav link!"
}

$div1 = New-PodeWebNavDivider

$link3 = New-PodeWebNavLink -Name 'Disabled' -Url '/' -Disabled

$dd1 = New-PodeWebNavDropdown -Name 'Dropdown' -Icon 'maximize-2' -Items @(
    New-PodeWebNavLink -Name 'Twitter' -Url 'https://twitter.com'
    New-PodeWebNavLink -Name 'Facebook' -Url 'https://facebook.com' -Disabled

    New-PodeWebNavDivider

    New-PodeWebNavDropdown -Name 'InnerDrop' -Items @(
        New-PodeWebNavLink -Name 'Twitch' -Url 'https://twitch.tv'
        New-PodeWebNavLink -Name 'Pode' -Url 'https://github.com/Badgerati/Pode'
    )
)

Set-PodeWebNavDefault -Items $link1, $link2, $div1, $link3, $dd1
```
