### PR TITLE
Remove default 'choose option' option on select elements

### DIFF
--- a/docs/Getting-Started/Migrating/05-to-06.md
+++ b/docs/Getting-Started/Migrating/05-to-06.md
@@ -1,0 +1,13 @@
+# From v0.5 to v0.6
+
+This is a brief guide on the breaking changes introduced into v0.6 from v0.5.
+
+## Select
+
+The `-NoChooseOption` and `-ChooseOptionValue` parameters on `New-PodeWebSelect` have been removed. The default "choose an option" option has also been removed.
+
+If you want to have a first option of "choose an option", this can be defined as the first option in the `-Options` array:
+
+```powershell
+New-PodeWebSelect -Name 'Role' -Options @('Choose...', 'User', 'Admin', 'Operations')
+```

--- a/docs/Tutorials/Elements/Select.md
+++ b/docs/Tutorials/Elements/Select.md
@@ -51,10 +51,6 @@ New-PodeWebCard -Content @(
 )
 ```
 
-## Choose Option
-
-You can hide the "Choose an Option" option by passing `-NoChooseOption`, or you can change it value via `-ChooseOptionValue`.
-
 ## Multiple
 
 You can render a multiple select element, where more than one option can be selected, by using the `-Multiple` switch. By default only the first 4 options are shown, this can be altered using the `-Size` parameter.

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -23,7 +23,8 @@ Start-PodeServer {
         New-PodeWebCredential -Name 'Credentials' -NoLabels
         New-PodeWebCheckbox -Name 'Checkboxes' -Options @('Terms', 'Privacy') -AsSwitch
         New-PodeWebRadio -Name 'Radios' -Options @('S', 'M', 'L')
-        New-PodeWebSelect -Name 'Role' -Options @('User', 'Admin', 'Operations') -Multiple
+        New-PodeWebSelect -Name 'Role1' -Options @('Choose...', 'User', 'Admin', 'Operations')
+        New-PodeWebSelect -Name 'Role2' -Options @('User', 'Admin', 'Operations') -Multiple
         New-PodeWebRange -Name 'Cores' -Value 30 -ShowValue
         New-PodeWebSelect -Name 'Amount' -ScriptBlock {
             return @(foreach ($i in (1..10)) {

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -435,15 +435,8 @@ function New-PodeWebSelect
         [string[]]
         $CssClass,
 
-        [Parameter()]
-        [string]
-        $ChooseOptionValue,
-
         [switch]
-        $Multiple,
-
-        [switch]
-        $NoChooseOption
+        $Multiple
     )
 
     $Id = Get-PodeWebElementId -Tag Select -Id $Id -Name $Name
@@ -464,8 +457,6 @@ function New-PodeWebSelect
         SelectedValue = $SelectedValue
         Multiple = $Multiple.IsPresent
         Size = $Size
-        ChooseOptionValue = $ChooseOptionValue
-        NoChooseOption = $NoChooseOption.IsPresent
         CssClasses = ($CssClass -join ' ')
     }
 

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -9,20 +9,6 @@
 
             "<select class='custom-select' id='$($data.ID)' name='$($data.Name)' pode-dynamic='$($data.IsDynamic)' $($multiple)>"
 
-            if (!$data.Multiple -and !$data.NoChooseOption) {
-                $chooseValue = $data.ChooseOptionValue
-                if ([string]::IsNullOrWhiteSpace($chooseValue)) {
-                    $chooseValue = 'Choose an option'
-                }
-
-                if ([string]::IsNullOrWhiteSpace($data.SelectedValue)) {
-                    "<option selected>$($chooseValue)</option>"
-                }
-                else {
-                    "<option>$($chooseValue)</option>"
-                }
-            }
-
             foreach ($option in $data.Options) {
                 if ([string]::IsNullOrWhiteSpace($option)) {
                     continue


### PR DESCRIPTION
### Description of the Change
Remove the `-NoChooseOption` and `-ChooseOptionValue` from `New-PodeWebSelect`. If people need a "choose an option", it can be defined using `-Options`, and if they don't, it's a simple case of not defining one.

### Related Issue
Resolves #155

### Examples
```powershell
New-PodeWebSelect -Name 'Role1' -Options @('Choose...', 'User', 'Admin', 'Operations')
```
