### PR TITLE
Added Support for Different Size Cells

### DIFF
--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -34,7 +34,9 @@ function New-PodeWebCell
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Content,
-        [ValidateRange(1, 12)][int]$Size
+        [ValidateRange(1, 12)]
+        [int]
+        $Width
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -45,7 +47,7 @@ function New-PodeWebCell
         ComponentType = 'Layout'
         LayoutType = 'Cell'
         Content = $Content
-        Size = $Size
+        Width = $Width
     }
 }
 

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -33,7 +33,8 @@ function New-PodeWebCell
     param(
         [Parameter(Mandatory=$true)]
         [hashtable[]]
-        $Content
+        $Content,
+        [ValidateRange(1, 12)][int]$Size
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -44,6 +45,7 @@ function New-PodeWebCell
         ComponentType = 'Layout'
         LayoutType = 'Cell'
         Content = $Content
+        Size = $Size
     }
 }
 

--- a/src/Templates/Views/layouts/grid.pode
+++ b/src/Templates/Views/layouts/grid.pode
@@ -8,7 +8,7 @@
             "<div class='row'>"
         }
 
-        "<div class='col'>"
+        $(if($cell.Size){"<div class='col-$($cell.Size)'>"}else{"<div class='col'>"})
             Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $cell.Content }
         "</div>"
 

--- a/src/Templates/Views/layouts/grid.pode
+++ b/src/Templates/Views/layouts/grid.pode
@@ -8,7 +8,7 @@
             "<div class='row'>"
         }
 
-        $(if($cell.Size){"<div class='col-$($cell.Size)'>"}else{"<div class='col'>"})
+        $(if($cell.Width){"<div class='col-$($cell.Width)'>"}else{"<div class='col'>"})
             Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $cell.Content }
         "</div>"
 


### PR DESCRIPTION
This is limited in a grid of 12

### Description of the Change
This change allows the user to specify a size when creating a New-PodeWebCell in a grid of 12 as bootstrap allows here [bootstrap docs](https://getbootstrap.com/docs/4.0/layout/grid/#all-breakpoints)

### Examples
```
Start-PodeServer {
    Add-PodeEndpoint -Address localhost -Port 8888 -Protocol Http

    Use-PodeWebTemplates -Title 'Example' -Theme Light

    Add-PodeWebPage -Name 'Services' -NoTitle -Icon 'Settings' -ScriptBlock {
        New-PodeWebGrid -Cells @(
            New-PodeWebCell -Size 8 -Content @(
                New-PodeWebCard -Content @(New-PodeWebParagraph -Value 'Size 8')
            )
            New-PodeWebCell -Size 4 -Content @(
                New-PodeWebCard -Content @(New-PodeWebParagraph -Value 'Size 4')
            )
        )
    }
}
```

Without the change:
![image](https://user-images.githubusercontent.com/11185446/121215056-56111680-c888-11eb-9642-363e0ed4718a.png)


With the change:
![image](https://user-images.githubusercontent.com/11185446/121214979-4560a080-c888-11eb-94ec-645c6ad0488d.png)




