### PR TITLE
Logo on login page redirects back to home page

### DIFF
--- a/docs/Tutorials/Icons.md
+++ b/docs/Tutorials/Icons.md
@@ -1,6 +1,6 @@
 # Icons
 
-All icons rendered in Pode.Web are done using [Material Design Icons](https://materialdesignicons.com). This applies to pretty much all `-Icon` parameters, except for the one on [`Set-PodeWebLoginPage`](../../Functions/Pages/Set-PodeWebLoginPage) which is actually the path to an image.
+All icons rendered in Pode.Web are done using [Material Design Icons](https://materialdesignicons.com). This applies to pretty much all `-Icon` parameters, except for the one on [`Set-PodeWebLoginPage`](../../Functions/Pages/Set-PodeWebLoginPage) which is actually the path to an image (This has been changed to `-Logo`, though `-Icon` is still an alias for now).
 
 A list of searchable icons can be [found here](https://pictogrammers.github.io/@mdi/font/5.4.55/). When you've found the one you need, you only have to supply the part after `mdi-`. For example let's say you need the `mdi-github` icon, then you only need to supply the `github` part:
 

--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -22,7 +22,7 @@ New-PodeAuthScheme -Form | Add-PodeAuth -Name Example -ScriptBlock {
 Set-PodeWebLoginPage -Authentication Example
 ```
 
-By default the Pode icon is displayed, but you can change this by using the `-Icon` parameter; this takes a literal or relative URL to an image file.
+By default the Pode icon is displayed as the logo, but you can change this by using the `-Logo` parameter; this takes a literal or relative URL to an image file.
 
 ## Home
 

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -7,8 +7,14 @@ function Set-PodeWebLoginPage
         $Authentication,
 
         [Parameter()]
+        [Alias('Icon')]
         [string]
-        $Icon,
+        $Logo,
+
+        [Parameter()]
+        [Alias('IconUrl')]
+        [string]
+        $LogoUrl,
 
         [Parameter()]
         [string]
@@ -39,9 +45,13 @@ function Set-PodeWebLoginPage
         Theme = $ThemeProperty
     }
 
-    # set a default icon
-    if ([string]::IsNullOrWhiteSpace($Icon)) {
-        $Icon = '/pode.web/images/icon.png'
+    # set a default logo/url
+    if ([string]::IsNullOrWhiteSpace($Logo)) {
+        $Logo = '/pode.web/images/icon.png'
+    }
+
+    if ([string]::IsNullOrWhiteSpace($LogoUrl)) {
+        $LogoUrl = '/'
     }
 
     # set default failure/success urls
@@ -64,7 +74,8 @@ function Set-PodeWebLoginPage
     Add-PodeRoute -Method Get -Path '/login' -Authentication $Authentication -EndpointName $endpointNames -Login -ScriptBlock {
         Write-PodeWebViewResponse -Path 'login' -Data @{
             Theme = Get-PodeWebTheme
-            Icon = $using:Icon
+            Logo = $using:Logo
+            LogoUrl = $using:LogoUrl
             Copyright = $using:Copyright
             Auth = @{
                 Name = $using:Authentication

--- a/src/Templates/Views/login.pode
+++ b/src/Templates/Views/login.pode
@@ -7,7 +7,9 @@
     <body id="login-page" pode-theme="$($data.Theme)" pode-theme-target="$(Get-PodeWebTheme -IgnoreCookie)">
         <form class="form-signin" action='/login' method='POST'>
             <div class='text-center mb-4'>
-                <img class='mb-4 rounded' src='$($data.Icon)' alt='' width='72' height='72'>
+                <a href='$($data.LogoUrl)'>
+                    <img class='mb-4 rounded' src='$($data.Logo)' alt='' width='72' height='72'>
+                </a>
                 <h1 class='h3 mb-3 font-weight-normal'>Please sign in</h1>
             </div>
 


### PR DESCRIPTION
### Description of the Change
The logo on the login page can now be clicked, and redirects back to the login page. This can be changed via `-LogoUrl`.

`-Icon` has also been renamed to `-Logo` on `Set-PodeWebLoginPage`. However, `-Icon` and `-IconUrl` are valid aliases - for now.
(icon was too confusing, and conflicted with other `-Icon` parameters that expect an MDI name)

### Related Issue
Resolves #80

### Examples
By default, it redirects back to the home page. It can be changed using `-LogoUrl`:
```powershell
Set-PodeWebLoginPage -Authentication Example -LogoUrl '<url>'
```
