### PR TITLE
Allow Update-PodeWebTableRow to change row colour

### DIFF
--- a/examples/catfacts.ps1
+++ b/examples/catfacts.ps1
@@ -19,7 +19,11 @@ Start-PodeServer {
                 Fact = $response
             }
 
-            $data | Update-PodeWebTableRow -Id $ElementData.Parent.ID -DataValue $WebEvent.Data['value']
+            $index = Get-Random -Minimum 0 -Maximum 4
+            $bgColour = (@('Green', 'Yellow', 'Blue', $null))[$index]
+            $colour = (@('White', 'Black', 'White', $null))[$index]
+
+            $data | Update-PodeWebTableRow -Id $ElementData.Parent.ID -DataValue $WebEvent.Data['value'] -BackgroundColour $bgColour -Colour $colour
         }
 
         # load all catfacts

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -215,7 +215,7 @@ function Update-PodeWebTableRow
 {
     [CmdletBinding(DefaultParameterSetName='Name_and_DataValue')]
     param(
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline=$true)]
         $Data,
 
         [Parameter(Mandatory=$true, ParameterSetName='ID_and_DataValue')]
@@ -236,7 +236,15 @@ function Update-PodeWebTableRow
         [Parameter(Mandatory=$true, ParameterSetName='ID_and_Index')]
         [Parameter(Mandatory=$true, ParameterSetName='Name_and_Index')]
         [int]
-        $Index
+        $Index,
+
+        [Parameter()]
+        [string]
+        $BackgroundColour,
+
+        [Parameter()]
+        [string]
+        $Colour
     )
 
     return @{
@@ -250,6 +258,8 @@ function Update-PodeWebTableRow
             Index = $Index
         }
         Data = $Data
+        BackgroundColour = $BackgroundColour
+        Colour = $Colour
     }
 }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1689,13 +1689,9 @@ function actionTableRow(action, sender) {
 }
 
 function updateTableRow(action) {
-    if ((!action.ID && !action.Name) || !action.Data) {
-        return;
-    }
-
     // ensure the table exists
     var table = getElementByNameOrId(action, 'table');
-    if (table.length == 0) {
+    if (!table || table.length == 0) {
         return;
     }
 
@@ -1720,22 +1716,40 @@ function updateTableRow(action) {
         return;
     }
 
-    // update the rows cells
-    var keys = Object.keys(action.Data);
+    // update the row's data
+    if (action.Data) {
+        var keys = Object.keys(action.Data);
 
-    keys.forEach((key) => {
-        var _html = '';
-        var _value = action.Data[key];
+        keys.forEach((key) => {
+            var _html = '';
+            var _value = action.Data[key];
 
-        if (Array.isArray(_value) || _value.ElementType) {
-            _html += buildElements(_value);
-        }
-        else {
-            _html += _value;
-        }
+            if (Array.isArray(_value) || _value.ElementType) {
+                _html += buildElements(_value);
+            }
+            else {
+                _html += _value;
+            }
 
-        row.find(`td[pode-column="${key}"]`).html(_html);
-    });
+            row.find(`td[pode-column="${key}"]`).html(_html);
+        });
+    }
+
+    // update the row's background colour
+    if (action.BackgroundColour) {
+        row[0].style.setProperty('background-color', action.BackgroundColour, 'important');
+    }
+    else {
+        row[0].style.setProperty('background-color', null);
+    }
+
+    // update the row's forecolour
+    if (action.Colour) {
+        row[0].style.setProperty('color', action.Colour, 'important');
+    }
+    else {
+        row[0].style.setProperty('color', null);
+    }
 
     // binds sort/buttons/etc
     $('[data-toggle="tooltip"]').tooltip();


### PR DESCRIPTION
### Description of the Change
Adds `-BackgroundColour` and `-Colour` to `Update-PodeWebTableRow`, allows you to change row colours. If no colour is specified, then the row is reset back to the theme's colour.

### Related Issue
Resolves #151 

### Examples
```powershell
Update-PodeWebTableRow -Name '<table-name>' -Index 0 -BackgroundColour Yellow -Colour Black
```
