### PR TITLE
Add support for dynamic select elements

### DIFF
--- a/docs/Tutorials/Elements/Select.md
+++ b/docs/Tutorials/Elements/Select.md
@@ -1,6 +1,10 @@
 # Select
 
-The Select element is a form input element, and can be added using [`New-PodeWebSelect`](../../../Functions/Elements/New-PodeWebSelect). This will add a dropdown select menu to your form, allowing the user to select an entry; to allow multiple entries to be selected you can pass `-Multiple`, and to specify a pre-selected value you can use `-SelectedValue`:
+The Select element is a form input element, and can be added using [`New-PodeWebSelect`](../../../Functions/Elements/New-PodeWebSelect). This will add a dropdown select menu to your form, allowing the user to select an entry; to allow multiple entries to be selected you can pass `-Multiple`, and to specify a pre-selected value you can use `-SelectedValue`.
+
+## Options
+
+To create a Select element with pre-defined options, you can use the `-Options` parameter:
 
 ```powershell
 New-PodeWebCard -Content @(
@@ -20,5 +24,33 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![select](../../../images/select.png)
+
+### Dynamic
+
+You can build a Select element's options dynamic by instead using the `-ScriptBlock` parameter. This will allow you to retrieve the options from elsewhere and use them as options instead.
+
+You can either return an array of raw values, or pipe the options into, and return, [`Update-PodeWebSelect`](../../../Functions/Outputs/Update-PodeWebSelect). The following will both build a Select element with 10 random numbers as the options:
+
+```powershell
+New-PodeWebCard -Content @(
+    New-PodeWebForm -Name 'Example' -ScriptBlock {
+        New-PodeWebSelect -Name 'Random1' -ScriptBlock {
+            return @(foreach ($i in (1..10)) {
+                Get-Random -Minimum 1 -Maximum 10
+            })
+        }
+
+        New-PodeWebSelect -Name 'Random2' -ScriptBlock {
+            $options = @(foreach ($i in (1..10)) {
+                Get-Random -Minimum 1 -Maximum 10
+            })
+
+            $options | Update-PodeWebSelect -Id $ElementData.Id
+        }
+    }
+)
+```
+
+## Choose Option
 
 You can hide the "Choose an Option" option by passing `-NoChooseOption`, or you can change it value via `-ChooseOptionValue`.

--- a/docs/Tutorials/Elements/Select.md
+++ b/docs/Tutorials/Elements/Select.md
@@ -27,7 +27,7 @@ Which looks like below:
 
 ### Dynamic
 
-You can build a Select element's options dynamic by instead using the `-ScriptBlock` parameter. This will allow you to retrieve the options from elsewhere and use them as options instead.
+You can build a Select element's options dynamically by using the `-ScriptBlock` parameter. This will allow you to retrieve the options from elsewhere and use them as options instead.
 
 You can either return an array of raw values, or pipe the options into, and return, [`Update-PodeWebSelect`](../../../Functions/Outputs/Update-PodeWebSelect). The following will both build a Select element with 10 random numbers as the options:
 

--- a/docs/Tutorials/Outputs/Select.md
+++ b/docs/Tutorials/Outputs/Select.md
@@ -2,9 +2,23 @@
 
 This page details the available output actions available to Select elements.
 
+## Clear
+
+To clear the options of a Select element, you can use [`Clear-PodeWebSelect`](../../../Functions/Outputs/Clear-PodeWebSelect):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebSelect -Name Options -Options Option1, Option2, Option3
+
+    New-PodeWebButton -Name 'Clear Select' -ScriptBlock {
+        Clear-PodeWebSelect -Name Options
+    }
+)
+```
+
 ## Set
 
-To set the current selected option/value of a select element, you can use [`Set-PodeWebSelect`](../../../Functions/Outputs/Set-PodeWebSelect):
+To set the currently selected option/value of a select element, you can use [`Set-PodeWebSelect`](../../../Functions/Outputs/Set-PodeWebSelect):
 
 ```powershell
 New-PodeWebContainer -NoBackground -Content @(
@@ -14,6 +28,46 @@ New-PodeWebContainer -NoBackground -Content @(
         $rand = Get-Random -Minimum 0 -Maximum 3
         $opt = (@('Option1', 'Option2', 'Option3'))[$rand]
         Set-PodeWebSelect -Name Options -Value $opt
+    }
+)
+```
+
+## Sync
+
+If you built a Select element with the `-ScriptBlock` parameter, then you can re-invoke the scriptblock to update the element by using [`Sync-PodeWebSelect`](../../../Functions/Outputs/Sync-PodeWebSelect):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebSelect -Name Options --ScriptBlock {
+        return @(foreach ($i in (1..10)) {
+            Get-Random -Minimum 1 -Maximum 10
+        })
+    }
+
+    New-PodeWebButton -Name 'Sync Select' -ScriptBlock {
+        Sync-PodeWebSelect -Name Options
+    }
+)
+```
+
+## Update
+
+You can update a Select element's options by using [`Update-PodeWebSelect`](../../../Functions/Outputs/Update-PodeWebSelect):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebSelect -Name Options --ScriptBlock {
+        return @(foreach ($i in (1..10)) {
+            Get-Random -Minimum 1 -Maximum 10
+        })
+    }
+
+    New-PodeWebButton -Name 'New Options' -ScriptBlock {
+        $options = @(foreach ($i in (1..10)) {
+            Get-Random -Minimum 1 -Maximum 10
+        })
+
+        $options | Update-PodeWebSelect -Name Options
     }
 )
 ```

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -25,7 +25,36 @@ Start-PodeServer {
         New-PodeWebRadio -Name 'Radios' -Options @('S', 'M', 'L')
         New-PodeWebSelect -Name 'Role' -Options @('User', 'Admin', 'Operations') -Multiple
         New-PodeWebRange -Name 'Cores' -Value 30 -ShowValue
+        New-PodeWebSelect -Name 'Amount' -ScriptBlock {
+            return @(foreach ($i in (1..10)) {
+                Get-Random -Minimum 1 -Maximum 10
+            })
+        }
     )
 
-    Set-PodeWebHomePage -Layouts $form -Title 'Testing Inputs'
+    $container = New-PodeWebContainer -Content @(
+        New-PodeWebButton -Name 'New Options' -ScriptBlock {
+            $options = @(foreach ($i in (1..10)) {
+                Get-Random -Minimum 1 -Maximum 10
+            })
+
+            $options | Update-PodeWebSelect -Name 'DynamicSelect'
+        }
+
+        New-PodeWebButton -Name 'Clear Options' -ScriptBlock {
+            Clear-PodeWebSelect -Name 'DynamicSelect'
+        }
+
+        New-PodeWebButton -Name 'Resync Options' -ScriptBlock {
+            Sync-PodeWebSelect -Name 'DynamicSelect'
+        }
+
+        New-PodeWebSelect -Name 'DynamicSelect' -Multiple -ScriptBlock {
+            return @(foreach ($i in (1..10)) {
+                Get-Random -Minimum 1 -Maximum 10
+            })
+        }
+    )
+
+    Set-PodeWebHomePage -Layouts $form, $container -Title 'Testing Inputs'
 }

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -691,6 +691,84 @@ function Set-PodeWebSelect
     }
 }
 
+function Update-PodeWebSelect
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [string[]]
+        $Options
+    )
+
+    begin {
+        $items = @()
+    }
+
+    process {
+        $items += $Options
+    }
+
+    end {
+        return @{
+            Operation = 'Update'
+            ElementType = 'Select'
+            Name = $Name
+            ID = $Id
+            Options = $items
+        }
+    }
+}
+
+function Clear-PodeWebSelect
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id
+    )
+
+    return @{
+        Operation = 'Clear'
+        ElementType = 'Select'
+        Name = $Name
+        ID = $Id
+    }
+}
+
+function Sync-PodeWebSelect
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id
+    )
+
+    return @{
+        Operation = 'Sync'
+        ElementType = 'Select'
+        Name = $Name
+        ID = $Id
+    }
+}
+
 function Update-PodeWebBadge
 {
     [CmdletBinding()]

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -7,7 +7,7 @@
                 $multiple = 'multiple'
             }
 
-            "<select class='custom-select' id='$($data.ID)' name='$($data.Name)' $($multiple)>"
+            "<select class='custom-select' id='$($data.ID)' name='$($data.Name)' pode-dynamic='$($data.IsDynamic)' $($multiple)>"
 
             if (!$data.Multiple -and !$data.NoChooseOption) {
                 $chooseValue = $data.ChooseOptionValue
@@ -24,6 +24,10 @@
             }
 
             foreach ($option in $data.Options) {
+                if ([string]::IsNullOrWhiteSpace($option)) {
+                    continue
+                }
+
                 if ([string]::IsNullOrWhiteSpace($data.SelectedValue)) {
                     "<option value='$($option)'>$($option)</option>"
                 }


### PR DESCRIPTION
### Description of the Change
Add support for `-ScriptBlock` on `New-PodeWebSelect` so options can be built more dynamically. Also adds `Update/Clear/Sync-PodeWebSelect`, so you can update/clear/sync a select element's options.

### Related Issue
Resolves #147 

### Examples
```powershell
New-PodeWebContainer -Content @(
    New-PodeWebButton -Name 'New Options' -ScriptBlock {
        $options = @(foreach ($i in (1..10)) {
            Get-Random -Minimum 1 -Maximum 10
        })

        $options | Update-PodeWebSelect -Name 'DynamicSelect'
    }

    New-PodeWebButton -Name 'Clear Options' -ScriptBlock {
        Clear-PodeWebSelect -Name 'DynamicSelect'
    }

    New-PodeWebButton -Name 'Resync Options' -ScriptBlock {
        Sync-PodeWebSelect -Name 'DynamicSelect'
    }

    New-PodeWebSelect -Name 'DynamicSelect' -Multiple -ScriptBlock {
        return @(foreach ($i in (1..10)) {
            Get-Random -Minimum 1 -Maximum 10
        })
    }
)
```
