### PR TITLE
Add spin, flip and rotate actions for icons

### DIFF
--- a/docs/Tutorials/Elements/Icon.md
+++ b/docs/Tutorials/Elements/Icon.md
@@ -14,3 +14,17 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![icon_ele](../../../images/icon_ele.png)
+
+## Actions
+
+### Flip
+
+You can flip an icon by passing `Horizontal` or `Vertical` to the `-Flip` parameter. You cannot supply both flip and rotate together.
+
+### Rotate
+
+You can rotate an icon by a fixed number of degrees by supplying a value, 45-315 in 45 degree increments, to the `-Rotate` parameter. You cannot supply both flip and rotate together.
+
+### Spin
+
+You can make an icon spin by supplying the `-Spin` switch.

--- a/examples/icons.ps1
+++ b/examples/icons.ps1
@@ -1,0 +1,30 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer -Threads 2 {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Inputs' -Theme Dark
+
+    # set the home page controls
+    $card1 = New-PodeWebCard -Content @(
+        New-PodeWebIcon -Name 'refresh'
+        New-PodeWebIcon -Name 'refresh' -Colour Green
+        New-PodeWebIcon -Name 'refresh' -Flip Horizontal
+        New-PodeWebIcon -Name 'refresh' -Rotate 180
+        New-PodeWebIcon -Name 'refresh' -Spin
+    )
+
+    $card2 = New-PodeWebCard -Content @(
+        New-PodeWebTable -Name Example -ScriptBlock {
+            return @{
+                Icon = (New-PodeWebIcon -Name 'refresh' -Spin -Colour Yellow)
+            }
+        }
+    )
+
+    Set-PodeWebHomePage -Layouts $card1, $card2 -Title 'Icons'
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1138,7 +1138,7 @@ function New-PodeWebAlert
 
 function New-PodeWebIcon
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Rotate')]
     param(
         [Parameter(Mandatory=$true)]
         [string]
@@ -1154,7 +1154,20 @@ function New-PodeWebIcon
 
         [Parameter()]
         [string]
-        $Title
+        $Title,
+
+        [Parameter(ParameterSetName='Flip')]
+        [ValidateSet('Horizontal', 'Vertical')]
+        [string]
+        $Flip,
+
+        [Parameter(ParameterSetName='Rotate')]
+        [ValidateSet(0, 45, 90, 135, 180, 225, 270, 315)]
+        [int]
+        $Rotate = 0,
+
+        [switch]
+        $Spin
     )
 
     if (![string]::IsNullOrWhiteSpace($Colour)) {
@@ -1169,6 +1182,9 @@ function New-PodeWebIcon
         Colour = $Colour
         CssClasses = ($CssClass -join ' ')
         Title = $Title
+        Flip = $Flip
+        Rotate = $Rotate
+        Spin = $Spin.IsPresent
     }
 }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2302,7 +2302,22 @@ function buildIcon(element) {
         title = `title='${element.Title}' data-toggle='tooltip'`;
     }
 
-    return `<span class='mdi mdi-${element.Name.toLowerCase()} mdi-size-20' ${colour} ${title}></span>`;
+    var spin = '';
+    if (element.Spin) {
+        spin = 'mdi-spin'
+    }
+
+    var flip = '';
+    if (element.Flip) {
+        flip = `mdi-flip-${element.Flip[0]}`.toLowerCase();
+    }
+
+    var rotate = '';
+    if (element.Rotate > 0) {
+        rotate = `mdi-rotate-${element.Rotate}`;
+    }
+
+    return `<span class='mdi mdi-${element.Name.toLowerCase()} ${spin} ${flip} ${rotate} mdi-size-20' ${colour} ${title}></span>`;
 }
 
 function buildBadge(element) {

--- a/src/Templates/Views/elements/icon.pode
+++ b/src/Templates/Views/elements/icon.pode
@@ -9,5 +9,20 @@ $(
         $title = "title='$($data.Title)' data-toggle='tooltip'"
     }
 
-    "<span class='mdi mdi-$($data.Name) $($data.CssClasses)' $($colour) $($title)></span>"
+    $spin = [string]::Empty
+    if ($data.Spin) {
+        $spin = 'mdi-spin'
+    }
+
+    $flip = [string]::Empty
+    if (![string]::IsNullOrWhiteSpace($data.Flip)) {
+        $flip = "mdi-flip-$($data.Flip[0])".ToLowerInvariant()
+    }
+
+    $rotate = [string]::Empty
+    if ($data.Rotate -gt 0) {
+        $rotate = "mdi-rotate-$($data.Rotate)"
+    }
+
+    "<span class='mdi mdi-$($data.Name) $($spin) $($flip) $($rotate) $($data.CssClasses)' $($colour) $($title)></span>"
 )


### PR DESCRIPTION
### Description of the Change
Add the following action parameters for `New-PodeWebIcon`: `-Spin`, `-Flip`, and `-Rotate`.

Spin just spins the icon.
Flip can accept either Horizontal or Vertical, and will flip the icon accordingly.
Rotate can accept a value from 45-315 in 45 degree increments.

### Related Issue
Resolves #88

### Examples
```powershell
New-PodeWebIcon -Name 'refresh' -Flip Horizontal
New-PodeWebIcon -Name 'refresh' -Rotate 180
New-PodeWebIcon -Name 'refresh' -Spin
```
