### PR TITLE
Adds output actions to control frontend theme for a user

### DIFF
--- a/docs/Tutorials/Outputs/Theme.md
+++ b/docs/Tutorials/Outputs/Theme.md
@@ -1,0 +1,32 @@
+# Theme
+
+This page details the available output actions available to the Theme of pages.
+
+## Update
+
+To update the theme for a user you can use [`Update-PodeWebTheme`](../../../Functions/Outputs/Update-PodeWebTheme). This will update the frontend cookie, and then reload the page to toggle the rendering theme:
+
+```powershell
+Use-PodeWebTemplates -Title Test -Theme Dark
+
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Dark Theme' -Icon 'moon-new' -Colour Dark -ScriptBlock {
+        Update-PodeWebTheme -Name Dark
+    }
+    New-PodeWebButton -Name 'Light Theme' -Icon 'weather-sunny' -Colour Light -ScriptBlock {
+        Update-PodeWebTheme -Name Light
+    }
+)
+```
+
+## Reset
+
+To reset a user's theme back to the default, you can use [`Reset-PodeWebTheme`](../../../Functions/Outputs/Reset-PodeWebTheme):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Reset Theme' -Icon 'refresh' -ScriptBlock {
+        Reset-PodeWebTheme
+    }
+)
+```

--- a/docs/Tutorials/Themes.md
+++ b/docs/Tutorials/Themes.md
@@ -61,3 +61,5 @@ The theme that gets used is defined in the following order:
 1. Cookie
 2. User Authentication
 3. Server Default
+
+You can also use the [`Update-PodeWebTheme`](../../Functions/Outputs/Update-PodeWebTheme) and [`Reset-PodeWebTheme`](../../Functions/Outputs/Reset-PodeWebTheme) output actions.

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -81,6 +81,11 @@ Start-PodeServer -StatusPageExceptions Show {
             Show-PodeWebToast -Message "Message of the day: $($WebEvent.Data.Value)"
             Show-PodeWebNotification -Title 'Hello, there' -Body 'General Kenobi' -Icon '/pode.web/images/icon.png'
         }
+        New-PodeWebContainer -Content @(
+            New-PodeWebButton -Name 'Dark Theme' -NoAuth -Icon 'moon-new' -Colour Dark -ScriptBlock { Update-PodeWebTheme -Name Dark }
+            New-PodeWebButton -Name 'Light Theme' -NoAuth -Icon 'weather-sunny' -Colour Light -ScriptBlock { Update-PodeWebTheme -Name Light }
+            New-PodeWebButton -Name 'Reset Theme' -NoAuth -Icon 'refresh' -ScriptBlock { Reset-PodeWebTheme }
+        )
         New-PodeWebAlert -Type Note -Value 'Hello, world'
     )
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -166,17 +166,20 @@ function Test-PodeWebThemeCustom
         $Name
     )
 
-    $inbuildThemes = Get-PodeWebInbuiltThemes
-    if ($Name -iin $inbuildThemes) {
-        return $false
-    }
-
     $customThemes = Get-PodeWebState -Name 'custom-themes'
-    if ($customThemes.Themes.Keys -icontains $Name) {
-        return $true
-    }
+    return ($customThemes.Themes.Keys -icontains $Name)
+}
 
-    return $false
+function Test-PodeWebThemeInbuilt
+{
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
+
+    $inbuildThemes = Get-PodeWebInbuiltThemes
+    return ($Name -iin $inbuildThemes)
 }
 
 function Test-PodeWebArrayEmpty

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1082,6 +1082,10 @@ function Update-PodeWebTheme
         $Name
     )
 
+    if (!(Test-PodeWebTheme -Name $Name)) {
+        throw "Theme does not exist: $($Name)"
+    }
+
     return @{
         Operation = 'Update'
         ElementType = 'Theme'

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1072,3 +1072,30 @@ function Sync-PodeWebTile
         Name = $Name
     }
 }
+
+function Update-PodeWebTheme
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Update'
+        ElementType = 'Theme'
+        Name = $Name.ToLowerInvariant()
+    }
+}
+
+function Reset-PodeWebTheme
+{
+    [CmdletBinding()]
+    param()
+
+    return @{
+        Operation = 'Reset'
+        ElementType = 'Theme'
+    }
+}

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -173,6 +173,18 @@ function Get-PodeWebTheme
     return $theme.ToLowerInvariant()
 }
 
+function Test-PodeWebTheme
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
+
+    return ((Test-PodeWebThemeInbuilt -Name $Name) -or (Test-PodeWebThemeCustom -Name $Name))
+}
+
 function Get-PodeWebUsername
 {
     [CmdletBinding()]

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -223,10 +223,8 @@ function checkAutoTheme() {
     var isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     theme = (isSystemDark ? 'dark' : 'light');
 
-    // set the cookie, expire after 1 month
-    var d = new Date();
-    d.setTime(d.getTime() + (30 * 24 * 60 * 60 * 1000));
-    document.cookie = `pode.web.theme=${theme}; expires=${d.toUTCString()}; path=/`
+    // set the cookie
+    setPodeThemeCookie(theme);
 
     // force a refresh
     refreshPage();
@@ -258,15 +256,22 @@ function setPodeTheme(theme, refresh) {
     // update body
     $('body').attr('pode-theme', theme);
 
-    // set the cookie, expire after 1 month
-    var d = new Date();
-    d.setTime(d.getTime() + (30 * 24 * 60 * 60 * 1000));
-    document.cookie = `pode.web.theme=${theme}; expires=${d.toUTCString()}; path=/`
+    // set the cookie
+    setPodeThemeCookie(theme);
 
     // refresh?
     if (refresh) {
         refreshPage();
     }
+}
+
+function setPodeThemeCookie(theme) {
+    // cookie expires after 1 month
+    var d = new Date();
+    d.setTime(d.getTime() + (30 * 24 * 60 * 60 * 1000));
+
+    // save theme cookie
+    document.cookie = `pode.web.theme=${theme}; expires=${d.toUTCString()}; path=/`
 }
 
 function serializeInputs(element) {

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -214,25 +214,19 @@ function loadBreadcrumb() {
 }
 
 function checkAutoTheme() {
-    // is the them auto-switchable?
-    var targetTheme = $('body').attr('pode-theme-target');
+    var theme = getPodeTheme();
 
-    // check if the system is dark/light
-    if (targetTheme == 'auto') {
-        var isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        targetTheme = (isSystemDark ? 'dark' : 'light');
+    if (theme != 'auto') {
+        return;
     }
 
-    // get the body theme, do we need to switch?
-    var bodyTheme = getPodeTheme();
-    if (bodyTheme == targetTheme) {
-        return false;
-    }
+    var isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    theme = (isSystemDark ? 'dark' : 'light');
 
     // set the cookie, expire after 1 month
     var d = new Date();
     d.setTime(d.getTime() + (30 * 24 * 60 * 60 * 1000));
-    document.cookie = `pode.web.theme=${targetTheme}; expires=${d.toUTCString()}; path=/`
+    document.cookie = `pode.web.theme=${theme}; expires=${d.toUTCString()}; path=/`
 
     // force a refresh
     refreshPage();
@@ -258,6 +252,21 @@ function mapElementThemes() {
 
 function getPodeTheme() {
     return $('body').attr('pode-theme');
+}
+
+function setPodeTheme(theme, refresh) {
+    // update body
+    $('body').attr('pode-theme', theme);
+
+    // set the cookie, expire after 1 month
+    var d = new Date();
+    d.setTime(d.getTime() + (30 * 24 * 60 * 60 * 1000));
+    document.cookie = `pode.web.theme=${theme}; expires=${d.toUTCString()}; path=/`
+
+    // refresh?
+    if (refresh) {
+        refreshPage();
+    }
 }
 
 function serializeInputs(element) {
@@ -1255,6 +1264,10 @@ function invokeActions(actions, sender) {
                 actionTile(action, sender);
                 break;
 
+            case 'theme':
+                actionTheme(action);
+                break;
+
             default:
                 break;
         }
@@ -2207,6 +2220,34 @@ function syncTile(action) {
     var id = getId(tile);
 
     loadTile(id);
+}
+
+function actionTheme(action) {
+    if (!action) {
+        return;
+    }
+
+    switch (action.Operation.toLowerCase()) {
+        case 'update':
+            updateTheme(action);
+            break;
+
+        case 'reset':
+            resetTheme();
+            break;
+    }
+}
+
+function updateTheme(action) {
+    if (!action.Name) {
+        return;
+    }
+
+    setPodeTheme(action.Name, true);
+}
+
+function resetTheme() {
+    setPodeTheme('', true);
 }
 
 function actionSelect(action) {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -4,7 +4,7 @@
         Theme = $data.Theme
     })
 
-    <body id="normal-page" pode-theme="$($data.Theme)" pode-theme-target="$(Get-PodeWebTheme -IgnoreCookie)">
+    <body id="normal-page" pode-theme="$($data.Theme)">
         <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow navbar-expand-lg">
             <button type='button' class='btn btn-icon-only' id='menu-toggle'>
                 <span class='mdi mdi-menu-open'></span>

--- a/src/Templates/Views/login.pode
+++ b/src/Templates/Views/login.pode
@@ -4,7 +4,7 @@
         Theme = $data.Theme
     })
 
-    <body id="login-page" pode-theme="$($data.Theme)" pode-theme-target="$(Get-PodeWebTheme -IgnoreCookie)" style="background-image: url('$($data.Background.Image)'); background-repeat: no-repeat; background-size: cover">
+    <body id="login-page" pode-theme="$($data.Theme)" style="background-image: url('$($data.Background.Image)'); background-repeat: no-repeat; background-size: cover">
         <form class="form-signin" action='/login' method='POST'>
             <div class='text-center mb-4'>
                 <a href='$($data.LogoUrl)'>


### PR DESCRIPTION
### Description of the Change
Adds new output actions for controlling the theme for a user: `Update-PodeWebTheme` and `Reset-PodeWebTheme`. The former take a `-Name` of a theme, and updates the users frontend to that theme. The latter resets a users frontend theme back to the default server's theme.

### Related Issue
Resolves #115

### Examples
```powershell
Use-PodeWebTemplates -Title Test -Theme Dark
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebButton -Name 'Dark Theme' -Icon 'moon-new' -Colour Dark -ScriptBlock {
        Update-PodeWebTheme -Name Dark
    }
    New-PodeWebButton -Name 'Light Theme' -Icon 'weather-sunny' -Colour Light -ScriptBlock {
        Update-PodeWebTheme -Name Light
    }
)
```
