### PR TITLE
Add -NoPageFilter switch to hide sidebar page filter

### DIFF
--- a/docs/Tutorials/Basics.md
+++ b/docs/Tutorials/Basics.md
@@ -77,6 +77,14 @@ Add-PodeWebPage -Name 'Services' -Icon 'Settings' -ScriptBlock {
 
 The above would render a new page with a table, showing all the services on the computer.
 
+### Sidebar
+
+Pages added to your site will appear in the sidebar on the left of your pages. The sidebar has a filter box at the top by default, but this can be hidden via `-NoPageFilter`:
+
+```powershell
+Use-PodeWebTemplates -Title 'Example' -Theme Dark -NoPageFilter
+```
+
 ## Custom Scripts/Styles
 
 You can reference custom JavaScript and CSS files to use via [`Import-PodeWebJavaScript`](../../Functions/Utilities/Import-PodeWebJavaScript) and [`Import-PodeWebStylesheet`](../../Functions/Utilities/Import-PodeWebStylesheet). Both take a relative/literal `-Url` to the file.

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -21,7 +21,10 @@ function Use-PodeWebTemplates
 
         [Parameter()]
         [string[]]
-        $EndpointName
+        $EndpointName,
+
+        [switch]
+        $NoPageFilter
     )
 
     $mod = (Get-Module -Name Pode -ErrorAction Ignore | Sort-Object -Property Version -Descending | Select-Object -First 1)
@@ -38,6 +41,7 @@ function Use-PodeWebTemplates
     Set-PodeWebState -Name 'title' -Value $Title
     Set-PodeWebState -Name 'logo' -Value $Logo
     Set-PodeWebState -Name 'favicon' -Value $FavIcon
+    Set-PodeWebState -Name 'no-page-filter' -Value $NoPageFilter.IsPresent
     Set-PodeWebState -Name 'social' -Value ([ordered]@{})
     Set-PodeWebState -Name 'pages' -Value @()
     Set-PodeWebState -Name 'default-nav' -Value $null

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -77,10 +77,19 @@
         <div class="container-fluid">
             <div class="row">
                 <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
-                    <div class='input-group mb-2 mLeft1 w90 mTop1-8'>
-                        <div class='input-group-prepend'><div class='input-group-text'><span data-feather='filter'></span></div></div>
-                        <input type='text' class='form-control pode-nav-filter' id="filter_sidebar" placeholder='Filter' for="sidebar-list">
-                    </div>
+                    $(
+                        $noPageFilter = Get-PodeWebState -Name 'no-page-filter'
+
+                        if (!$noPageFilter) {
+                            "<div class='input-group mb-2 mLeft1 w90 mTop1-8'>
+                                <div class='input-group-prepend'><div class='input-group-text'><span data-feather='filter'></span></div></div>
+                                <input type='text' class='form-control pode-nav-filter' id='filter_sidebar' placeholder='Filter' for='sidebar-list'>
+                            </div>"
+                        }
+                        else {
+                            "<div class='mb-2 mTop1-8'></div>"
+                        }
+                    )
 
                     <footer class="footer powered-by mt-auto py-3">
                         <div>


### PR DESCRIPTION
### Description of the Change
Adds a new `-NoPageFilter` switch to `Use-PodeWebTemplates`, which will hide the filter bar at the top of the sidebar.

### Related Issue
Resolves #74 

### Examples
```powershell
Use-PodeWebTemplates -Title 'Example' -Theme Dark -NoPageFilter
```