### PR TITLE
Add a new -HideSidebar switch on Use-PodeWebTemplates

### DIFF
--- a/docs/Tutorials/Basics.md
+++ b/docs/Tutorials/Basics.md
@@ -79,10 +79,16 @@ The above would render a new page with a table, showing all the services on the 
 
 ### Sidebar
 
-Pages added to your site will appear in the sidebar on the left of your pages. The sidebar has a filter box at the top by default, but this can be hidden via `-NoPageFilter`:
+Pages added to your site will appear in the sidebar on the left of your pages. The sidebar has a filter box at the top by default, but this can be removed via `-NoPageFilter`:
 
 ```powershell
 Use-PodeWebTemplates -Title 'Example' -Theme Dark -NoPageFilter
+```
+
+You can also force the sidebar to be hidden by default via `-HideSidebar`:
+
+```powershell
+Use-PodeWebTemplates -Title 'Example' -Theme Dark -HideSidebar
 ```
 
 ## Custom Scripts/Styles

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -24,7 +24,10 @@ function Use-PodeWebTemplates
         $EndpointName,
 
         [switch]
-        $NoPageFilter
+        $NoPageFilter,
+
+        [switch]
+        $HideSidebar
     )
 
     $mod = (Get-Module -Name Pode -ErrorAction Ignore | Sort-Object -Property Version -Descending | Select-Object -First 1)
@@ -42,6 +45,7 @@ function Use-PodeWebTemplates
     Set-PodeWebState -Name 'logo' -Value $Logo
     Set-PodeWebState -Name 'favicon' -Value $FavIcon
     Set-PodeWebState -Name 'no-page-filter' -Value $NoPageFilter.IsPresent
+    Set-PodeWebState -Name 'hide-sidebar' -Value $HideSidebar.IsPresent
     Set-PodeWebState -Name 'social' -Value ([ordered]@{})
     Set-PodeWebState -Name 'pages' -Value @()
     Set-PodeWebState -Name 'default-nav' -Value $null

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -35,7 +35,8 @@ $(() => {
     setupAccordion();
 
     bindSidebarFilter();
-    bindMenuToggle();
+    bindSidebarToggle();
+    toggleSidebar();
     bindNavLinks();
     bindPageLinks();
     bindPageHelp();
@@ -685,7 +686,7 @@ function invokeTimer(timerId) {
     sendAjaxReq(`/elements/timer/${timerId}`, null, null, true);
 }
 
-function bindMenuToggle() {
+function bindSidebarToggle() {
     $('button#menu-toggle').off('click').on('click', function(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -695,6 +696,12 @@ function bindMenuToggle() {
 
         $('button#menu-toggle span').toggleClass('mdi-rotate-180');
     });
+}
+
+function toggleSidebar() {
+    if ($('nav#sidebarMenu').hasClass('hide-on-start')) {
+        $('button#menu-toggle').trigger('click');
+    }
 }
 
 function bindTablePagination() {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -76,7 +76,14 @@
 
         <div class="container-fluid">
             <div class="row">
-                <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
+                $(
+                    $hideSidebar = [string]::Empty
+                    if (Get-PodeWebState -Name 'hide-sidebar') {
+                        $hideSidebar = 'hide-on-start'
+                    }
+
+                    "<nav id='sidebarMenu' class='col-md-3 col-lg-2 d-md-block bg-light sidebar collapse $($hideSidebar)'>"
+                )
                     $(
                         $noPageFilter = Get-PodeWebState -Name 'no-page-filter'
 


### PR DESCRIPTION
### Description of the Change
Adds a new `-HideSidebar` switch to `Use-PodeWebTemplates`, which hides the sidebar by default on pages.

### Related Issue
Resolves #125 

### Examples
```powershell
Use-PodeWebTemplates -Title 'Example' -Theme Dark -HideSidebar 
```