### PR TITLE
Get -NoAuth from PageData for dynamic pages

### DIFF
--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -169,6 +169,14 @@ Add-PodeWebPage -Name Services -Icon Settings -Layouts $servicesTable -ScriptBlo
 }
 ```
 
+### No Authentication
+
+If you add a page when you've enabled authentication, you can set a page to be accessible without authentication by supplying the `-NoAuth` switch to [`Add-PodeWebPage`](../../Functions/Pages/Add-PodeWebPage).
+
+If you do this and you add all elements/layouts dynamically (via `-ScriptBlock`), then there's no further action needed.
+
+If however you're added the elements/layouts using the `-Layouts` parameter, then certain elements/layouts will also need their `-NoAuth` switches to be supplied (such as charts, for example), otherwise data/actions will fail with a 401 response.
+
 ## Convert Module
 
 Similar to how Pode has a function to convert a Module to a REST API; Pode.Web has one that can convert a Module into Web Pages: [`ConvertTo-PodeWebPage`](../../Functions/Pages/ConvertTo-PodeWebPage)!

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -99,7 +99,7 @@ function New-PodeWebTextbox
     $routePath = "/elements/autocomplete/$($Id)"
     if (($null -ne $AutoComplete) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -1059,7 +1059,7 @@ function New-PodeWebButton
     $routePath = "/elements/button/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -1368,7 +1368,7 @@ function New-PodeWebChart
     $routePath = "/elements/chart/$($Id)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -1585,7 +1585,7 @@ function New-PodeWebTable
         NoExport = $NoExport.IsPresent
         AutoRefresh = $AutoRefresh.IsPresent
         NoRefresh = $NoRefresh.IsPresent
-        NoAuth = $NoAuthentication.IsPresent
+        NoAuthentication = $NoAuthentication.IsPresent
         CssClasses = ($CssClass -join ' ')
         Paging = @{
             Enabled = $Paginate.IsPresent
@@ -1595,7 +1595,7 @@ function New-PodeWebTable
 
     # auth an endpoint
     $auth = $null
-    if (!$NoAuthentication) {
+    if (!$NoAuthentication -and !$PageData.NoAuthentication) {
         $auth = (Get-PodeWebState -Name 'auth')
     }
 
@@ -1735,7 +1735,7 @@ function Add-PodeWebTableButton
     $routePath = "/elements/table/$($Table.ID)/button/$($Name)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$Table.NoAuth) {
+        if (!$Table.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -1807,6 +1807,11 @@ function New-PodeWebCodeEditor
         [string[]]
         $EndpointName,
 
+        [Parameter()]
+        [Alias('NoAuth')]
+        [switch]
+        $NoAuthentication,
+
         [switch]
         $ReadOnly,
 
@@ -1835,7 +1840,7 @@ function New-PodeWebCodeEditor
     $routePath = "/elements/code-editor/$($Id)/upload"
     if ($uploadable -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -1918,7 +1923,7 @@ function New-PodeWebForm
     $routePath = "/elements/form/$($Id)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -2004,7 +2009,7 @@ function New-PodeWebTimer
     $routePath = "/elements/timer/$($Id)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -2122,13 +2127,12 @@ function New-PodeWebTile
         CssClasses = ($CssClass -join ' ')
         AutoRefresh = $AutoRefresh.IsPresent
         NoRefresh = $NoRefresh.IsPresent
-        NoAuth = $NoAuthentication.IsPresent
         NewLine = $NewLine.IsPresent
     }
 
     # auth an endpoint
     $auth = $null
-    if (!$NoAuthentication) {
+    if (!$NoAuthentication -and !$PageData.NoAuthentication) {
         $auth = (Get-PodeWebState -Name 'auth')
     }
 

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -270,7 +270,7 @@ function New-PodeWebModal
     $routePath = "/layouts/modal/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -446,7 +446,7 @@ function New-PodeWebSteps
     $routePath = "/layouts/steps/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -520,7 +520,7 @@ function New-PodeWebStep
     $routePath = "/layouts/step/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$NoAuthentication) {
+        if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -306,6 +306,7 @@ function Add-PodeWebPage
         Icon = $Icon
         Group = $Group
         Url = (Get-PodeWebPagePath -Name $Name -Group $Group)
+        NoAuthentication = $NoAuthentication.IsPresent
         Access = @{
             Groups = @($AccessGroups)
             Users = @($AccessUsers)


### PR DESCRIPTION
### Description of the Change
When defining a dynamic page with `-NoAuth`, elements/layouts will get the NoAuth value from the page's PageData variable - saving having to supply it.

### Related Issue
Resolves #92
