### PR TITLE
NoHide on Card optional header

### DIFF
--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -134,7 +134,10 @@ function New-PodeWebCard
         $CssClass,
 
         [switch]
-        $NoTitle
+        $NoTitle,
+
+        [switch]
+        $NoHide
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -148,6 +151,7 @@ function New-PodeWebCard
         ID = (Get-PodeWebElementId -Tag Card -Id $Id -Name $Name -NameAsToken)
         Content = $Content
         NoTitle = $NoTitle.IsPresent
+        NoHide  = $NoHide.IsPresent
         CssClasses = ($CssClass -join ' ')
     }
 }

--- a/src/Templates/Public/styles/default-light.css
+++ b/src/Templates/Public/styles/default-light.css
@@ -62,7 +62,7 @@ pre code {
 }
 
 .pode-container:not([pode-transparent='True']) {
-    background-color: #f5f5f5;
+    background-color: #ffffff;
     border-color: #bbb;
 }
 

--- a/src/Templates/Views/layouts/card.pode
+++ b/src/Templates/Views/layouts/card.pode
@@ -1,7 +1,12 @@
 <div class="card $($data.CssClasses)">
-    $(if (!$data.NoTitle) {
-        "<div class='card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom'>
-            <h5>$($data.Name)</h5>"
+    $(if ((!$data.NoTitle -and $data.Name) -or !$data.NoHide) {
+        "<div class='card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom'>"
+            if (!$data.NoTitle) {
+                "<h5>$($data.Name)</h5>"
+            }
+            else {
+                "<h5></h5>"
+            }
             if (!$data.NoHide) {
                 "<div class='btn-toolbar mb-2 mb-md-0 mTop-05'>
                     <div class='btn-group mr-2'>

--- a/src/Templates/Views/layouts/card.pode
+++ b/src/Templates/Views/layouts/card.pode
@@ -1,21 +1,17 @@
 <div class="card $($data.CssClasses)">
-    <div class="card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom">
-        $(if (!$data.NoTitle) {
-            "<h5>$($data.Name)</h5>"
-        }
-        else {
-            "<h5></h5>"
-        })
-        <div class="btn-toolbar mb-2 mb-md-0 mTop-05">
-            <div class="btn-group mr-2">
-                <button type='button' class='btn btn btn-outline-secondary pode-card-collapse'>
-                    <span data-feather='eye' title='Hide' data-toggle='tooltip'></span>
-                    <span data-feather='eye-off' style='display: none;' title='Show' data-toggle='tooltip'></span>
-                </button>
+    $(if (!$data.NoTitle) {
+        "<div class='card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom'>
+            <h5>$($data.Name)</h5>
+            <div class='btn-toolbar mb-2 mb-md-0 mTop-05'>
+                <div class='btn-group mr-2'>
+                    <button type='button' class='btn btn btn-outline-secondary pode-card-collapse'>
+                        <span data-feather='eye' title='Hide' data-toggle='tooltip'></span>
+                        <span data-feather='eye-off' style='display: none;' title='Show' data-toggle='tooltip'></span>
+                    </button>
+                </div>
             </div>
-        </div>
-    </div>
-
+        </div>"
+    })
     <div class="card-body">
         $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })
     </div>

--- a/src/Templates/Views/layouts/card.pode
+++ b/src/Templates/Views/layouts/card.pode
@@ -1,16 +1,18 @@
 <div class="card $($data.CssClasses)">
-    $(if (!$data.NoTitle) {
+    $(if (!$data.NoTitle -or !$data.NoHide) {
         "<div class='card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom'>
-            <h5>$($data.Name)</h5>
-            <div class='btn-toolbar mb-2 mb-md-0 mTop-05'>
-                <div class='btn-group mr-2'>
-                    <button type='button' class='btn btn btn-outline-secondary pode-card-collapse'>
-                        <span data-feather='eye' title='Hide' data-toggle='tooltip'></span>
-                        <span data-feather='eye-off' style='display: none;' title='Show' data-toggle='tooltip'></span>
-                    </button>
-                </div>
-            </div>
-        </div>"
+            <h5>$($data.Name)</h5>"
+            if (!$data.NoHide) {
+                "<div class='btn-toolbar mb-2 mb-md-0 mTop-05'>
+                    <div class='btn-group mr-2'>
+                        <button type='button' class='btn btn btn-outline-secondary pode-card-collapse'>
+                            <span data-feather='eye' title='Hide' data-toggle='tooltip'></span>
+                            <span data-feather='eye-off' style='display: none;' title='Show' data-toggle='tooltip'></span>
+                        </button>
+                    </div>
+                </div>"
+            }
+        "</div>"
     })
     <div class="card-body">
         $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })

--- a/src/Templates/Views/layouts/card.pode
+++ b/src/Templates/Views/layouts/card.pode
@@ -1,5 +1,5 @@
 <div class="card $($data.CssClasses)">
-    $(if (!$data.NoTitle -or !$data.NoHide) {
+    $(if (!$data.NoTitle) {
         "<div class='card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom'>
             <h5>$($data.Name)</h5>"
             if (!$data.NoHide) {


### PR DESCRIPTION
### Description of the Change
`New-PodeWebCard -NoHide` removes hide button
`New-PodeWebCard -NoTitle` removes the title bar not only the "Name"

There are 2 options I was thinking about, no technical difference of what you can do just what is more clear: 
1. NoTitle = no title bar (removes the bar with the "name" and "hide").
2. Like before NoTitle removes the name so:
NoTitle = no name (remove the name, if you also provide NoHide assumes you also want to remove the bar, but if only no -Name assume you want an empty bar).

It's currently set to option 1.

### Related Issue
https://github.com/Badgerati/Pode.Web/issues/72