### PR TITLE
Add support for RefreshInterval for AutoRefresh

### DIFF
--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -141,7 +141,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
     $grid1 = New-PodeWebGrid -Cells @(
         New-PodeWebCell -Content @(
-            New-PodeWebChart -Name 'Line Example 1' -NoAuth -Type Line -ScriptBlock $chartData -Append -TimeLabels -MaxItems 30 -AutoRefresh -AsCard
+            New-PodeWebChart -Name 'Line Example 1' -NoAuth -Type Line -ScriptBlock $chartData -Append -TimeLabels -MaxItems 15 -AutoRefresh -AsCard -RefreshInterval 10
         )
         New-PodeWebCell -Content @(
             New-PodeWebChart -Name 'Top Processes' -NoAuth -Type Bar -ScriptBlock $processData -AsCard
@@ -176,11 +176,7 @@ Start-PodeServer -StatusPageExceptions Show {
         )
     )
 
-    $iframe = New-PodeWebContainer -Content @(
-        New-PodeWebIFrame -Url '/'
-    )
-
-    Set-PodeWebHomePage -NoAuth -Layouts $hero, $grid1, $section, $carousel, $section2, $section3, $codeEditor, $iframe -NoTitle
+    Set-PodeWebHomePage -NoAuth -Layouts $hero, $grid1, $section, $carousel, $section2, $section3, $codeEditor -NoTitle
 
 
     # tabs and charts

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -141,7 +141,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
     $grid1 = New-PodeWebGrid -Cells @(
         New-PodeWebCell -Content @(
-            New-PodeWebChart -Name 'Line Example 1' -NoAuth -Type Line -ScriptBlock $chartData -Append -TimeLabels -MaxItems 15 -AutoRefresh -AsCard -RefreshInterval 10
+            New-PodeWebChart -Name 'Line Example 1' -NoAuth -Type Line -ScriptBlock $chartData -Append -TimeLabels -MaxItems 15 -AutoRefresh -AsCard
         )
         New-PodeWebCell -Content @(
             New-PodeWebChart -Name 'Top Processes' -NoAuth -Type Bar -ScriptBlock $processData -AsCard

--- a/examples/tiles.ps1
+++ b/examples/tiles.ps1
@@ -20,7 +20,7 @@ Start-PodeServer -Threads 2 {
     $card = New-PodeWebCard -Content @(
         New-PodeWebGrid -Cells @(
             New-PodeWebCell -Content @(New-PodeWebTile -Name Example1 -ScriptBlock { return (Get-Random -Minimum 0 -Maximum 1000) } -Icon 'information')
-            New-PodeWebCell -Content @(New-PodeWebTile -Name Example2 -ScriptBlock { return ([datetime]::Now.ToString())} -Colour Red -AutoRefresh)
+            New-PodeWebCell -Content @(New-PodeWebTile -Name Example2 -ScriptBlock { return ([datetime]::Now.ToString())} -Colour Red -AutoRefresh -RefreshInterval 5)
             New-PodeWebCell -Content @(New-PodeWebTile -Name Example3 -Content @(
                 New-PodeWebChart -Name 'Top Processes' -Type Bar -ScriptBlock $processData
             ) -Colour Yellow)

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1359,6 +1359,10 @@ function New-PodeWebChart
         [int]
         $MaxY = 0,
 
+        [Parameter()]
+        [int]
+        $RefreshInterval = 60,
+
         [switch]
         $Append,
 
@@ -1382,6 +1386,10 @@ function New-PodeWebChart
 
     if ($MaxItems -lt 0) {
         $MaxItems = 0
+    }
+
+    if ($RefreshInterval -le 0) {
+        $RefreshInterval = 60
     }
 
     $routePath = "/elements/chart/$($Id)"
@@ -1425,6 +1433,7 @@ function New-PodeWebChart
         Height = $Height
         TimeLabels = $TimeLabels.IsPresent
         AutoRefresh = $AutoRefresh.IsPresent
+        RefreshInterval = ($RefreshInterval * 1000)
         NoRefresh = $NoRefresh.IsPresent
         NoLegend = $NoLegend.IsPresent
         CssClasses = ($CssClass -join ' ')
@@ -1578,6 +1587,10 @@ function New-PodeWebTable
         [scriptblock]
         $ClickScriptBlock,
 
+        [Parameter()]
+        [int]
+        $RefreshInterval = 60,
+
         [switch]
         $Filter,
 
@@ -1619,6 +1632,10 @@ function New-PodeWebTable
         $CsvFilePath = Join-PodeWebPath (Get-PodeServerPath) $CsvFilePath
     }
 
+    if ($RefreshInterval -le 0) {
+        $RefreshInterval = 60
+    }
+
     $element = @{
         ComponentType = 'Element'
         ElementType = 'Table'
@@ -1636,6 +1653,7 @@ function New-PodeWebTable
         IsDynamic = ($PSCmdlet.ParameterSetName -iin @('dynamic', 'csv'))
         NoExport = $NoExport.IsPresent
         AutoRefresh = $AutoRefresh.IsPresent
+        RefreshInterval = ($RefreshInterval * 1000)
         NoRefresh = $NoRefresh.IsPresent
         NoAuthentication = $NoAuthentication.IsPresent
         CssClasses = ($CssClass -join ' ')
@@ -2140,6 +2158,10 @@ function New-PodeWebTile
         [string]
         $Colour = 'Blue',
 
+        [Parameter()]
+        [int]
+        $RefreshInterval = 60,
+
         [switch]
         $NoRefresh,
 
@@ -2164,6 +2186,10 @@ function New-PodeWebTile
     $Id = Get-PodeWebElementId -Tag Tile -Id $Id -Name $Name
     $colourType = Convert-PodeWebColourToClass -Colour $Colour
 
+    if ($RefreshInterval -le 0) {
+        $RefreshInterval = 60
+    }
+
     $element = @{
         ComponentType = 'Element'
         ElementType = 'Tile'
@@ -2178,6 +2204,7 @@ function New-PodeWebTile
         ColourType = $ColourType
         CssClasses = ($CssClass -join ' ')
         AutoRefresh = $AutoRefresh.IsPresent
+        RefreshInterval = ($RefreshInterval * 1000)
         NoRefresh = $NoRefresh.IsPresent
         NewLine = $NewLine.IsPresent
     }

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -14,9 +14,6 @@ $.expr.pseudos.icontains = $.expr.createPseudo(function(arg) {
 
 var pageLoaded = false;
 $(() => {
-    console.log('please no');
-    console.log('please dont');
-
     if (pageLoaded) {
         return;
     }
@@ -790,8 +787,6 @@ function toggleIcon(element, icon1, icon2, title1, title2) {
         element = element.find('.mdi');
     }
 
-    console.log(element);
-
     // fix icon names
     if (icon1 && !icon1.startsWith('mdi-')) {
         icon1 = `mdi-${icon1}`;
@@ -1018,7 +1013,6 @@ function loadChart(chartId, firstLoad) {
         url = form.attr('method');
     }
 
-    console.log(data);
     sendAjaxReq(url, data, chart, true);
 }
 
@@ -1455,7 +1449,6 @@ function bindChartRefresh() {
         loadChart(button.attr('for'));
     });
 
-    console.log('oce?');
     $("canvas[pode-auto-refresh='True']").each((index, item) => {
         var interval = $(item).attr('pode-refresh-interval');
 
@@ -1465,10 +1458,8 @@ function bindChartRefresh() {
         }
 
         setTimeout(() => {
-            console.log('things');
             loadChart($(item).attr('id'), false);
             setInterval(() => {
-                console.log('stuff');
                 loadChart($(item).attr('id'), false);
             }, interval);
         }, timeout);

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -12,7 +12,16 @@ $.expr.pseudos.icontains = $.expr.createPseudo(function(arg) {
     hljs.highlightAll();
 })();
 
+var pageLoaded = false;
 $(() => {
+    console.log('please no');
+    console.log('please dont');
+
+    if (pageLoaded) {
+        return;
+    }
+    pageLoaded = true;
+
     if (checkAutoTheme()) {
         return;
     }
@@ -947,12 +956,19 @@ function bindTileRefresh() {
     });
 
     $("div.pode-tile[pode-auto-refresh='True']").each((i, e) => {
+        var interval = $(e).attr('pode-refresh-interval');
+
+        var timeout = interval;
+        if (interval == 60000) {
+            timeout = (60 - (new Date()).getSeconds()) * 1000;
+        }
+
         setTimeout(() => {
             loadTile($(e).attr('id'));
             setInterval(() => {
                 loadTile($(e).attr('id'));
-            }, 60000);
-        }, (60 - (new Date()).getSeconds()) * 1000);
+            }, interval);
+        }, timeout);
     });
 }
 
@@ -971,11 +987,11 @@ function bindTileClick() {
 
 function loadCharts() {
     $(`canvas[pode-dynamic='True']`).each((i, e) => {
-        loadChart($(e).attr('id'));
+        loadChart($(e).attr('id'), true);
     });
 }
 
-function loadChart(chartId) {
+function loadChart(chartId, firstLoad) {
     if (!chartId) {
         return;
     }
@@ -984,7 +1000,7 @@ function loadChart(chartId) {
 
     // is this the chart's first load?
     var data = '';
-    if (!_charts[chartId] || !_charts[chartId].append) {
+    if (firstLoad) { //} !_charts[chartId] || !_charts[chartId].append) {
         data = 'FirstLoad=1';
     }
 
@@ -1002,6 +1018,7 @@ function loadChart(chartId) {
         url = form.attr('method');
     }
 
+    console.log(data);
     sendAjaxReq(url, data, chart, true);
 }
 
@@ -1395,12 +1412,19 @@ function bindTableRefresh() {
     });
 
     $("table[pode-auto-refresh='True']").each((index, item) => {
+        var interval = $(item).attr('pode-refresh-interval');
+
+        var timeout = interval;
+        if (interval == 60000) {
+            timeout = (60 - (new Date()).getSeconds()) * 1000;
+        }
+
         setTimeout(() => {
             loadTable($(item).attr('id'));
             setInterval(() => {
                 loadTable($(item).attr('id'));
-            }, 60000);
-        }, (60 - (new Date()).getSeconds()) * 1000);
+            }, interval);
+        }, timeout);
     });
 }
 
@@ -1431,13 +1455,23 @@ function bindChartRefresh() {
         loadChart(button.attr('for'));
     });
 
+    console.log('oce?');
     $("canvas[pode-auto-refresh='True']").each((index, item) => {
+        var interval = $(item).attr('pode-refresh-interval');
+
+        var timeout = interval;
+        if (interval == 60000) {
+            timeout = (60 - (new Date()).getSeconds()) * 1000;
+        }
+
         setTimeout(() => {
-            loadChart($(item).attr('id'));
+            console.log('things');
+            loadChart($(item).attr('id'), false);
             setInterval(() => {
-                loadChart($(item).attr('id'));
-            }, 60000);
-        }, (60 - (new Date()).getSeconds()) * 1000);
+                console.log('stuff');
+                loadChart($(item).attr('id'), false);
+            }, interval);
+        }, timeout);
     });
 }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -982,11 +982,11 @@ function bindTileClick() {
 
 function loadCharts() {
     $(`canvas[pode-dynamic='True']`).each((i, e) => {
-        loadChart($(e).attr('id'), true);
+        loadChart($(e).attr('id'));
     });
 }
 
-function loadChart(chartId, firstLoad) {
+function loadChart(chartId) {
     if (!chartId) {
         return;
     }
@@ -995,7 +995,7 @@ function loadChart(chartId, firstLoad) {
 
     // is this the chart's first load?
     var data = '';
-    if (firstLoad) { //} !_charts[chartId] || !_charts[chartId].append) {
+    if (!_charts[chartId] || !_charts[chartId].append) {
         data = 'FirstLoad=1';
     }
 
@@ -1458,9 +1458,9 @@ function bindChartRefresh() {
         }
 
         setTimeout(() => {
-            loadChart($(item).attr('id'), false);
+            loadChart($(item).attr('id'));
             setInterval(() => {
-                loadChart($(item).attr('id'), false);
+                loadChart($(item).attr('id'));
             }, interval);
         }, timeout);
     });

--- a/src/Templates/Views/elements/chart.pode
+++ b/src/Templates/Views/elements/chart.pode
@@ -24,6 +24,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
         pode-max="$($data.MaxItems)"
         pode-time-labels="$($data.TimeLabels)"
         pode-auto-refresh="$($data.AutoRefresh)"
+        pode-refresh-interval="$($data.RefreshInterval)"
         pode-min-x="$($data.Min.X)"
         pode-min-y="$($data.Min.Y)"
         pode-max-x="$($data.Max.X)"

--- a/src/Templates/Views/elements/table.pode
+++ b/src/Templates/Views/elements/table.pode
@@ -25,6 +25,7 @@ $(if ($data.Filter) {
                 pode-click-dynamic='$($data.ClickIsDynamic)'
                 pode-data-column='$($data.DataColumn)'
                 pode-auto-refresh='$($data.AutoRefresh)'
+                pode-refresh-interval='$($data.RefreshInterval)'
                 pode-sort='$($data.Sort)'
                 pode-paginate='$($data.Paging.Enabled)'>
                 <thead></thead>

--- a/src/Templates/Views/elements/tile.pode
+++ b/src/Templates/Views/elements/tile.pode
@@ -2,7 +2,7 @@ $(if ($data.NewLine) {
     "<br/>"
 })
 
-<div id="$($data.ID)" class="container pode-tile alert-$($data.ColourType) rounded $($data.CssClasses)" name="$($data.Name)" pode-dynamic="$($data.IsDynamic)" pode-click="$($data.Click)" pode-auto-refresh='$($data.AutoRefresh)'>
+<div id="$($data.ID)" class="container pode-tile alert-$($data.ColourType) rounded $($data.CssClasses)" name="$($data.Name)" pode-dynamic="$($data.IsDynamic)" pode-click="$($data.Click)" pode-auto-refresh="$($data.AutoRefresh)" pode-refresh-interval="$($data.RefreshInterval)">
     <h6 class="pode-tile-header">
         $(if (![string]::IsNullOrWhiteSpace($data.Icon)) {
             "<span class='mdi mdi-$($data.Icon.ToLowerInvariant())'></span>"


### PR DESCRIPTION
### Description of the Change
Adds support for a `-RefreshInterval` parameter for elements that have the `-AutoRefresh` switch. The default interval is 60s.

Support added to Charts, Tables, and Tiles - which means you could now have a tile that updates every 10s.

### Related Issue
Resolves #105 

### Examples
```powershell
New-PodeWebTile -Name Example -ScriptBlock { return ([datetime]::Now.ToString())} -AutoRefresh -RefreshInterval 5
```
