### PR TITLE
New Get/Test-PodeWebPage functions

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -316,17 +316,6 @@ function Protect-PodeWebName
     return ($Name -ireplace '[^a-z0-9_]', '').Trim()
 }
 
-function Test-PodeWebPage
-{
-    param(
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Name
-    )
-
-    return (Get-PodeWebState -Name 'pages' | Where-Object { $_.Name -ieq $Name } | Measure-Object).Count -ne 0
-}
-
 function Test-PodeWebRoute
 {
     param(

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -700,3 +700,86 @@ function Use-PodeWebPages
         Use-PodeScript -Path $_.FullName
     }
 }
+
+function Get-PodeWebPage
+{
+    [CmdletBinding(DefaultParameterSetName='Group')]
+    param(
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter(ParameterSetName='Group')]
+        [string]
+        $Group,
+
+        [Parameter(ParameterSetName='NoGroup')]
+        [switch]
+        $NoGroup
+    )
+
+    # get all pages
+    $pages = Get-PodeWebState -Name 'pages'
+
+    # filter by group
+    if ($NoGroup) {
+        $pages = @(foreach ($page in $pages) {
+            if ([string]::IsNullOrWhiteSpace($page.Group)) {
+                $page
+            }
+        })
+    }
+    elseif (![string]::IsNullOrWhiteSpace($Group)) {
+        $pages = @(foreach ($page in $pages) {
+            if ($page.Group -ieq $Group) {
+                $page
+            }
+        })
+    }
+
+    # filter by page name
+    if (![string]::IsNullOrWhiteSpace($Name)) {
+        $pages = @(foreach ($page in $pages) {
+            if ($page.Name -ieq $Name) {
+                $page
+            }
+        })
+    }
+
+    # return filtered pages
+    return $pages
+}
+
+function Test-PodeWebPage
+{
+    [CmdletBinding(DefaultParameterSetName='Group')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(ParameterSetName='Group')]
+        [string]
+        $Group,
+
+        [Parameter(ParameterSetName='NoGroup')]
+        [switch]
+        $NoGroup
+    )
+
+    # get pages
+    $pages = @()
+    if ($NoGroup) {
+        $pages = Get-PodeWebPage -Name $Name -NoGroup:$NoGroup
+    }
+    else {
+        $pages = Get-PodeWebPage -Name $Name -Group $Group
+    }
+
+    # are there any pages?
+    if ($null -eq $pages) {
+        return $false
+    }
+
+    return (@($pages) | Measure-Object).Count -gt 0
+}


### PR DESCRIPTION
### Description of the Change
Adds two new functions: `Get-PodeWebPage` and `Test-PodeWebPage`.

You can either supply no parameters, to get/test all pages. just `-Name` will filter all pages with that name, in every group. `-Group` will filter for pages in specific groups, or to filter for pages in no group use `-NoGroup`.

### Related Issue
Resolves #79 

### Examples
```powershell
Get-PodeWebPage -Name 'Charts'
Get-PodeWebPage -Group 'Tools'

Test-PodeWebPage -Name 'Options' -NoGroup
```
