### PR TITLE
Add new Sync-PodeWebChart output action

### DIFF
--- a/docs/Tutorials/Outputs/Charts.md
+++ b/docs/Tutorials/Outputs/Charts.md
@@ -57,3 +57,22 @@ New-PodeWebContainer -Content @(
     }
 )
 ```
+
+## Sync
+
+To force a chart to refresh its data you can use [`Sync-PodeWebChart`](../../../Functions/Outputs/Sync-PodeWebChart):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Refresh Processes' -ScriptBlock {
+        Sync-PodeWebChart -Name 'Processes'
+    }
+
+    New-PodeWebChart -Name 'Processes' -Type Line -NoRefresh -ScriptBlock {
+        Get-Process |
+            Sort-Object -Property CPU -Descending |
+            Select-Object -First 15 |
+            ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU
+    }
+)
+```

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -332,6 +332,27 @@ function ConvertTo-PodeWebChartData
     }
 }
 
+function Sync-PodeWebChart
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Sync'
+        ElementType = 'Chart'
+        ID = $Id
+        Name = $Name
+    }
+}
+
 function Out-PodeWebTextbox
 {
     [CmdletBinding()]

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2066,7 +2066,22 @@ function actionChart(action, sender) {
         case 'output':
             writeChart(action, sender);
             break;
+
+        case 'sync':
+            syncChart(action);
+            break;
     }
+}
+
+function syncChart(action) {
+    if (!action.ID && !action.Name) {
+        return;
+    }
+
+    var chart = getElementByNameOrId(action, 'canvas');
+    var id = getId(chart);
+
+    loadChart(id);
 }
 
 var _charts = {};


### PR DESCRIPTION
### Description of the Change
Adds a new `Sync-PodeWebChart` so you can refresh a chart as an output action.

### Related Issue
Resolves #101

### Examples
```powershell
New-PodeWebButton -Name 'Refresh Processes' -ScriptBlock {
    Sync-PodeWebChart -Name 'Processes'
}

New-PodeWebChart -Name 'Processes' -Type Line -NoRefresh -ScriptBlock {
    Get-Process |
        Sort-Object -Property CPU -Descending |
        Select-Object -First 15 |
        ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU
}
```
