### PR TITLE
Add min/max for x/y axes

### DIFF
--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -147,7 +147,7 @@ Start-PodeServer -StatusPageExceptions Show {
             New-PodeWebChart -Name 'Top Processes' -NoAuth -Type Bar -ScriptBlock $processData -AsCard
         )
         New-PodeWebCell -Content @(
-            New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time' -NoAuth -AsCard
+            New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time' -MaxY 100 -NoAuth -AsCard
         )
     )
 

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1343,6 +1343,22 @@ function New-PodeWebChart
         [string[]]
         $EndpointName,
 
+        [Parameter()]
+        [int]
+        $MinX = 0,
+
+        [Parameter()]
+        [int]
+        $MaxX = 0,
+
+        [Parameter()]
+        [int]
+        $MinY = 0,
+
+        [Parameter()]
+        [int]
+        $MaxY = 0,
+
         [switch]
         $Append,
 
@@ -1354,6 +1370,9 @@ function New-PodeWebChart
 
         [switch]
         $NoRefresh,
+
+        [switch]
+        $NoLegend,
 
         [switch]
         $AsCard
@@ -1407,7 +1426,16 @@ function New-PodeWebChart
         TimeLabels = $TimeLabels.IsPresent
         AutoRefresh = $AutoRefresh.IsPresent
         NoRefresh = $NoRefresh.IsPresent
+        NoLegend = $NoLegend.IsPresent
         CssClasses = ($CssClass -join ' ')
+        Min = @{
+            X = $MinX
+            Y = $MinY
+        }
+        Max = @{
+            X = $MaxX
+            Y = $MaxY
+        }
     }
 
     if ($AsCard) {
@@ -1438,9 +1466,28 @@ function New-PodeWebCounterChart
         $MaxItems = 30,
 
         [Parameter()]
+        [int]
+        $MinX = 0,
+
+        [Parameter()]
+        [int]
+        $MaxX = 0,
+
+        [Parameter()]
+        [int]
+        $MinY = 0,
+
+        [Parameter()]
+        [int]
+        $MaxY = 0,
+
+        [Parameter()]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication,
+
+        [switch]
+        $NoLegend,
 
         [switch]
         $AsCard
@@ -1463,8 +1510,13 @@ function New-PodeWebCounterChart
         -TimeLabels `
         -AutoRefresh `
         -CssClass $CssClass `
+        -MinX $MinX `
+        -MinY $MinY `
+        -MaxX $MaxX `
+        -MaxY $MaxY `
         -NoAuthentication:$NoAuthentication `
         -AsCard:$AsCard `
+        -NoLegend:$NoLegend `
         -ScriptBlock {
             param($counter)
             @{

--- a/src/Templates/Views/elements/chart.pode
+++ b/src/Templates/Views/elements/chart.pode
@@ -23,6 +23,11 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
         pode-append="$($data.Append)"
         pode-max="$($data.MaxItems)"
         pode-time-labels="$($data.TimeLabels)"
-        pode-auto-refresh="$($data.AutoRefresh)">
+        pode-auto-refresh="$($data.AutoRefresh)"
+        pode-min-x="$($data.Min.X)"
+        pode-min-y="$($data.Min.Y)"
+        pode-max-x="$($data.Max.X)"
+        pode-max-y="$($data.Max.Y)"
+        pode-legend="$(!$data.NoLegend)">
     </canvas>
 </div>


### PR DESCRIPTION
### Description of the Change
Adds support for specifying custom min/max values for the x/y axes on charts.

### Related Issue
Resolves #102

### Examples
```powershell
New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time' -MinY 0 -MaxY 100
```
