### PR TITLE
Add -Mode parameter for Accordion, to toggle Normal, Collapsed, and Expanded

### DIFF
--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -647,6 +647,11 @@ function New-PodeWebAccordion
         [int]
         $CycleInterval = 15,
 
+        [Parameter()]
+        [ValidateSet('Normal', 'Collapsed', 'Expanded')]
+        [string]
+        $Mode = 'Normal',
+
         [switch]
         $Cycle
     )
@@ -665,6 +670,7 @@ function New-PodeWebAccordion
         ID = (Get-PodeWebElementId -Tag Accordion -Id $Id -NameAsToken)
         Bellows = $Bellows
         CssClasses = ($CssClass -join ' ')
+        Mode = $Mode
         Cycle = @{
             Enabled = $Cycle.IsPresent
             Interval = ($CycleInterval * 1000)

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -151,12 +151,12 @@ function bindFileStreams() {
 }
 
 function setupAccordion() {
-    $('div.accordion div.card div.collapse').off('hide.bs.collapse').on('hide.bs.collapse', function(e) {
+    $('div.accordion div.bellow div.collapse').off('hide.bs.collapse').on('hide.bs.collapse', function(e) {
         var icon = $(e.target).closest('div.card').find('span.arrow-toggle');
         toggleIcon(icon, 'chevron-down', 'chevron-up');
     });
 
-    $('div.accordion div.card div.collapse').off('show.bs.collapse').on('show.bs.collapse', function(e) {
+    $('div.accordion div.bellow div.collapse').off('show.bs.collapse').on('show.bs.collapse', function(e) {
         var icon = $(e.target).closest('div.card').find('span.arrow-toggle');
         toggleIcon(icon, 'chevron-up', 'chevron-down');
     });
@@ -2913,7 +2913,7 @@ function actionAccordion(action) {
 }
 
 function moveAccordion(itemId) {
-    $(`div.accordion div.card#${itemId} div.card-header button`).trigger('click');
+    $(`div.accordion div.bellow#${itemId} div.bellow-header button`).trigger('click');
 }
 
 function actionPage(action) {

--- a/src/Templates/Views/layouts/accordion.pode
+++ b/src/Templates/Views/layouts/accordion.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="accordion $($data.CssClasses)" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)">
+<div id="$($data.ID)" class="accordion $($data.CssClasses)" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)" pode-mode="$($data.Mode.ToLowerInvariant())">
 
     $(for ($i = 0; $i -lt $data.Bellows.Length; $i++) {
         $bellow = $data.Bellows[$i]
@@ -8,10 +8,10 @@
         $show = 'show'
         $arrow = 'up'
 
-        if ($i -gt 0) {
+        if ((($i -gt 0) -and ($data.Mode -ine 'expanded')) -or ($data.Mode -ieq 'collapsed')) {
             $collapsed = 'collapsed'
-            $expanded = 'false'
             $show = [string]::Empty
+            $expanded = 'false'
             $arrow = 'down'
         }
 


### PR DESCRIPTION
### Description of the Change
Adds a new `-Mode` parameter to `New-PodeWebAccordian`. The valid modes are Normal, Collapsed, and Expanded - default is Normal.

If Collapsed is selected, the Accordian starts of with all Bellow collapsed. Or all expanded for Expanded.

### Related Issue
Resolves #122

### Examples
```powershell
New-PodeWebAccordion -Mode Collapsed -Bellows @(...)
```