### PR TITLE
Added Support for Size in New-PodeWebText

### DIFF
--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -848,6 +848,10 @@ function New-PodeWebText
         $Value,
 
         [Parameter()]
+        [string]
+        $Size,
+
+        [Parameter()]
         [ValidateSet('Normal', 'Underlined', 'StrikeThrough', 'Deleted', 'Inserted', 'Italics', 'Bold', 'Small')]
         [string]
         $Style = 'Normal',
@@ -878,6 +882,7 @@ function New-PodeWebText
         InParagraph = $InParagraph.IsPresent
         Alignment = $Alignment.ToLowerInvariant()
         CssClasses = ($CssClass -join ' ')
+        Size = $Size
     }
 }
 

--- a/src/Templates/Views/elements/text.pode
+++ b/src/Templates/Views/elements/text.pode
@@ -3,8 +3,12 @@ $(
     if (![string]::IsNullOrWhiteSpace($data.ID)) {
         $id = "id='$($data.ID)'"
     }
+    
+    if ($data.Size)  {
+        $size = "style='font-size: $($data.Size)'"
+    }
 
-    $value = "<span class='pode-text $($data.CssClasses)' $($id)>$($data.Value)</span>"
+    $value = "<span class='pode-text $($data.CssClasses)' $($id) $($size)>$($data.Value)</span>"
 
     switch ($data.Style.ToLowerInvariant()) {
         'underlined' {


### PR DESCRIPTION
I've added support for text size.

![image](https://user-images.githubusercontent.com/11185446/126911317-d8c9d399-07cd-4dd4-bee8-7eef7bae0bef.png)


the following code can be used to test this out

```
Import-Module Pode,Pode.Web 

Start-PodeServer {
    # add a simple endpoint
    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http

    # set the use of the pode.web templates
    Use-PodeWebTemplates -Title 'Example' -Theme Light

    # add the page
    Add-PodeWebPage -Name test -Icon Activity -Layouts @(
        New-PodeWebCard -Name test -Content @(
            New-PodeWebText -Value test2 
            New-PodeWebRaw -Value '<br>'
            New-PodeWebText -Value test2 -Style 'strikethrough' -Size 50px
            New-PodeWebText -Value test3 -Size 10px -InParagraph
            New-PodeWebText -Value test4 -Size 250% -InParagraph
            New-PodeWebText -Value test5 -Size xxx-large
            
        )
    )
}
```