### PR TITLE
Adds the group name to the page URL when a page is grouped

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -643,8 +643,8 @@ function Get-PodeWebPagePath
     $path = [string]::Empty
 
     if ($null -ne $Page) {
-        $Name = $page.Name
-        $Group = $page.Group
+        $Name = $Page.Name
+        $Group = $Page.Group
     }
 
     if (![string]::IsNullOrWhiteSpace($Group)) {

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -368,9 +368,13 @@ function Get-PodeWebElementId
     # start with element tag
     $_id += "$($Tag)"
 
-    # add page name if we have one
+    # add page name and group if we have one
     if (![string]::IsNullOrWhiteSpace($PageData.Name)) {
         $_id += "_$($PageData.Name)"
+    }
+
+    if (![string]::IsNullOrWhiteSpace($PageData.Group)) {
+        $_id += "_$($PageData.Group)"
     }
 
     # add name if we have one
@@ -617,4 +621,36 @@ function Test-PodeWebOutputWrapped
     }
 
     return (($Output -is [hashtable]) -and ($Output.Operation -ieq 'Output') -and ![string]::IsNullOrWhiteSpace($Output.ElementType))
+}
+
+function Get-PodeWebPagePath
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(ParameterSetName='Name')]
+        [string]
+        $Group,
+
+        [Parameter(ParameterSetName='Page')]
+        [hashtable]
+        $Page
+    )
+
+    $path = [string]::Empty
+
+    if ($null -ne $Page) {
+        $Name = $page.Name
+        $Group = $page.Group
+    }
+
+    if (![string]::IsNullOrWhiteSpace($Group)) {
+        $path += "/groups/$($Group)"
+    }
+
+    $path += "/pages/$($Name)"
+    return $path
 }

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -736,13 +736,17 @@ function Move-PodeWebPage
 
         [Parameter()]
         [string]
+        $Group,
+
+        [Parameter()]
+        [string]
         $DataValue,
 
         [switch]
         $NewTab
     )
 
-    $page = "/pages/$($Name -replace '\s+', '+')"
+    $page = ((Get-PodeWebPagePath -Name $Name -Group $Group) -replace '\s+', '+')
 
     if (![string]::IsNullOrWhiteSpace($DataValue)) {
         $page += "?Value=$($DataValue)"

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -285,7 +285,7 @@ function Add-PodeWebPage
 
     # test if page/page-link exists
     if (Test-PodeWebPage -Name $Name -Group $Group -NoGroup) {
-        throw "Web page/link already exists: $($Name)"
+        throw "Web page/link already exists: $($Name) [Group: $($Group)]"
     }
 
     # set page title
@@ -452,7 +452,7 @@ function Add-PodeWebPageLink
 
     # test if page/page-link exists
     if (Test-PodeWebPage -Name $Name -Group $Group -NoGroup) {
-        throw "Web page/link already exists: $($Name)"
+        throw "Web page/link already exists: $($Name) [Group: $($Group)]"
     }
 
     # setup page meta

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -63,7 +63,7 @@ function Use-PodeWebTemplates
     Add-PodeRoute -Method Get -Path '/' -EndpointName $EndpointName -ScriptBlock {
         $pages = @(Get-PodeWebState -Name 'pages')
         if (($null -ne $pages) -and ($pages.Length -gt 0)) {
-            Move-PodeResponseUrl -Url "/pages/$($pages[0].Name)"
+            Move-PodeResponseUrl -Url (Get-PodeWebPagePath -Page $pages[0])
             return
         }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1074,9 +1074,24 @@ function bindPageLinks() {
         e.preventDefault();
         e.stopPropagation();
 
-        var url = `/pages/${$(this).attr('name')}`;
+        var url = getPagePath(null, null, this);
         sendAjaxReq(url, null, null, true);
     });
+}
+
+function getPagePath(name, group, page) {
+    if (page) {
+        name = $(page).attr('name');
+        group = $(page).attr('pode-page-group');
+    }
+
+    var path = '';
+    if (group) {
+        path += `/groups/${group}`;
+    }
+
+    path += `/pages/${name}`;
+    return path;
 }
 
 function bindTableFilters() {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -143,7 +143,7 @@
                                         }
 
                                         "<li class='nav-item nav-page-item'>
-                                            <a class='nav-link $(if ($data.Page.Name -ieq $page.Name) { "active" })' name='$($page.Name)' pode-page-type='$($page.PageType)' pode-dynamic='$($page.IsDynamic)' $($href)>
+                                            <a class='nav-link $(if ($data.Page.Name -ieq $page.Name) { "active" })' name='$($page.Name)' pode-page-group='$($pageGroup.Name)' pode-page-type='$($page.PageType)' pode-dynamic='$($page.IsDynamic)' $($href)>
                                                 <div>
                                                     <span class='mdi mdi-$($page.Icon.ToLowerInvariant()) mdi-size-22 mRight02'></span>
                                                     $($page.Name)
@@ -172,7 +172,7 @@
                         "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom'>
                             <h1 class='h2'>"
                                 if ($data.Page.ShowBack) {
-                                    "<a href='/pages/$($data.Page.Name)'><span class='mdi mdi-arrow-left'></span></a>"
+                                    "<a href='$($data.Page.Url)'><span class='mdi mdi-arrow-left'></span></a>"
                                 }
                                 $data.Page.Title
                             "</h1>


### PR DESCRIPTION
### Description of the Change
The default URL path for pages is `/pages/<page>`. This works, until you want two pages with the same name in two different groups; at which point you get a "page already exists" error.

This adds the group name to the URL path when a page has a `-Group` specified: `/groups/<group>/pages/<page>`.

If no group, then the page path is the default.

### Related Issue
Resolves #81
