### PR TITLE
Adds new clear output actions for Charts, Tables, and Textboxes

### DIFF
--- a/docs/Tutorials/Outputs/Charts.md
+++ b/docs/Tutorials/Outputs/Charts.md
@@ -76,3 +76,22 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+## Clear
+
+To clear a chart's data you can use [`Clear-PodeWebChart`](../../../Functions/Outputs/Clear-PodeWebChart):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Clear Processes' -ScriptBlock {
+        Clear-PodeWebChart -Name 'Processes'
+    }
+
+    New-PodeWebChart -Name 'Processes' -Type Line -NoRefresh -ScriptBlock {
+        Get-Process |
+            Sort-Object -Property CPU -Descending |
+            Select-Object -First 15 |
+            ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU
+    }
+)
+```

--- a/docs/Tutorials/Outputs/Table.md
+++ b/docs/Tutorials/Outputs/Table.md
@@ -84,3 +84,21 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+## Clear
+
+To clear a table's data you can use [`Clear-PodeWebTable`](../../../Functions/Outputs/Clear-PodeWebTable):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Clear Processes' -ScriptBlock {
+        Clear-PodeWebTable -Name 'Processes'
+    }
+
+    New-PodeWebTable -Name 'Processes' -NoRefresh -ScriptBlock {
+        Get-Process |
+            Sort-Object -Property CPU -Descending |
+            Select-Object -First 15 -Property Name, ID, WorkingSet, CPU
+    }
+)
+```

--- a/docs/Tutorials/Outputs/Textbox.md
+++ b/docs/Tutorials/Outputs/Textbox.md
@@ -27,3 +27,17 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+## Clear
+
+You can clear the content of a textbox by using [`Clear-PodeWebTextbox`](../../../Functions/Outputs/Clear-PodeWebTextbox):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebTextbox -Name 'Content'
+
+    New-PodeWebButton -Name 'Clear Textbox' -ScriptBlock {
+        Clear-PodeWebTextbox -Name 'Content'
+    }
+)
+```

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -190,6 +190,27 @@ function Sync-PodeWebTable
     }
 }
 
+function Clear-PodeWebTable
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Clear'
+        ElementType = 'Table'
+        ID = $Id
+        Name = $Name
+    }
+}
+
 function Update-PodeWebTableRow
 {
     [CmdletBinding(DefaultParameterSetName='Name_and_DataValue')]
@@ -384,6 +405,27 @@ function Sync-PodeWebChart
     }
 }
 
+function Clear-PodeWebChart
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Clear'
+        ElementType = 'Chart'
+        ID = $Id
+        Name = $Name
+    }
+}
+
 function Out-PodeWebTextbox
 {
     [CmdletBinding()]
@@ -490,6 +532,32 @@ function Update-PodeWebTextbox
             AsJson = $AsJson.IsPresent
             Multiline = $Multiline.IsPresent
         }
+    }
+}
+
+function Clear-PodeWebTextbox
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [switch]
+        $Multiline
+    )
+
+    return @{
+        Operation = 'Clear'
+        ElementType = 'Textbox'
+        ID = $Id
+        Name = $Name
+        Multiline = $Multiline.IsPresent
     }
 }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1762,6 +1762,28 @@ function actionTable(action, sender) {
         case 'sync':
             syncTable(action);
             break;
+
+        case 'clear':
+            clearTable(action);
+            break;
+    }
+}
+
+function clearTable(action) {
+    if (!action.ID && !action.Name) {
+        return;
+    }
+
+    // get table
+    var table = getElementByNameOrId(action, 'table');
+    var tableId = `table#${getId(table)}`;
+
+    // empty table
+    $(`${tableId} tbody`).empty();
+
+    // empty paging
+    if (isTablePaginated(table)) {
+        table.closest('div[role="table"]').find('nav ul').empty();
     }
 }
 
@@ -2273,7 +2295,19 @@ function actionTextbox(action, sender) {
         case 'output':
             writeTextbox(action, sender);
             break;
+
+        case 'clear':
+            clearTextbox(action);
+            break;
     }
+}
+
+function clearTextbox(action) {
+    var txt = action.Multiline
+        ? getElementByNameOrId(action, 'textarea')
+        : getElementByNameOrId(action, 'input');
+
+    txt.val('');
 }
 
 function updateTextbox(action) {
@@ -2391,7 +2425,33 @@ function actionChart(action, sender) {
         case 'sync':
             syncChart(action);
             break;
+
+        case 'clear':
+            clearChart(action);
+            break;
     }
+}
+
+function clearChart(action) {
+    if (!action.ID && !action.Name) {
+        return;
+    }
+
+    var chart = getElementByNameOrId(action, 'canvas');
+    var id = getId(chart);
+
+    var _chart = _charts[id];
+
+    // clear labels (x-axis)
+    _chart.canvas.data.labels = [];
+
+    // clear data (y-axis)
+    _chart.canvas.data.datasets.forEach((dataset) => {
+        dataset.data = [];
+    });
+
+    // re-render
+    _chart.canvas.update();
 }
 
 function syncChart(action) {


### PR DESCRIPTION
### Description of the Change
Adds new clear output actions for Charts, Tables, and Textboxes:

* `Clear-PodeWebChart`
* `Clear-PodeWebTable`
* `Clear-PodeWebTextbox`

### Related Issue
Resolves #140 

### Examples
```powershell
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebButton -Name 'Clear Processes' -ScriptBlock {
        Clear-PodeWebChart -Name 'Processes'
    }

    New-PodeWebChart -Name 'Processes' -Type Line -NoRefresh -ScriptBlock {
        Get-Process |
            Sort-Object -Property CPU -Descending |
            Select-Object -First 15 |
            ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU
    }
)
```
