### PR TITLE
Add -ArgumentList to Add-PodeWebPage, and update docs

### DIFF
--- a/docs/Tutorials/Elements/Button.md
+++ b/docs/Tutorials/Elements/Button.md
@@ -22,6 +22,18 @@ Which looks like below:
 
 ![button_dynamic](../../../images/button_dynamic.png)
 
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebButton -Name 'Click Me' -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```
+
 ## URL
 
 To have a button that simply redirects to another URL, all you have to do is supply `-Url`:

--- a/docs/Tutorials/Elements/Charts.md
+++ b/docs/Tutorials/Elements/Charts.md
@@ -13,6 +13,18 @@ A chart gets its data from a supplied `-ScriptBlock`, more information below, an
 
 To supply data to be rendered on a chart, you have to supply a `-ScritpBlock` which returns the appropriate data in the correct format; fortunately there's [`ConvertTo-PodeWebChartData`](../../../Functions/Outputs/ConvertTo-PodeWebChartData) to help with this format.
 
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebChart -Name 'Example Chart' -Type Line -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```
+
 ### Raw
 
 Before showing the ConvertTo function, the data format needed is as follows: the returned value has be an array of hashtables, with each hashtable requires a `Key` property, and a `Values` property that's an array of further hashtables. The `Key` is the value used on the X-axis, and the `Values` is an array of data points used on the Y-axis. The `Values` hashtables also has to contain a `Key` and a `Value` property - the `Key` here is the dataset group name, and the `Value` is the value on the Y-axis.

--- a/docs/Tutorials/Elements/Form.md
+++ b/docs/Tutorials/Elements/Form.md
@@ -27,6 +27,18 @@ Which looks like below:
 
 ![form](../../../images/form.png)
 
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebForm -Name 'Example' -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+} -Content @()
+```
+
 ## Elements
 
 The available form elements in Pode.Web are:

--- a/docs/Tutorials/Elements/Table.md
+++ b/docs/Tutorials/Elements/Table.md
@@ -14,6 +14,18 @@ A table gets its data from a supplied `-ScriptBlock`, more information below, an
 
 To supply data to be rendered in a table, you have to supply a `-ScritpBlock` which returns the appropriate data in the correct format. You can also supply other elements to be rendered within the table, within the data that's returned.
 
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebTable -Name 'Example' -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```
+
 ### Raw
 
 The data format to be returned from a table's `-ScriptBlock` is simple, it's purely just Key:Value in an ordered hashtable/pscustomobject.
@@ -89,6 +101,8 @@ New-PodeWebContainer -Content @(
 You can set a table's rows to be clickable by passing `-Click`. This by default will set it so that when a row is clicked the page is reloaded, and the `-DataColumn` value for that row will be set in the query string as `?value=<value>` - available in `$WebEvent.Query.Value`.
 
 You can set a dynamic click action by supplying the `-ClickScriptBlock` parameter. Now when a row is clicked the scriptblock is called instead, and the `-DataColumn` value will now be available via `$WebEvent.Data.Value` within the scriptblock. The scriptblock expects the normal output actions to be returned.
+
+Any values specified to `-ArgumentList` will also be passed to the `-ClickScriptBlock` as well.
 
 ### Filter
 

--- a/docs/Tutorials/Elements/Tile.md
+++ b/docs/Tutorials/Elements/Tile.md
@@ -48,6 +48,18 @@ Which looks like below:
 ![tile_cpu_ok](../../../images/tile_cpu_ok.png)
 ![tile_cpu_warn](../../../images/tile_cpu_warn.png)
 
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebTile -Name 'Example' -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```
+
 ## Elements
 
 You can also display other elements within a tile, such as a chart. To display elements, add them via the `-Content` parameter.

--- a/docs/Tutorials/Elements/Timer.md
+++ b/docs/Tutorials/Elements/Timer.md
@@ -15,3 +15,15 @@ New-PodeWebCard -Content @(
     New-PodeWebBadge -Id 'bdg_example' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')) -Colour Cyan
 )
 ```
+
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebTimer -Name 'Example' -Interval 10 -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```

--- a/docs/Tutorials/Layouts/Modal.md
+++ b/docs/Tutorials/Layouts/Modal.md
@@ -94,3 +94,17 @@ New-PodeWebModal -Name 'Edit Service' -AsForm -Content @(
 Which would look like below:
 
 ![modal_form](../../../images/modal_form.png)
+
+### Arguments
+
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebModal -Name 'Stop Service' -Content @() -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```

--- a/docs/Tutorials/Layouts/Steps.md
+++ b/docs/Tutorials/Layouts/Steps.md
@@ -42,3 +42,17 @@ Which would look like below:
 ![steps_step_1](../../../images/steps_step_1.png)
 ![steps_step_2](../../../images/steps_step_2.png)
 ![steps_step_3](../../../images/steps_step_3.png)
+
+### Arguments
+
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+New-PodeWebSteps -Name 'AddUser' -Steps @() -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```

--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -175,6 +175,18 @@ Add-PodeWebPage -Name Services -Icon Settings -Layouts $servicesTable -ScriptBlo
 }
 ```
 
+You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
+
+```powershell
+Add-PodeWebPage -Name Services -Icon Settings -ArgumentList 'Value1', 2, $false -ScriptBlock {
+    param($value1, $value2, $value3)
+
+    # $value1 = 'Value1'
+    # $value2 = 2
+    # $value3 = $false
+}
+```
+
 ### No Authentication
 
 If you add a page when you've enabled authentication, you can set a page to be accessible without authentication by supplying the `-NoAuth` switch to [`Add-PodeWebPage`](../../Functions/Pages/Add-PodeWebPage).

--- a/examples/dynamic-pages.ps1
+++ b/examples/dynamic-pages.ps1
@@ -1,0 +1,27 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Dynamic Pages' -Theme Dark
+
+    # set the home page controls (just a simple paragraph)
+    $section = New-PodeWebCard -Name 'Welcome' -NoTitle -Content @(
+        New-PodeWebParagraph -Value 'This is an example homepage, with some example text'
+        New-PodeWebParagraph -Value 'Using some example paragraphs'
+    )
+    Set-PodeWebHomePage -Layouts $section -Title 'Awesome Homepage'
+
+    Add-PodeWebPage -Name Example -ArgumentList 'Title', 'BodyText' -ScriptBlock {
+        param($title, $text)
+
+        New-PodeWebContainer -Content @(
+            New-PodeWebHeader -Size 2 -Value $title
+            New-PodeWebText -Value $text
+        )
+    }
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1871,7 +1871,7 @@ function New-PodeWebTable
             param($Data)
             $global:ElementData = $using:element
 
-            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ClickScriptBlock -Return
+            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ClickScriptBlock -Arguments $Data.Data -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }


### PR DESCRIPTION
### Description of the Change
Add `-ArgumentList` parameter to `Add-PodeWebPage`, and update docs for all elements/layouts to reference ArgumentList.

### Related Issue
Resolves #137 

### Examples
```powershell
Add-PodeWebPage -Name Example -ArgumentList 'value1', 2, $false -ScriptBlock {
    param($value1, $value2, $value3)

    # $value1 = 'Value1'
    # $value2 = 2
    # $value3 = $false
}
```
