### PR TITLE
Fix Basics link, and bump mkdocs version

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -9,7 +9,7 @@ $src_path = './pode_modules'
 
 $Versions = @{
     MkDocs = '1.1.2'
-    MkDocsTheme = '6.2.8'
+    MkDocsTheme = '7.1.6'
     PlatyPS = '0.14.0'
 }
 
@@ -275,11 +275,13 @@ task DocsHelpBuild DocsDeps, {
     $path = Join-Path $pwd 'docs'
     Get-ChildItem -Path $path -Recurse -Filter '*.md' | ForEach-Object {
         $depth = ($_.FullName.Replace($path, [string]::Empty).trim('\/') -split '[\\/]').Length
+        $updated = $false
 
         $content = (Get-Content -Path $_.FullName | ForEach-Object {
             $line = $_
 
             while ($line -imatch '\[`(?<name>[a-z]+\-podeweb[a-z]+)`\](?<char>[^(])') {
+                $updated = $true
                 $name = $Matches['name']
                 $char = $Matches['char']
                 $line = ($line -ireplace "\[``$($name)``\][^(]", "[``$($name)``]($('../' * $depth)Functions/$($map[$name])/$($name))$($char)")
@@ -288,7 +290,9 @@ task DocsHelpBuild DocsDeps, {
             $line
         })
 
-        $content | Out-File -FilePath $_.FullName -Force -Encoding ascii
+        if ($updated) {
+            $content | Out-File -FilePath $_.FullName -Force -Encoding ascii
+        }
     }
 
     # remove the module

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -41,4 +41,4 @@ Start-PodeServer {
 }
 ```
 
-Then, you can jump over to the [Basics](../Tutorials/Basics)!
+Then, you can jump over to the [Basics](../../Tutorials/Basics)!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,10 +7,22 @@ theme:
   features:
     - navigation.tabs
     - navigation.tabs.sticky
+  font:
+    text: Fira Sans
+    code: Fira Code
   palette:
-    scheme: preference
-    primary: cyan
-    accent: cyan
+    - scheme: default
+      primary: cyan
+      accent: cyan
+      toggle:
+        icon: material/weather-sunny
+        name: Light Mode
+    - scheme: slate
+      primary: cyan
+      accent: cyan
+      toggle:
+        icon: material/weather-night
+        name: Dark Mode
 
 markdown_extensions:
   - pymdownx.highlight
@@ -19,7 +31,6 @@ markdown_extensions:
   - meta
 
 repo_name: badgerati/pode.web
-
 repo_url: https://github.com/Badgerati/Pode.Web
 
 extra:


### PR DESCRIPTION
### Description of the Change
Fixes the Basic link on the Getting Started page, and also bumps the mkdocs version.

### Related Issue
Resolves #61 
