### PR TITLE
Add new Use-PodeWebPages functions, to auto-load page files

### DIFF
--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -57,6 +57,8 @@ Add-PodeWebPage -Name Charts -Icon 'bar-chart-2' -Layouts @(
 )
 ```
 
+You can split up your pages into different .ps1 files, if you do and you place them within a `/pages` directory, then [`Use-PodeWebPages`](../../Functions/Pages/Use-PodeWebPages) will auto-load them all for you.
+
 ### Group
 
 You can group multiple pages together on the sidebar by using the `-Group` parameter on [`Add-PodeWebPage`](../../Functions/Pages/Add-PodeWebPage). This will group pages together into a collapsible container.

--- a/examples/basic.ps1
+++ b/examples/basic.ps1
@@ -29,5 +29,5 @@ Start-PodeServer {
 
     Add-PodeWebPage -Name Processes -Icon Activity -Layouts $form
 
-    Use-PodeWebPages -Path './pages'
+    Use-PodeWebPages
 }

--- a/examples/basic.ps1
+++ b/examples/basic.ps1
@@ -28,4 +28,6 @@ Start-PodeServer {
     )
 
     Add-PodeWebPage -Name Processes -Icon Activity -Layouts $form
+
+    Use-PodeWebPages -Path './pages'
 }

--- a/examples/pages/services.ps1
+++ b/examples/pages/services.ps1
@@ -1,0 +1,7 @@
+Add-PodeWebPage -Name Services -Icon Activity -ScriptBlock {
+    New-PodeWebForm -Name 'Search' -AsCard -ScriptBlock {
+        Get-Service -Name $WebEvent.Data.Name -ErrorAction Ignore | Select-Object DisplayName, Name, Status | Out-PodeWebTextbox -Multiline -Preformat -AsJson
+    } -Content @(
+        New-PodeWebTextbox -Name 'Name'
+    )
+}

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -555,3 +555,31 @@ function ConvertTo-PodeWebPage
         Add-PodeWebPage -Name $cmd -Icon Settings -Layouts $tabs -Group $group -NoAuthentication:$NoAuthentication
     }
 }
+
+function Use-PodeWebPages
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    # use default ./pages, or custom path
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $Path = Join-Path (Get-PodeServerPath) 'pages'
+    }
+    elseif ($Path.StartsWith('.')) {
+        $Path = Join-Path (Get-PodeServerPath) $Path
+    }
+
+    # fail if path not found
+    if (!(Test-Path -Path $Path)) {
+        throw "Path to load pages not found: $($Path)"
+    }
+
+    # get .ps1 files and load them
+    Get-ChildItem -Path $Path -Filter *.ps1 -Force -Recurse | ForEach-Object {
+        Use-PodeScript -Path $_.FullName
+    }
+}


### PR DESCRIPTION
### Description of the Change
Adds a new `Use-PodeWebPages` function to automatically load page .ps1 files from a /pages folder.

### Related Issue
Resolves #48 

### Examples
Folder structure:
```plain
server.ps1
/pages
    page1.ps1
    page2.ps1
```

server.ps1:
```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
    Use-PodeWebTemplates -Title 'Example' -Theme Dark

    Use-PodeWebPages
}
```
