### PR TITLE
Fix the heart emoji to be an icon

### DIFF
--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -718,6 +718,10 @@ a.nav-link .mdi:before {
     top: 3px;
 }
 
+.mdi-size-15::before {
+    font-size: 15px;
+}
+
 .mdi-size-20::before {
     font-size: 20px;
 }

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -94,7 +94,8 @@
                     <footer class="footer powered-by mt-auto py-3">
                         <div>
                             <span class="text-muted">
-                                🧡 Powered by <a href='https://badgerati.github.io/Pode/' style='color: deepskyblue; text-decoration: none;'>Pode</a>
+                                <span class="mdi mdi-heart mdi-size-15" style="color:orangered"></span>
+                                Powered by <a href='https://badgerati.github.io/Pode/' style='color: deepskyblue; text-decoration: none;'>Pode</a>
                             </span>
                         </div>
                     </footer>

--- a/src/Templates/Views/login.pode
+++ b/src/Templates/Views/login.pode
@@ -8,7 +8,7 @@
         <form class="form-signin" action='/login' method='POST'>
             <div class='text-center mb-4'>
                 <a href='$($data.LogoUrl)'>
-                    <img class='mb-4 rounded' src='$($data.Logo)' alt='' width='72' height='72'>
+                    <img class='mb-4 rounded' src='$($data.Logo)' alt='logo' height='72'>
                 </a>
                 <h1 class='h3 mb-3 font-weight-normal'>Please sign in</h1>
             </div>


### PR DESCRIPTION
This is just a quick fix so that <3 emoji in the "powered by" footer is an icon; done so that it renders in all browsers, and doesn't appear as a square.

Also only sets the height of the login logo, rather than height+width, which resulted in squashed logos.