### PR TITLE
Adds a new Accordion layout

### DIFF
--- a/docs/Tutorials/Layouts/Accordion.md
+++ b/docs/Tutorials/Layouts/Accordion.md
@@ -1,0 +1,47 @@
+# Accordion
+
+An accordion layout is an array of accordion bellows with content. They are displayed in a collapsible manor, with the first bellow being expanded. When another bellow is expanded, all other bellows are collapsed.
+
+The bellows take an array of content, that can be either other layouts or raw elements.
+
+## Usage
+
+To create an accordion layout you use [`New-PodeWebAccordion`](../../../Functions/Layouts/New-PodeWebAccordion), and supply it an array of `-Bellows` using [`New-PodeWebBellow`](../../../Functions/Layouts/New-PodeWebBellow). The bellows themselves accept an array of other elements/layouts as `-Content`.
+
+For example, the following renders an accordion with 3 bellows each containing an image:
+
+```powershell
+New-PodeWebAccordion -Bellows @(
+    New-PodeWebBellow -Name Bellow1 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+    New-PodeWebBellow -Name Bellow2 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+    New-PodeWebBellow -Name Bellow3 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+)
+```
+
+Which would look like below:
+
+![accordion_layout](../../../images/accordion_layout.png)
+
+## Cycling
+
+You can render accordions that automatically cycle through their bellows every X seconds, by using the `-Cycle` switch and `-CycleInterval` parameter. The default interval is every 15secs:
+
+```powershell
+New-PodeWebAccordion -Cycle -Bellows @(
+    New-PodeWebBellow -Name Bellow1 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+    New-PodeWebBellow -Name Bellow2 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+    New-PodeWebBellow -Name Bellow3 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+)
+```

--- a/docs/Tutorials/Outputs/Accordion.md
+++ b/docs/Tutorials/Outputs/Accordion.md
@@ -1,0 +1,27 @@
+# Accordion
+
+This page details the available output actions available to control an Accordion layout.
+
+## Move
+
+You can change the current active accordion bellow by using [`Move-PodeWebAccordion`](../../../Functions/Outputs/Move-PodeWebAccordion). This will make the specified bellow become the active one, and collapse the others.
+
+```powershell
+New-PodeWebAccordion -Items @(
+    New-PodeWebBellow -Name 'Item 1' -Content @(
+        New-PodeWebButton -Name 'Next' -Id 'next_1' -ScriptBlock {
+            Move-PodeWebAccordion -Name 'Item 2'
+        }
+    )
+    New-PodeWebBellow -Name 'Item 2' -Content @(
+        New-PodeWebButton -Name 'Next' -Id 'next_2' -ScriptBlock {
+            Move-PodeWebAccordion -Name 'Item 3'
+        }
+    )
+    New-PodeWebBellow -Name 'Item 3' -Content @(
+        New-PodeWebButton -Name 'Next' -Id 'next_3' -ScriptBlock {
+            Move-PodeWebAccordion -Name 'Item 1'
+        }
+    )
+)
+```

--- a/examples/accordion.ps1
+++ b/examples/accordion.ps1
@@ -1,0 +1,26 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer -Threads 2 {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Inputs' -Theme Dark
+
+    # set the home page controls
+    $card = New-PodeWebAccordion -Items @(
+        New-PodeWebAccordionItem -Name 'Section 1' -Icon 'information' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebAccordionItem -Name 'Section 2' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebAccordionItem -Name 'Section 3' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+    )
+
+    Set-PodeWebHomePage -Layouts $card -Title 'Accordion'
+}

--- a/examples/accordion.ps1
+++ b/examples/accordion.ps1
@@ -10,15 +10,24 @@ Start-PodeServer -Threads 2 {
     Use-PodeWebTemplates -Title 'Inputs' -Theme Dark
 
     # set the home page controls
-    $card = New-PodeWebAccordion -Items @(
-        New-PodeWebAccordionItem -Name 'Section 1' -Icon 'information' -Content @(
+    $card = New-PodeWebAccordion -Cycle -Bellows @(
+        New-PodeWebBellow -Name 'Bellow 1' -Icon 'information' -Content @(
             New-PodeWebText -Value 'Some random text' -InParagraph
+            New-PodeWebButton -Name 'Next' -Id 'next_1' -ScriptBlock {
+                Move-PodeWebAccordion -Name 'Bellow 2'
+            }
         )
-        New-PodeWebAccordionItem -Name 'Section 2' -Content @(
+        New-PodeWebBellow -Name 'Bellow 2' -Content @(
             New-PodeWebText -Value 'Some random text' -InParagraph
+            New-PodeWebButton -Name 'Next' -Id 'next_2' -ScriptBlock {
+                Move-PodeWebAccordion -Name 'Bellow 3'
+            }
         )
-        New-PodeWebAccordionItem -Name 'Section 3' -Content @(
+        New-PodeWebBellow -Name 'Bellow 3' -Content @(
             New-PodeWebText -Value 'Some random text' -InParagraph
+            New-PodeWebButton -Name 'Next' -Id 'next_3' -ScriptBlock {
+                Move-PodeWebAccordion -Name 'Bellow 1'
+            }
         )
     )
 

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -608,3 +608,64 @@ function New-PodeWebBreadcrumbItem
         Active = $Active.IsPresent
     }
 }
+
+function New-PodeWebAccordion
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]
+        $Items,
+
+        [Parameter()]
+        [string[]]
+        $CssClass
+    )
+
+    if (!(Test-PodeWebContent -Content $Content -ComponentType Layout -LayoutType AccordionItem)) {
+        throw 'Accordions can only contain AccordionItem layouts'
+    }
+
+    return @{
+        ComponentType = 'Layout'
+        LayoutType = 'Accordion'
+        ID = (Get-PodeWebElementId -Tag Accordion -Id $Id -NameAsToken)
+        Items = $Items
+        CssClasses = ($CssClass -join ' ')
+    }
+}
+
+function New-PodeWebAccordionItem
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [hashtable[]]
+        $Content,
+
+        [Parameter()]
+        [string]
+        $Icon
+    )
+
+    if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
+        throw 'An AccordionItem can only contain layouts and/or elements'
+    }
+
+    return @{
+        ComponentType = 'Layout'
+        LayoutType = 'AccordionItem'
+        Name = $Name
+        ID = (Get-PodeWebElementId -Tag AccordionItem -Name $Name)
+        Content = $Content
+        Icon = $Icon
+    }
+}

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -354,7 +354,7 @@ function New-PodeWebCarousel
         $CssClass
     )
 
-    if (!(Test-PodeWebContent -Content $Content -ComponentType Layout -LayoutType Slide)) {
+    if (!(Test-PodeWebContent -Content $Slides -ComponentType Layout -LayoutType Slide)) {
         throw 'A Carousel can only contain Slide layouts'
     }
 
@@ -435,7 +435,7 @@ function New-PodeWebSteps
         $NoAuthentication
     )
 
-    if (!(Test-PodeWebContent -Content $Content -ComponentType Layout -LayoutType Step)) {
+    if (!(Test-PodeWebContent -Content $Steps -ComponentType Layout -LayoutType Step)) {
         throw 'Steps can only contain Step layouts'
     }
 
@@ -619,27 +619,42 @@ function New-PodeWebAccordion
 
         [Parameter(Mandatory=$true)]
         [hashtable[]]
-        $Items,
+        $Bellows,
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [int]
+        $CycleInterval = 15,
+
+        [switch]
+        $Cycle
     )
 
-    if (!(Test-PodeWebContent -Content $Content -ComponentType Layout -LayoutType AccordionItem)) {
-        throw 'Accordions can only contain AccordionItem layouts'
+    if (!(Test-PodeWebContent -Content $Bellows -ComponentType Layout -LayoutType Bellow)) {
+        throw 'Accordions can only contain Bellow layouts'
+    }
+
+    if ($CycleInterval -lt 10) {
+        $CycleInterval = 10
     }
 
     return @{
         ComponentType = 'Layout'
         LayoutType = 'Accordion'
         ID = (Get-PodeWebElementId -Tag Accordion -Id $Id -NameAsToken)
-        Items = $Items
+        Bellows = $Bellows
         CssClasses = ($CssClass -join ' ')
+        Cycle = @{
+            Enabled = $Cycle.IsPresent
+            Interval = ($CycleInterval * 1000)
+        }
     }
 }
 
-function New-PodeWebAccordionItem
+function New-PodeWebBellow
 {
     [CmdletBinding()]
     param(
@@ -657,14 +672,14 @@ function New-PodeWebAccordionItem
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
-        throw 'An AccordionItem can only contain layouts and/or elements'
+        throw 'A Bellow can only contain layouts and/or elements'
     }
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'AccordionItem'
+        LayoutType = 'Bellow'
         Name = $Name
-        ID = (Get-PodeWebElementId -Tag AccordionItem -Name $Name)
+        ID = (Get-PodeWebElementId -Tag Bellow -Name $Name)
         Content = $Content
         Icon = $Icon
     }

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -801,6 +801,27 @@ function Move-PodeWebTab
     }
 }
 
+function Move-PodeWebAccordion
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id
+    )
+
+    return @{
+        Operation = 'Move'
+        ElementType = 'Accordion'
+        ID = $Id
+        Name = $Name
+    }
+}
+
 function Reset-PodeWebPage
 {
     [CmdletBinding()]

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -55,6 +55,7 @@ $(() => {
     bindCardCollapse();
 
     bindTabCycling();
+    bindAccordionCycling();
     bindTimers();
 });
 
@@ -566,6 +567,15 @@ function bindTabCycling() {
     });
 }
 
+function bindAccordionCycling() {
+    $('div.accordion[pode-cycle="True"]').each((i, e) => {
+        setInterval(() => {
+            var itemId = $(e).find('div.card div.bellow-body.show').attr('pode-next');
+            moveAccordion(itemId);
+        }, $(e).attr('pode-interval'));
+    });
+}
+
 function bindTimers() {
     $('span.pode-timer').each((i, e) => {
         var id = $(e).attr('id');
@@ -932,6 +942,10 @@ function invokeActions(actions, sender) {
 
             case 'tab':
                 actionTab(action);
+                break;
+
+            case 'accordion':
+                actionAccordion(action);
                 break;
 
             case 'page':
@@ -2488,6 +2502,19 @@ function actionTab(action) {
 
 function moveTab(tabId) {
     $(`a.nav-link#${tabId}`).trigger('click');
+}
+
+function actionAccordion(action) {
+    if (!action) {
+        return;
+    }
+
+    var item = getElementByNameOrId(action, 'div.accordion div.card');
+    moveAccordion(getId(item));
+}
+
+function moveAccordion(itemId) {
+    $(`div.accordion div.card#${itemId} div.card-header button`).trigger('click');
 }
 
 function actionPage(action) {

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -26,6 +26,7 @@ $(() => {
     loadTiles();
 
     setupSteppers();
+    setupAccordion();
 
     bindSidebarFilter();
     bindMenuToggle();
@@ -46,6 +47,7 @@ $(() => {
     bindRangeValue();
     bindProgressValue();
     bindModalSubmits();
+
     bindTileRefresh();
     bindTileClick();
 
@@ -55,6 +57,18 @@ $(() => {
     bindTabCycling();
     bindTimers();
 });
+
+function setupAccordion() {
+    $('div.accordion div.card div.collapse').off('hide.bs.collapse').on('hide.bs.collapse', function(e) {
+        var icon = $(e.target).closest('div.card').find('span.arrow-toggle');
+        toggleCollapseArrow(icon, 'mdi-chevron-down', 'mdi-chevron-up');
+    });
+
+    $('div.accordion div.card div.collapse').off('show.bs.collapse').on('show.bs.collapse', function(e) {
+        var icon = $(e.target).closest('div.card').find('span.arrow-toggle');
+        toggleCollapseArrow(icon, 'mdi-chevron-up', 'mdi-chevron-down');
+    });
+}
 
 function loadBreadcrumb() {
     // get breadcrumb
@@ -652,18 +666,20 @@ function isNumeric(value) {
 }
 
 function bindPageGroupCollapse() {
-    $('ul#sidebar-list div.collapse').on('hide.bs.collapse', function(e) {
-        toggleCollapseArrow(e.target, 'mdi-arrow-expand', 'mdi-arrow-collapse');
+    $('ul#sidebar-list div.collapse').off('hide.bs.collapse').on('hide.bs.collapse', function(e) {
+        var id = $(e.target).attr('id');
+        var icon = $(`a[aria-controls="${id}"] span.mdi`);
+        toggleCollapseArrow(icon, 'mdi-chevron-down', 'mdi-chevron-up');
     });
 
-    $('ul#sidebar-list div.collapse').on('show.bs.collapse', function(e) {
-        toggleCollapseArrow(e.target, 'mdi-arrow-collapse', 'mdi-arrow-expand');
+    $('ul#sidebar-list div.collapse').off('show.bs.collapse').on('show.bs.collapse', function(e) {
+        var id = $(e.target).attr('id');
+        var icon = $(`a[aria-controls="${id}"] span.mdi`);
+        toggleCollapseArrow(icon, 'mdi-chevron-up', 'mdi-chevron-down');
     });
 }
 
-function toggleCollapseArrow(element, showIcon, hideIcon) {
-    var id = $(element).attr('id');
-    var icon = $(`a[aria-controls="${id}"] span.mdi`);
+function toggleCollapseArrow(icon, showIcon, hideIcon) {
     icon.toggleClass(showIcon);
     icon.toggleClass(hideIcon);
 }

--- a/src/Templates/Public/styles/default-dark.css
+++ b/src/Templates/Public/styles/default-dark.css
@@ -102,6 +102,22 @@ a.navbar-brand {
     background-color: #142440 !important;
 }
 
+.accordion .card .card-header button {
+    color: #ccc;
+}
+
+.accordion .card .card-header button.collapsed {
+    color: #214981;
+}
+
+.accordion .card .card-header:hover {
+    background-color: #142440 !important;
+    color: #ccc !important;
+}
+.accordion .card .card-header button:hover {
+    color: #ccc !important;
+}
+
 cite {
     color: #999 !important;
 }

--- a/src/Templates/Public/styles/default-light.css
+++ b/src/Templates/Public/styles/default-light.css
@@ -41,6 +41,22 @@ body, main[role="main"], body#login-page, body#normal-page {
     border-color: #bbb !important;
 }
 
+.accordion .card .card-header button {
+    color: #333;
+}
+
+.accordion .card .card-header button.collapsed {
+    color: #999;
+}
+
+.accordion .card .card-header:hover {
+    background-color: #eee !important;
+    color: #333 !important;
+}
+.accordion .card .card-header button:hover {
+    color: #333 !important;
+}
+
 pre code {
     background-color: #f0f0f0 !important;
     border-color: #bbb !important;

--- a/src/Templates/Public/styles/default-terminal.css
+++ b/src/Templates/Public/styles/default-terminal.css
@@ -119,6 +119,22 @@ a.navbar-brand {
     background-color: #111 !important;
 }
 
+.accordion .card .card-header button {
+    color: #ffb000;
+}
+
+.accordion .card .card-header button.collapsed {
+    color: #33ff00;
+}
+
+.accordion .card .card-header:hover {
+    background-color: #33ff00 !important;
+    color: #111 !important;
+}
+.accordion .card .card-header button:hover {
+    color: #111 !important;
+}
+
 cite {
     color: #33ff00 !important;
 }

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -419,8 +419,27 @@ table tbody td {
     word-break: break-word;
 }
 
-.card {
+.pode-card {
     margin-bottom: 2em;
+}
+
+.accordion .card-header button {
+    font-size: 1.1rem;
+    font-weight: bold;
+}
+
+.accordion .card-header button span.arrow-toggle {
+    float: right;
+}
+
+.accordion .card-header button:focus {
+    outline: none;
+    box-shadow: none;
+    text-decoration: none;
+}
+
+.accordion .card-header button:hover {
+    text-decoration: none;
 }
 
 .toast {
@@ -744,9 +763,14 @@ table tbody td {
     line-height: 14px;
 }
 
-.btn:not(.btn-icon-only, .btn-no-text) .mdi::before {
+.btn:not(.btn-icon-only, .btn-no-text, .btn-block) .mdi::before {
     position: relative;
     top: 4px;
+}
+
+.accordion .card-header .btn .mdi::before {
+    position: relative;
+    top: 2px;
 }
 
 a.nav-link .mdi:before {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -119,7 +119,7 @@
                                         "<li class='nav-item mTop1 nav-group-title'>
                                             <a class='nav-link' data-toggle='collapse' href='#nav-$($pageGroup.Name)' aria-expanded='$($data.Page.Group -ieq $pageGroup.Name)' aria-controls='nav-$($pageGroup.Name)'>
                                                 <div>
-                                                    <span class='mdi mdi-arrow-collapse mdi-size-22 mRight02'></span>
+                                                    <span class='mdi mdi-chevron-down mdi-size-22 mRight02'></span>
                                                     <span class='h6'>$($pageGroup.Name)</span>
                                                     <span class='badge badge-inbuilt-theme'>$($pageGroup.Count)</span>
                                                 </div>

--- a/src/Templates/Views/layouts/accordion.pode
+++ b/src/Templates/Views/layouts/accordion.pode
@@ -1,0 +1,39 @@
+<div id="$($data.ID)" class="accordion $($data.CssClasses)">
+
+    $(for ($i = 0; $i -lt $data.Items.Length; $i++) {
+        $item = $data.Items[$i]
+
+        $collapsed = [string]::Empty
+        $expanded = 'true'
+        $show = 'show'
+        $arrow = 'up'
+
+        if ($i -gt 0) {
+            $collapsed = 'collapsed'
+            $expanded = 'false'
+            $show = [string]::Empty
+            $arrow = 'down'
+        }
+
+        "<div class='card'>
+            <div class='card-header' id='$($data.ID)_head_$($i)'>
+                <h2 class='mb-0'>
+                    <button class='btn btn-link btn-block text-left $($collapsed)' type='button' data-toggle='collapse' data-target='#$($data.ID)_body_$($i)' aria-expanded='$($expanded)' aria-controls='$($data.ID)_body_$($i)'>"
+                        if (![string]::IsNullOrWhiteSpace($item.Icon)) {
+                            "<span class='mdi mdi-$($item.Icon.ToLowerInvariant())'></span>"
+                        }
+                        $item.Name
+                        "<span class='mdi mdi-chevron-$($arrow) arrow-toggle'></span>
+                    </button>
+                </h2>
+            </div>
+
+            <div id='$($data.ID)_body_$($i)' class='collapse $($show)' aria-labelledby='$($data.ID)_head_$($i)' data-parent='#$($data.ID)'>
+                <div class='card-body'>
+                    $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $item.Content })
+                </div>
+            </div>
+        </div>"
+    })
+
+</div>

--- a/src/Templates/Views/layouts/accordion.pode
+++ b/src/Templates/Views/layouts/accordion.pode
@@ -1,7 +1,7 @@
-<div id="$($data.ID)" class="accordion $($data.CssClasses)">
+<div id="$($data.ID)" class="accordion $($data.CssClasses)" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)">
 
-    $(for ($i = 0; $i -lt $data.Items.Length; $i++) {
-        $item = $data.Items[$i]
+    $(for ($i = 0; $i -lt $data.Bellows.Length; $i++) {
+        $bellow = $data.Bellows[$i]
 
         $collapsed = [string]::Empty
         $expanded = 'true'
@@ -15,22 +15,22 @@
             $arrow = 'down'
         }
 
-        "<div class='card'>
-            <div class='card-header' id='$($data.ID)_head_$($i)'>
+        "<div class='card bellow' id='$($bellow.ID)' name='$($bellow.Name)'>
+            <div class='card-header bellow-head' id='$($bellow.ID)_head'>
                 <h2 class='mb-0'>
-                    <button class='btn btn-link btn-block text-left $($collapsed)' type='button' data-toggle='collapse' data-target='#$($data.ID)_body_$($i)' aria-expanded='$($expanded)' aria-controls='$($data.ID)_body_$($i)'>"
-                        if (![string]::IsNullOrWhiteSpace($item.Icon)) {
-                            "<span class='mdi mdi-$($item.Icon.ToLowerInvariant())'></span>"
+                    <button class='btn btn-link btn-block text-left $($collapsed)' type='button' data-toggle='collapse' data-target='#$($bellow.ID)_body' aria-expanded='$($expanded)' aria-controls='$($bellow.ID)_body'>"
+                        if (![string]::IsNullOrWhiteSpace($bellow.Icon)) {
+                            "<span class='mdi mdi-$($bellow.Icon.ToLowerInvariant())'></span>"
                         }
-                        $item.Name
+                        $bellow.Name
                         "<span class='mdi mdi-chevron-$($arrow) arrow-toggle'></span>
                     </button>
                 </h2>
             </div>
 
-            <div id='$($data.ID)_body_$($i)' class='collapse $($show)' aria-labelledby='$($data.ID)_head_$($i)' data-parent='#$($data.ID)'>
+            <div id='$($bellow.ID)_body' class='bellow-body collapse $($show)' aria-labelledby='$($bellow.ID)_head' data-parent='#$($data.ID)' pode-prev='$($data.Bellows[$i - 1].ID)' pode-next='$($data.Bellows[($i + 1) % $data.Bellows.Length].ID)'>
                 <div class='card-body'>
-                    $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $item.Content })
+                    $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $bellow.Content })
                 </div>
             </div>
         </div>"

--- a/src/Templates/Views/layouts/card.pode
+++ b/src/Templates/Views/layouts/card.pode
@@ -1,4 +1,4 @@
-<div class="card $($data.CssClasses)">
+<div class="card pode-card $($data.CssClasses)">
     $(if ((!$data.NoTitle -and $data.Name) -or !$data.NoHide) {
         "<div class='card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom'>"
             if (!$data.NoTitle) {


### PR DESCRIPTION
### Description of the Change
Adds a new Accordion layout, which takes an arrow of "Bellows". The first bellow is displayed as expanded with the rest collapsed, and expanding another bellow will collapse all other bellows.

A bellow can contain or layouts/elements, and similar tabs they can be auto-cycled through.

### Examples
The following renders an accordion with 3 bellows each containing an image:

```powershell
New-PodeWebAccordion -Bellows @(
    New-PodeWebBellow -Name Bellow1 -Content @(
        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
    )
    New-PodeWebBellow -Name Bellow2 -Content @(
        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
    )
    New-PodeWebBellow -Name Bellow3 -Content @(
        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
    )
)
```

