### PR TITLE
Add support for most elements to have JS events

### DIFF
--- a/docs/Tutorials/Basics.md
+++ b/docs/Tutorials/Basics.md
@@ -58,7 +58,7 @@ Once the templates are enabled, you can start to add some pages! You can find mo
 * Login
 * Webpage
 
-To just add a new page, you use [`Add-PodeWebPage`](../../Functions/Pages/Add-PodeWebPage), supplying the `-Name` of the page and a `-ScriptBlock` for defining the layouts/elements on the page:
+To just add a new page, you use [`Add-PodeWebPage`](../../Functions/Pages/Add-PodeWebPage), supplying the `-Name` of the page and a `-ScriptBlock` for defining the layout/element components on the page:
 
 ```powershell
 Add-PodeWebPage -Name 'Services' -Icon 'Settings' -ScriptBlock {

--- a/docs/Tutorials/Elements/Alert.md
+++ b/docs/Tutorials/Elements/Alert.md
@@ -1,5 +1,9 @@
 # Alert
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 An alert is a colour block containing information text; alerts can for warning, errors, tips, etcs. To add an alert you use [`New-PodeWebAlert`](../../../Functions/Elements/New-PodeWebAlert), and supply either a `-Value` or `-Content`:
 
 ```powershell

--- a/docs/Tutorials/Elements/Badge.md
+++ b/docs/Tutorials/Elements/Badge.md
@@ -1,5 +1,9 @@
 # Badge
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 A Badge is just normal text, but has a styled/coloured background. You can add a badge to your page using [`New-PodeWebBadge`](../../../Functions/Elements/New-PodeWebBadge):
 
 ```powershell

--- a/docs/Tutorials/Elements/Button.md
+++ b/docs/Tutorials/Elements/Button.md
@@ -1,5 +1,9 @@
 # Button
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 To display a button on your page you use [`New-PodeWebButton`](../../../Functions/Elements/New-PodeWebButton); a button can either be dynamic and run custom logic via a `-ScriptBlock`, or it can redirect a user to a `-Url`.
 
 ## Dynamic

--- a/docs/Tutorials/Elements/Charts.md
+++ b/docs/Tutorials/Elements/Charts.md
@@ -1,5 +1,9 @@
 # Charts
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 You can display data rendered as a chart by using [`New-PodeWebChart`](../../../Functions/Elements/New-PodeWebChart), and the following chart types are supported:
 
 * Line (default)

--- a/docs/Tutorials/Elements/Checkbox.md
+++ b/docs/Tutorials/Elements/Checkbox.md
@@ -1,5 +1,9 @@
 # Checkbox
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The Checkbox element is a form input element, and can be added using [`New-PodeWebCheckbox`](../../../Functions/Elements/New-PodeWebCheckbox). This will add a checkbox to your form, and you can render with checkbox as a switch using `-AsSwitch`:
 
 ```powershell

--- a/docs/Tutorials/Elements/Code.md
+++ b/docs/Tutorials/Elements/Code.md
@@ -1,5 +1,9 @@
 # Code
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 The code element will render pre-formatted text as `<code>value</code>`. To create a code element you use [`New-PodeWebCode`](../../../Functions/Elements/New-PodeWebCode):
 
 ```powershell

--- a/docs/Tutorials/Elements/CodeBlock.md
+++ b/docs/Tutorials/Elements/CodeBlock.md
@@ -1,5 +1,9 @@
 # Code Block
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 The code block element will render pre-formatted text as `<pre>value</pre>`. To create a code block element you use [`New-PodeWebCodeBlock`](../../../Functions/Elements/New-PodeWebCodeBlock), and you can specify the highlighting language via `-Language` - the default is plain text.
 
 ```powershell

--- a/docs/Tutorials/Elements/CodeEditor.md
+++ b/docs/Tutorials/Elements/CodeEditor.md
@@ -1,5 +1,9 @@
 # Code Editor
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The code editor, which is done using MicroSoft's Monaco Editor, is currently still a WIP but functional. You can add a code editor to your page via [`New-PodeWebCodeEditor`](../../../Functions/Elements/New-PodeWebCodeEditor), and specify the language is editor is for via `-Language`.
 
 To display the editor with some initial content you can supply `-Value`:

--- a/docs/Tutorials/Elements/CommentBlock.md
+++ b/docs/Tutorials/Elements/CommentBlock.md
@@ -1,5 +1,9 @@
 # Comment Block
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 A Comment Block lets you display messages/comments on your page, showing a user's name, message and an icon/avatar. You can add comment blocks using [`New-PodeWebComment`](../../../Functions/Elements/New-PodeWebComment):
 
 ```powershell

--- a/docs/Tutorials/Elements/Credentials.md
+++ b/docs/Tutorials/Elements/Credentials.md
@@ -1,5 +1,9 @@
 # Credentials
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The Credentials element is a form input element, and can be added using [`New-PodeWebCredential`](../../../Functions/Elements/New-PodeWebCredential). This will automatically add a username and password input fields to your form:
 
 ```powershell

--- a/docs/Tutorials/Elements/DateTime.md
+++ b/docs/Tutorials/Elements/DateTime.md
@@ -1,5 +1,9 @@
 # DateTime
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The DateTime element is a form input element, and can be added using [`New-PodeWebDateTime`](../../../Functions/Elements/New-PodeWebDateTime). This will automatically add a date and time input fields to your form:
 
 ```powershell

--- a/docs/Tutorials/Elements/FileStream.md
+++ b/docs/Tutorials/Elements/FileStream.md
@@ -1,5 +1,9 @@
 # File Stream
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 A file stream element is a readonly textarea that will stream the contents of a file from the server - usually a text/log file from the `/public` directory. To add a file streaming element to your page you can use [`New-PodeWebFileStream`](../../../Functions/Elements/New-PodeWebFileStream).
 
 The simplest file stream just needs a `-Url` being supplied; this URL should be a relative/literal URL path to a static text file.

--- a/docs/Tutorials/Elements/FileUpload.md
+++ b/docs/Tutorials/Elements/FileUpload.md
@@ -1,5 +1,9 @@
 # File Upload
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 The File Upload element is a form input element, and can be created using [`New-PodeWebFileUpload`](../../../Functions/Elements/New-PodeWebFileUpload). It allows users to upload files from your page forms:
 
 ```powershell

--- a/docs/Tutorials/Elements/Form.md
+++ b/docs/Tutorials/Elements/Form.md
@@ -1,5 +1,9 @@
 # Form
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 A form is kind of like a layout, but is an element that contains other elements. It automatically wraps the `-Content` as a `<form>` and adds a submit button to the bottom. When clicked, the form is serialised and sent to the `-ScriptBlock`. To add a form to you page use [`New-PodeWebForm`](../../../Functions/Elements/New-PodeWebForm) along with other form elements:
 
 ```powershell

--- a/docs/Tutorials/Elements/Header.md
+++ b/docs/Tutorials/Elements/Header.md
@@ -1,5 +1,9 @@
 # Header
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 You can render header titles to your page by using [`New-PodeWebHeader`](../../../Functions/Elements/New-PodeWebHeader). This will show a title in various header sizes (`h1` - `h6`):
 
 ```powershell

--- a/docs/Tutorials/Elements/Hidden.md
+++ b/docs/Tutorials/Elements/Hidden.md
@@ -1,5 +1,9 @@
 # Hidden
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 The Hidden element is a form input element, and can be added using [`New-PodeWebHidden`](../../../Functions/Elements/New-PodeWebHidden). It allows you to add hidden values/elements to your forms:
 
 ```powershell

--- a/docs/Tutorials/Elements/IFrame.md
+++ b/docs/Tutorials/Elements/IFrame.md
@@ -1,5 +1,9 @@
 # iFrame
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 The iFrame element lets you embed other websites into your pages via [`New-PodeWebIFrame`](../../../Functions/Elements/New-PodeWebIFrame), and you just need to supply the `-Url` to embed:
 
 ```powershell

--- a/docs/Tutorials/Elements/Icon.md
+++ b/docs/Tutorials/Elements/Icon.md
@@ -1,5 +1,9 @@
 # Icon
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The icon element will render a [Material Design Icon](https://materialdesignicons.com) to your page. To create an icon element you use [`New-PodeWebIcon`](../../../Functions/Elements/New-PodeWebIcon), and supply the name of a Material Design Icon using `-Name`; you can also change the icon colour via `-Colour` which can be a known name (red/green/etc) or a hex value (#333333).
 
 ```powershell

--- a/docs/Tutorials/Elements/Image.md
+++ b/docs/Tutorials/Elements/Image.md
@@ -1,5 +1,9 @@
 # Image
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 This will render an image onto your page, using [`New-PodeWebImage`](../../../Functions/Elements/New-PodeWebImage). You need to supply a `-Source` URL to the image you wish to display:
 
 ```powershell

--- a/docs/Tutorials/Elements/Line.md
+++ b/docs/Tutorials/Elements/Line.md
@@ -1,5 +1,9 @@
 # Line
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 This will render a line (`<hr>`) to your page, using [`New-PodeWebLine`](../../../Functions/Elements/New-PodeWebLine):
 
 ```powershell

--- a/docs/Tutorials/Elements/Link.md
+++ b/docs/Tutorials/Elements/Link.md
@@ -1,5 +1,9 @@
 # Link
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 This will render a hyperlink (`<a>`) to your page, using [`New-PodeWebLink`](../../../Functions/Elements/New-PodeWebLink). You need to supply a `-Source` (the href), and a `-Value` to show to the user:
 
 ```powershell

--- a/docs/Tutorials/Elements/List.md
+++ b/docs/Tutorials/Elements/List.md
@@ -1,5 +1,9 @@
 # List
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 Pode.Web lets you display lists of items, either bullet pointed or numbered, using [`New-PodeWebList`](../../../Functions/Elements/New-PodeWebList). You need to supply an array of `-Items` or `-Values`, and then the `-Numbered` flag for numbered lists.
 
 ## Items

--- a/docs/Tutorials/Elements/MinMax.md
+++ b/docs/Tutorials/Elements/MinMax.md
@@ -1,5 +1,9 @@
 # MinMax
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The MinMax element is a form input element, and can be added using [`New-PodeWebMinMax`](../../../Functions/Elements/New-PodeWebMinMax). This will add a pair of number type textboxes to your form to allow input of minimum/maximum values, you can set preset values using `-MinValue` and `-MaxValue`:
 
 ```powershell

--- a/docs/Tutorials/Elements/Paragraph.md
+++ b/docs/Tutorials/Elements/Paragraph.md
@@ -1,5 +1,9 @@
 # Paragraph
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 You can display a `-Value`, or other `-Elements`, within a paragraph block using [`New-PodeWebParagraph`](../../../Functions/Elements/New-PodeWebParagraph). This lets you separate blocks of text/elements neatly on a page:
 
 ```powershell

--- a/docs/Tutorials/Elements/ProgressBar.md
+++ b/docs/Tutorials/Elements/ProgressBar.md
@@ -1,5 +1,9 @@
 # Progress Bar
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 You can show a progress bar on your page via [`New-PodeWebProgress`](../../../Functions/Elements/New-PodeWebProgress). The default min/max values are 0-100, but can be changed via `-Min` and `-Max`. You can specify the current value via `-Value`, and alter the `-Colour`. You can also make the progress bar `-Striped` and/or `-Animated` (only really works with a striped progress bar!):
 
 ```powershell

--- a/docs/Tutorials/Elements/Quote.md
+++ b/docs/Tutorials/Elements/Quote.md
@@ -1,5 +1,9 @@
 # Quote
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 You can render a quote to your page by using [`New-PodeWebQuote`](../../../Functions/Elements/New-PodeWebQuote). This will show a quoted message (`-Value`), with optional `-Source`, to your page:
 
 ```powershell

--- a/docs/Tutorials/Elements/Radio.md
+++ b/docs/Tutorials/Elements/Radio.md
@@ -1,5 +1,9 @@
 # Radio
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The Radio element is a form input element, and can be added using [`New-PodeWebRadio`](../../../Functions/Elements/New-PodeWebRadio). This will add a series of radio buttons to your form:
 
 ```powershell

--- a/docs/Tutorials/Elements/Range.md
+++ b/docs/Tutorials/Elements/Range.md
@@ -1,5 +1,9 @@
 # Range
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The Range element is a form input element, and can be added using [`New-PodeWebRange`](../../../Functions/Elements/New-PodeWebRange). This will add a range slider to your form, with default min/max values of 0-100, but these can be altered via `-Min` and `-Max`. You can set a default `-Value`, and show the currently selected value via `-ShowValue`:
 
 ```powershell

--- a/docs/Tutorials/Elements/Raw.md
+++ b/docs/Tutorials/Elements/Raw.md
@@ -1,5 +1,9 @@
 # Raw
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 This will render raw HTML to your page, using [`New-PodeWebRaw`](../../../Functions/Elements/New-PodeWebRaw):
 
 ```powershell

--- a/docs/Tutorials/Elements/Select.md
+++ b/docs/Tutorials/Elements/Select.md
@@ -1,5 +1,9 @@
 # Select
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 The Select element is a form input element, and can be added using [`New-PodeWebSelect`](../../../Functions/Elements/New-PodeWebSelect). This will add a dropdown select menu to your form, allowing the user to select an entry; to allow multiple entries to be selected you can pass `-Multiple`, and to specify a pre-selected value you can use `-SelectedValue`.
 
 ## Options

--- a/docs/Tutorials/Elements/Spinner.md
+++ b/docs/Tutorials/Elements/Spinner.md
@@ -1,5 +1,9 @@
 # Spinner
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 The spinner element will render a progress spinner to your page. To create a spinner element you use [`New-PodeWebSpinner`](../../../Functions/Elements/New-PodeWebSpinner), you can also change the spinner colour via `-Colour` which can be a known name (red/green/etc) or a hex value (#333333).
 
 ```powershell

--- a/docs/Tutorials/Elements/Table.md
+++ b/docs/Tutorials/Elements/Table.md
@@ -1,5 +1,9 @@
 # Table
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 You can display data rendered in a table by using [`New-PodeWebTable`](../../../Functions/Elements/New-PodeWebTable), and you can also render certain other elements within a table such as:
 
 * Buttons

--- a/docs/Tutorials/Elements/Text.md
+++ b/docs/Tutorials/Elements/Text.md
@@ -1,5 +1,9 @@
 # Text
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 You can render different types of text/typography to your page by using [`New-PodeWebText`](../../../Functions/Elements/New-PodeWebText). You can specify the `-Value` to display, and then a custom `-Style` to render the text; such as Normal, Bold, Italic, etc. (default is Normal):
 
 ```powershell

--- a/docs/Tutorials/Elements/Textbox.md
+++ b/docs/Tutorials/Elements/Textbox.md
@@ -1,5 +1,9 @@
 # Textbox
 
+| Support | |
+| ------- |-|
+| Events | Yes |
+
 A textbox element is a form input element; you can render a textbox, single and multiline, to your page using [`New-PodeWebTextbox`](../../../Functions/Elements/New-PodeWebTextbox).
 
 A textbox by default is a normal plain single lined textbox, however you can customise its `-Type` to Email/Password/etc. To change the textbox to be multilined you ca supply `-Multiline`.

--- a/docs/Tutorials/Elements/Tile.md
+++ b/docs/Tutorials/Elements/Tile.md
@@ -1,5 +1,9 @@
 # Tile
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 A tile is a small coloured container, that contains either a static value or more elements. There purpose is to display quick informational data like: CPU, counters, charts, etc.
 
 To add a tile you use [`New-PodeWebTile`](../../../Functions/Elements/New-PodeWebTile), and supply a `-Name` and either a `-ScriptBlock` or `-Content`.

--- a/docs/Tutorials/Elements/Timer.md
+++ b/docs/Tutorials/Elements/Timer.md
@@ -1,5 +1,9 @@
 # Timer
 
+| Support | |
+| ------- |-|
+| Events | No |
+
 A timer is a non-visible element, it sets up a javascript timer in the background that periodically (60s) invokes logic. You can add a timer using [`New-PodeWebTimer`](../../../Functions/Elements/New-PodeWebTimer), and they're mostly used with the outputs function to alter the page.
 
 The below example sets up a timer that will update the badge's value and colour every 10 seconds:

--- a/docs/Tutorials/Events.md
+++ b/docs/Tutorials/Events.md
@@ -1,0 +1,31 @@
+# Events
+
+In JavaScript you have events that can trigger, such as `onchange` or `onfocus`. You can bind scriptblocks to these events for different components by using [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent).
+
+For now only Element components support registering events, and not all elements support events (check an elements page to see if it supports events!).
+
+The following events are supported:
+
+* Change
+* Focus
+* FocusOut
+* Click
+* MouseOver
+* MouseOut
+* KeyDown
+* KeyUp
+
+Similar to say a Button's click scriptblock, these events can run whatever logic you like, including returning output actions for Pode.Web to action against on the frontend.
+
+## Example
+
+Let's say you want to have a Select element, but not in a form. When the Select's current value is changed, you want to run a script to show a message:
+
+```powershell
+New-PodeWebSelect -Name 'Role' -Options @('Choose...', 'User', 'Admin', 'Operations') |
+    Register-PodeWebEvent -Type Change -ScriptBlock {
+        Show-PodeWebToast -Message "The value was changed: $($WebEvent.Data['Role'])"
+    }
+```
+
+If the element the event triggers for is a form input element, the value will be serialised and available in `$WebEvent.Data`.

--- a/docs/Tutorials/Layouts/Accordion.md
+++ b/docs/Tutorials/Layouts/Accordion.md
@@ -2,7 +2,7 @@
 
 An accordion layout is an array of accordion bellows with content. They are displayed in a collapsible manor, with the first bellow being expanded. When another bellow is expanded, all other bellows are collapsed.
 
-The bellows take an array of content, that can be either other layouts or raw elements.
+The bellows take an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Layouts/Card.md
+++ b/docs/Tutorials/Layouts/Card.md
@@ -2,7 +2,7 @@
 
 A card is a layout that renders with an optional title, and can be collapsed by the end-user.
 
-A card takes an array of content, that can be either other layouts or raw elements.
+A card takes an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Layouts/Carousel.md
+++ b/docs/Tutorials/Layouts/Carousel.md
@@ -2,7 +2,7 @@
 
 A carousel layout is an array of slides with content, each slide can also have a title and a message. The slides will periodically move between one-another, with arrows on either side to manually move to the next slide.
 
-The slides take an array of content, that can be either other layouts or raw elements.
+The slides take an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Layouts/Container.md
+++ b/docs/Tutorials/Layouts/Container.md
@@ -2,7 +2,7 @@
 
 A container is similar to a card layout, but it has not title, nor can it be collapsed. It's a way of group multiple elements together, with the option of making the background of the container transparent.
 
-A container takes an array of content, that can be either other layouts or raw elements.
+A container takes an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Layouts/Grid.md
+++ b/docs/Tutorials/Layouts/Grid.md
@@ -2,7 +2,7 @@
 
 A grid layout is an array of cells with content, equally spaced in size, that can be either horizontal or vertical in orientation.
 
-The cells take an array of content, that can be either other layouts or raw elements.
+The cells take an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Layouts/Hero.md
+++ b/docs/Tutorials/Layouts/Hero.md
@@ -2,7 +2,7 @@
 
 A hero is a layout that renders with a title, message, and extra optional content. They're the big display messages that are normally seen at the top of websites with buttons like "Download Now!" etc.
 
-A hero can take an array of content, that can be either other layouts or raw elements.
+A hero can take an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Layouts/Modal.md
+++ b/docs/Tutorials/Layouts/Modal.md
@@ -2,7 +2,7 @@
 
 A modal is a layout that renders on top of all other content on your web page - such as prompts to comfirm information before performing an action, or a quick edit dialog.
 
-A modal takes an array of content, that can be either other layouts or raw elements.
+A modal takes an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Layouts/Steps.md
+++ b/docs/Tutorials/Layouts/Steps.md
@@ -2,7 +2,7 @@
 
 A steps layout is an array of steps with content. You can use them to step through multiple parts of a setup process.
 
-The steps take an array of content, that can be either other layouts or raw elements.
+The steps take an array of components via `-Content`, that can be either other layouts or raw elements.
 
 ## Usage
 

--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -1,6 +1,6 @@
 # Pages
 
-There are 3 different kinds of pages in Pode.Web, which are defined below. Besides the Login page, the Home and normal Webpages can be populated with Layouts and Elements. When you add pages to your site, they appear on sidebar for navigation.
+There are 3 different kinds of pages in Pode.Web, which are defined below. Besides the Login page, the Home and normal Webpages can be populated with Layout/Element components. When you add pages to your site, they appear on sidebar for navigation.
 
 ## Login
 
@@ -63,7 +63,7 @@ You can split up your pages into different .ps1 files, if you do and you place t
 
 ### Link
 
-If you just need to place a redirect link into the sidebar, then use [`Add-PodeWebPageLink`](../../Functions/Pages/Add-PodeWebPageLink). This works in a similar way to `Add-PodeWebPage`, but takes either a flat `-Url` to redirect to, or a `-ScriptBlock` that you can return output actions from - *not* layouts/elements. Page links can also be grouped, like normal pages.
+If you just need to place a redirect link into the sidebar, then use [`Add-PodeWebPageLink`](../../Functions/Pages/Add-PodeWebPageLink). This works in a similar way to `Add-PodeWebPage`, but takes either a flat `-Url` to redirect to, or a `-ScriptBlock` that you can return output actions from - *not* layout/element components. Page links can also be grouped, like normal pages.
 
 Flat URLs:
 
@@ -89,7 +89,7 @@ A help icon can be displayed to the right of the page's title by supplying a `-H
 
 ### Static
 
-A static page is one that uses just `-Layouts`; this is a page that will render the same layouts/elements on every page load, regardless of payload or query parameters supplied to the page.
+A static page is one that uses just `-Layouts`; this is a page that will render the same layout/element components on every page load, regardless of payload or query parameters supplied to the page.
 
 For example, this page will always render a form to search for processes:
 
@@ -109,7 +109,7 @@ Add-PodeWebPage -Name Processes -Icon Activity -Layouts @(
 
 ### Dynamic
 
-Add dynamic page uses a `-ScriptBlock` instead of `-Layouts`, the scriptblock lets you render different layouts/elements depending on query/payload data in the `$WebEvent`. The scriptblock also has access to a `$PageData` object, containing information about the current page - such as Name, Group, Access, etc.
+Add dynamic page uses a `-ScriptBlock` instead of `-Layouts`, the scriptblock lets you render different layout/element components depending on query/payload data in the `$WebEvent`. The scriptblock also has access to a `$PageData` object, containing information about the current page - such as Name, Group, Access, etc.
 
 For example, the below page will render a table of services if a `value` query parameter is not present. Otherwise, if it is present, then a page with a code-block showing information about the service is displayed:
 

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -72,7 +72,10 @@ Start-PodeServer -StatusPageExceptions Show {
             New-PodeWebText -Value "Look, here's a "
             New-PodeWebLink -Source 'https://github.com/badgerati/pode' -Value 'link' -NewTab
             New-PodeWebText -Value "! "
-            New-PodeWebBadge -Id 'bdg_test' -Value 'Sweet!' -Colour Cyan
+            New-PodeWebBadge -Id 'bdg_test' -Value 'Sweet!' -Colour Cyan |
+                Register-PodeWebEvent -Type Click -NoAuth -ScriptBlock {
+                    Show-PodeWebToast -Message 'Badge was clicked!'
+                }
         )
         $timer1
         New-PodeWebImage -Source '/pode.web/images/icon.png' -Height 70 -Alignment Right

--- a/examples/icons.ps1
+++ b/examples/icons.ps1
@@ -21,7 +21,10 @@ Start-PodeServer -Threads 2 {
     $card2 = New-PodeWebCard -Content @(
         New-PodeWebTable -Name Example -ScriptBlock {
             return @{
-                Icon = (New-PodeWebIcon -Name 'refresh' -Spin -Colour Yellow)
+                Icon = (New-PodeWebIcon -Name 'refresh' -Spin -Colour Yellow |
+                    Register-PodeWebEvent -Type Click -ScriptBlock {
+                        Show-PodeWebToast -Message 'Spinning icon clicked!'
+                    })
             }
         }
     )

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -26,10 +26,13 @@ Start-PodeServer {
         New-PodeWebSelect -Name 'Role1' -Options @('Choose...', 'User', 'Admin', 'Operations')
         New-PodeWebSelect -Name 'Role2' -Options @('User', 'Admin', 'Operations') -Multiple
         New-PodeWebRange -Name 'Cores' -Value 30 -ShowValue
+
         New-PodeWebSelect -Name 'Amount' -ScriptBlock {
             return @(foreach ($i in (1..10)) {
                 Get-Random -Minimum 1 -Maximum 10
             })
+        } | Register-PodeWebEvent -Type Change -PassThru -ScriptBlock {
+            Show-PodeWebToast -Message 'The value was changed!'
         }
     )
 

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -17,10 +17,10 @@ Start-PodeServer {
             return @('billy', 'bobby', 'alice', 'john', 'sarah', 'matt', 'zack', 'henry')
         } |
         Register-PodeWebEvent -Type KeyDown -PassThru -ScriptBlock {
-            Show-PodeWebToast -Message 'The element has a keydown!'
+            Show-PodeWebToast -Message "The element has a keydown: $($WebEvent.Data['Name'])"
         } |
         Register-PodeWebEvent -Type KeyUp -PassThru -ScriptBlock {
-            Show-PodeWebToast -Message 'The element has a keyup!'
+            Show-PodeWebToast -Message "The element has a keyup: $($WebEvent.Data['Name'])"
         }
 
         New-PodeWebTextbox -Name 'Password' -Type Password -PrependIcon Lock
@@ -40,7 +40,7 @@ Start-PodeServer {
             })
         } |
         Register-PodeWebEvent -Type Change -PassThru -ScriptBlock {
-            Show-PodeWebToast -Message 'The value was changed!'
+            Show-PodeWebToast -Message "The value was changed: $($WebEvent.Data['Amount'])"
         } |
         Register-PodeWebEvent -Type Focus -PassThru -ScriptBlock {
             Show-PodeWebToast -Message 'The element was focused!'

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -16,10 +16,10 @@ Start-PodeServer {
         New-PodeWebTextbox -Name 'Name' -AppendIcon Account -AutoComplete {
             return @('billy', 'bobby', 'alice', 'john', 'sarah', 'matt', 'zack', 'henry')
         } |
-        Register-PodeWebEvent -Type KeyDown -PassThru -ScriptBlock {
+        Register-PodeWebEvent -Type KeyDown -ScriptBlock {
             Show-PodeWebToast -Message "The element has a keydown: $($WebEvent.Data['Name'])"
         } |
-        Register-PodeWebEvent -Type KeyUp -PassThru -ScriptBlock {
+        Register-PodeWebEvent -Type KeyUp -ScriptBlock {
             Show-PodeWebToast -Message "The element has a keyup: $($WebEvent.Data['Name'])"
         }
 
@@ -39,19 +39,19 @@ Start-PodeServer {
                 Get-Random -Minimum 1 -Maximum 10
             })
         } |
-        Register-PodeWebEvent -Type Change -PassThru -ScriptBlock {
+        Register-PodeWebEvent -Type Change -ScriptBlock {
             Show-PodeWebToast -Message "The value was changed: $($WebEvent.Data['Amount'])"
         } |
-        Register-PodeWebEvent -Type Focus -PassThru -ScriptBlock {
+        Register-PodeWebEvent -Type Focus -ScriptBlock {
             Show-PodeWebToast -Message 'The element was focused!'
         } |
-        Register-PodeWebEvent -Type FocusOut -PassThru -ScriptBlock {
+        Register-PodeWebEvent -Type FocusOut -ScriptBlock {
             Show-PodeWebToast -Message 'The element was unfocused!'
         } |
-        Register-PodeWebEvent -Type MouseOver -PassThru -ScriptBlock {
+        Register-PodeWebEvent -Type MouseOver -ScriptBlock {
             Show-PodeWebToast -Message 'The element has the mouse over!'
         } |
-        Register-PodeWebEvent -Type MouseOut -PassThru -ScriptBlock {
+        Register-PodeWebEvent -Type MouseOut -ScriptBlock {
             Show-PodeWebToast -Message 'The element has no mouse!'
         }
     )

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -15,7 +15,14 @@ Start-PodeServer {
     } -Content @(
         New-PodeWebTextbox -Name 'Name' -AppendIcon Account -AutoComplete {
             return @('billy', 'bobby', 'alice', 'john', 'sarah', 'matt', 'zack', 'henry')
+        } |
+        Register-PodeWebEvent -Type KeyDown -PassThru -ScriptBlock {
+            Show-PodeWebToast -Message 'The element has a keydown!'
+        } |
+        Register-PodeWebEvent -Type KeyUp -PassThru -ScriptBlock {
+            Show-PodeWebToast -Message 'The element has a keyup!'
         }
+
         New-PodeWebTextbox -Name 'Password' -Type Password -PrependIcon Lock
         New-PodeWebTextbox -Name 'Date' -Type Date
         New-PodeWebTextbox -Name 'Time' -Type Time
@@ -31,8 +38,21 @@ Start-PodeServer {
             return @(foreach ($i in (1..10)) {
                 Get-Random -Minimum 1 -Maximum 10
             })
-        } | Register-PodeWebEvent -Type Change -PassThru -ScriptBlock {
+        } |
+        Register-PodeWebEvent -Type Change -PassThru -ScriptBlock {
             Show-PodeWebToast -Message 'The value was changed!'
+        } |
+        Register-PodeWebEvent -Type Focus -PassThru -ScriptBlock {
+            Show-PodeWebToast -Message 'The element was focused!'
+        } |
+        Register-PodeWebEvent -Type FocusOut -PassThru -ScriptBlock {
+            Show-PodeWebToast -Message 'The element was unfocused!'
+        } |
+        Register-PodeWebEvent -Type MouseOver -PassThru -ScriptBlock {
+            Show-PodeWebToast -Message 'The element has the mouse over!'
+        } |
+        Register-PodeWebEvent -Type MouseOut -PassThru -ScriptBlock {
+            Show-PodeWebToast -Message 'The element has no mouse!'
         }
     )
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -540,11 +540,7 @@ function Test-PodeWebContent
 
         [Parameter()]
         [string[]]
-        $ElementType,
-
-        [Parameter()]
-        [string[]]
-        $LayoutType
+        $ObjectType
     )
 
     # if no content, then it's true
@@ -561,19 +557,19 @@ function Test-PodeWebContent
         }
     }
 
-    # ensure the content ElementTypes are correct
-    if (!(Test-PodeWebArrayEmpty -Array $ElementType)) {
+    # ensure the content elements are correct
+    if (!(Test-PodeWebArrayEmpty -Array $ObjectType)) {
         foreach ($item in $Content) {
-            if ($item.ElementType -inotin $ElementType) {
+            if ($item.ObjectType -inotin $ObjectType) {
                 return $false
             }
         }
     }
 
-    # ensure the content LayoutTypes are correct
-    if (!(Test-PodeWebArrayEmpty -Array $LayoutType)) {
+    # ensure the content elements are correct
+    if (!(Test-PodeWebArrayEmpty -Array $ObjectType)) {
         foreach ($item in $Content) {
-            if ($item.LayoutType -inotin $LayoutType) {
+            if ($item.ObjectType -inotin $ObjectType) {
                 return $false
             }
         }
@@ -623,7 +619,7 @@ function Test-PodeWebOutputWrapped
         $Output = $Output[0]
     }
 
-    return (($Output -is [hashtable]) -and ![string]::IsNullOrWhiteSpace($Output.Operation) -and ![string]::IsNullOrWhiteSpace($Output.ElementType))
+    return (($Output -is [hashtable]) -and ![string]::IsNullOrWhiteSpace($Output.Operation) -and ![string]::IsNullOrWhiteSpace($Output.ObjectType))
 }
 
 function Get-PodeWebPagePath
@@ -656,4 +652,25 @@ function Get-PodeWebPagePath
 
     $path += "/pages/$($Name)"
     return $path
+}
+
+function ConvertTo-PodeWebEvents
+{
+    param(
+        [Parameter()]
+        [string[]]
+        $Events
+    )
+
+    $js_events = [string]::Empty
+
+    if (($null -eq $Events) -or ($Events.Length -eq 0)) {
+        return $js_events
+    }
+
+    foreach ($evt in $Events) {
+        $js_events += " on$($evt)=`"invokeEvent('$($evt)', this);`""
+    }
+
+    return $js_events
 }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -123,6 +123,7 @@ function New-PodeWebTextbox
             Text = $AppendText
             Icon = $AppendIcon
         }
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     # create autocomplete route
@@ -462,6 +463,7 @@ function New-PodeWebSelect
         Multiple = $Multiple.IsPresent
         Size = $Size
         CssClasses = ($CssClass -join ' ')
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     $routePath = "/components/select/$($Id)"
@@ -838,6 +840,7 @@ function New-PodeWebListItem
         ObjectType = 'ListItem'
         ID = (Get-PodeWebElementId -Tag ListItem -RandomToken)
         Content = $Content
+        NoEvents = $true
     }
 }
 
@@ -1245,6 +1248,7 @@ function New-PodeWebButton
         NewLine = $NewLine.IsPresent
         NewTab = $NewTab.IsPresent
         NoEvents = $true
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     $routePath = "/components/button/$($Id)"
@@ -1631,6 +1635,7 @@ function New-PodeWebChart
             Y = $MaxY
         }
         NoEvents = $true
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     $routePath = "/components/chart/$($Id)"
@@ -2142,6 +2147,7 @@ function New-PodeWebCodeEditor
         ReadOnly = $ReadOnly.IsPresent
         Uploadable = $uploadable
         CssClasses = ($CssClass -join ' ')
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     # upload route
@@ -2241,6 +2247,7 @@ function New-PodeWebForm
         NoHeader = $NoHeader.IsPresent
         CssClasses = ($CssClass -join ' ')
         NoEvents = $true
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     $routePath = "/components/form/$($Id)"
@@ -2328,6 +2335,7 @@ function New-PodeWebTimer
         Interval = ($Interval * 1000)
         CssClasses = ($CssClass -join ' ')
         NoEvents = $true
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     $routePath = "/components/timer/$($Id)"
@@ -2454,6 +2462,7 @@ function New-PodeWebTile
         NoRefresh = $NoRefresh.IsPresent
         NewLine = $NewLine.IsPresent
         NoEvents = $true
+        NoAuthentication = $NoAuthentication.IsPresent
     }
 
     # auth an endpoint

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -98,7 +98,7 @@ function New-PodeWebTextbox
     # build element
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Textbox'
+        ObjectType = 'Textbox'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -126,7 +126,7 @@ function New-PodeWebTextbox
     }
 
     # create autocomplete route
-    $routePath = "/elements/autocomplete/$($Id)"
+    $routePath = "/components/textbox/$($Id)/autocomplete"
     if (($null -ne $AutoComplete) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -174,11 +174,12 @@ function New-PodeWebFileUpload
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'FileUpload'
+        ObjectType = 'FileUpload'
         Parent = $ElementData
         Name = $Name
         ID = $Id
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -217,13 +218,14 @@ function New-PodeWebParagraph
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Paragraph'
+        ObjectType = 'Paragraph'
         Parent = $ElementData
         ID = $Id
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Elements = $Elements
         Alignment = $Alignment.ToLowerInvariant()
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -264,13 +266,14 @@ function New-PodeWebCodeBlock
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'CodeBlock'
+        ObjectType = 'CodeBlock'
         Parent = $ElementData
         ID = $Id
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Language = $Language.ToLowerInvariant()
         Scrollable = $Scrollable.IsPresent
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -295,11 +298,12 @@ function New-PodeWebCode
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Code'
+        ObjectType = 'Code'
         Parent = $ElementData
         ID = $Id
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -345,7 +349,7 @@ function New-PodeWebCheckbox
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Checkbox'
+        ObjectType = 'Checkbox'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -389,7 +393,7 @@ function New-PodeWebRadio
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Radio'
+        ObjectType = 'Radio'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -447,7 +451,7 @@ function New-PodeWebSelect
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Select'
+        ObjectType = 'Select'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -460,7 +464,7 @@ function New-PodeWebSelect
         CssClasses = ($CssClass -join ' ')
     }
 
-    $routePath = "/elements/select/$($Id)"
+    $routePath = "/components/select/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -539,7 +543,7 @@ function New-PodeWebRange
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Range'
+        ObjectType = 'Range'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -613,7 +617,7 @@ function New-PodeWebProgress
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Progress'
+        ObjectType = 'Progress'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -677,7 +681,7 @@ function New-PodeWebImage
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Image'
+        ObjectType = 'Image'
         Parent = $ElementData
         ID = $Id
         Source = $Source
@@ -719,13 +723,14 @@ function New-PodeWebHeader
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Header'
+        ObjectType = 'Header'
         Parent = $ElementData
         ID = $Id
         Size = $Size
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Secondary = [System.Net.WebUtility]::HtmlEncode($Secondary)
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -759,13 +764,14 @@ function New-PodeWebQuote
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Quote'
+        ObjectType = 'Quote'
         Parent = $ElementData
         ID = $Id
         Alignment = $Alignment.ToLowerInvariant()
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Source = [System.Net.WebUtility]::HtmlEncode($Source)
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -793,7 +799,7 @@ function New-PodeWebList
         $Numbered
     )
 
-    if (!(Test-PodeWebContent -Content $Items -ComponentType Element -ElementType ListItem)) {
+    if (!(Test-PodeWebContent -Content $Items -ComponentType Element -ObjectType ListItem)) {
         throw 'Lists can only contain ListItem elements, or raw Values'
     }
 
@@ -801,7 +807,7 @@ function New-PodeWebList
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'List'
+        ObjectType = 'List'
         Parent = $ElementData
         ID = $Id
         Values  = @(foreach ($value in $Values) {
@@ -810,6 +816,7 @@ function New-PodeWebList
         Items = $Items
         Numbered = $Numbered.IsPresent
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -828,7 +835,7 @@ function New-PodeWebListItem
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'ListItem'
+        ObjectType = 'ListItem'
         ID = (Get-PodeWebElementId -Tag ListItem -RandomToken)
         Content = $Content
     }
@@ -862,7 +869,7 @@ function New-PodeWebLink
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Link'
+        ObjectType = 'Link'
         Parent = $ElementData
         ID = $Id
         Source = $Source
@@ -903,18 +910,17 @@ function New-PodeWebText
         $InParagraph
     )
 
-    $Id = Get-PodeWebElementId -Tag Txt -Id $Id -RandomToken
-
     return @{
         ComponentType = 'Element'
-        ElementType = 'Text'
+        ObjectType = 'Text'
         Parent = $ElementData
-        ID = $Id
+        ID = (Get-PodeWebElementId -Tag Txt -Id $Id -RandomToken)
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Style = $Style
         InParagraph = $InParagraph.IsPresent
         Alignment = $Alignment.ToLowerInvariant()
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -923,15 +929,21 @@ function New-PodeWebLine
     [CmdletBinding()]
     param(
         [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
         [string[]]
         $CssClass
     )
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Line'
+        ObjectType = 'Line'
         Parent = $ElementData
+        ID = (Get-PodeWebElementId -Tag Line -Id $Id -RandomToken)
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -960,12 +972,13 @@ function New-PodeWebHidden
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Hidden'
+        ObjectType = 'Hidden'
         Parent = $ElementData
         Name = $Name
         ID = $Id
         Value = $Value
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -1000,7 +1013,7 @@ function New-PodeWebCredential
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Credential'
+        ObjectType = 'Credential'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -1042,7 +1055,7 @@ function New-PodeWebDateTime
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'DateTime'
+        ObjectType = 'DateTime'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -1108,7 +1121,7 @@ function New-PodeWebMinMax
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'MinMax'
+        ObjectType = 'MinMax'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -1144,9 +1157,10 @@ function New-PodeWebRaw
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Raw'
+        ObjectType = 'Raw'
         Parent = $ElementData
         Value = $Value
+        NoEvents = $true
     }
 }
 
@@ -1216,7 +1230,7 @@ function New-PodeWebButton
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Button'
+        ObjectType = 'Button'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -1230,9 +1244,10 @@ function New-PodeWebButton
         CssClasses = ($CssClass -join ' ')
         NewLine = $NewLine.IsPresent
         NewTab = $NewTab.IsPresent
+        NoEvents = $true
     }
 
-    $routePath = "/elements/button/$($Id)"
+    $routePath = "/components/button/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -1300,7 +1315,7 @@ function New-PodeWebAlert
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Alert'
+        ObjectType = 'Alert'
         Parent = $ElementData
         ID = $Id
         Type = $Type
@@ -1316,6 +1331,10 @@ function New-PodeWebIcon
 {
     [CmdletBinding(DefaultParameterSetName='Rotate')]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
@@ -1346,14 +1365,17 @@ function New-PodeWebIcon
         $Spin
     )
 
+    $Id = Get-PodeWebElementId -Tag Icon -Id $Id -RandomToken
+
     if (![string]::IsNullOrWhiteSpace($Colour)) {
         $Colour = $Colour.ToLowerInvariant()
     }
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Icon'
+        ObjectType = 'Icon'
         Parent = $ElementData
+        ID = $Id
         Name = $Name
         Colour = $Colour
         CssClasses = ($CssClass -join ' ')
@@ -1368,6 +1390,10 @@ function New-PodeWebSpinner
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter()]
         [string]
         $Colour,
@@ -1387,11 +1413,13 @@ function New-PodeWebSpinner
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Spinner'
+        ObjectType = 'Spinner'
         Parent = $ElementData
+        ID = (Get-PodeWebElementId -Tag Spinner -Id $Id -RandomToken)
         Colour = $Colour
         CssClasses = ($CssClass -join ' ')
         Title = $Title
+        NoEvents = $true
     }
 }
 
@@ -1422,7 +1450,7 @@ function New-PodeWebBadge
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'Badge'
+        ObjectType = 'Badge'
         Parent = $ElementData
         ID = $Id
         Colour = $Colour
@@ -1436,6 +1464,10 @@ function New-PodeWebComment
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [string]
         $Icon,
@@ -1457,15 +1489,19 @@ function New-PodeWebComment
         $CssClass
     )
 
+    $Id = Get-PodeWebElementId -Tag Comment -Id $Id -RandomToken
+
     return @{
         ComponentType = 'Element'
-        ElementType = 'Comment'
+        ObjectType = 'Comment'
         Parent = $ElementData
+        ID = $Id
         Icon = $Icon
         Username = $Username
         Message = $Message
         TimeStamp = $TimeStamp
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 }
 
@@ -1570,7 +1606,7 @@ function New-PodeWebChart
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Chart'
+        ObjectType = 'Chart'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -1594,9 +1630,10 @@ function New-PodeWebChart
             X = $MaxX
             Y = $MaxY
         }
+        NoEvents = $true
     }
 
-    $routePath = "/elements/chart/$($Id)"
+    $routePath = "/components/chart/$($Id)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -1823,7 +1860,7 @@ function New-PodeWebTable
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Table'
+        ObjectType = 'Table'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -1852,6 +1889,7 @@ function New-PodeWebTable
             Enabled = $Paginate.IsPresent
             Size = $PageSize
         }
+        NoEvents = $true
     }
 
     # auth an endpoint
@@ -1865,7 +1903,7 @@ function New-PodeWebTable
     }
 
     # main table data script
-    $routePath = "/elements/table/$($Id)"
+    $routePath = "/components/table/$($Id)"
     $buildRoute = (($null -ne $ScriptBlock) -or ![string]::IsNullOrWhiteSpace($CsvFilePath))
 
     if ($buildRoute -and !(Test-PodeWebRoute -Path $routePath)) {
@@ -1996,10 +2034,10 @@ function Add-PodeWebTableButton
     )
 
     if ($Table.ComponentType -ieq 'layout') {
-        $Table = @($Table.Content | Where-Object { $_.ElementType -ieq 'table' })[0]
+        $Table = @($Table.Content | Where-Object { $_.ObjectType -ieq 'table' })[0]
     }
 
-    $routePath = "/elements/table/$($Table.ID)/button/$($Name)"
+    $routePath = "/components/table/$($Table.ID)/button/$($Name)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$Table.NoAuthentication) {
@@ -2094,7 +2132,7 @@ function New-PodeWebCodeEditor
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Code-Editor'
+        ObjectType = 'Code-Editor'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -2107,7 +2145,7 @@ function New-PodeWebCodeEditor
     }
 
     # upload route
-    $routePath = "/elements/code-editor/$($Id)/upload"
+    $routePath = "/components/code-editor/$($Id)/upload"
     if ($uploadable -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -2194,7 +2232,7 @@ function New-PodeWebForm
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Form'
+        ObjectType = 'Form'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -2202,9 +2240,10 @@ function New-PodeWebForm
         Content = $Content
         NoHeader = $NoHeader.IsPresent
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 
-    $routePath = "/elements/form/$($Id)"
+    $routePath = "/components/form/$($Id)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -2282,15 +2321,16 @@ function New-PodeWebTimer
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Timer'
+        ObjectType = 'Timer'
         Parent = $ElementData
         Name = $Name
         ID = $Id
         Interval = ($Interval * 1000)
         CssClasses = ($CssClass -join ' ')
+        NoEvents = $true
     }
 
-    $routePath = "/elements/timer/$($Id)"
+    $routePath = "/components/timer/$($Id)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -2398,7 +2438,7 @@ function New-PodeWebTile
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'Tile'
+        ObjectType = 'Tile'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -2413,6 +2453,7 @@ function New-PodeWebTile
         RefreshInterval = ($RefreshInterval * 1000)
         NoRefresh = $NoRefresh.IsPresent
         NewLine = $NewLine.IsPresent
+        NoEvents = $true
     }
 
     # auth an endpoint
@@ -2426,7 +2467,7 @@ function New-PodeWebTile
     }
 
     # main route to load tile value
-    $routePath = "/elements/tile/$($Id)"
+    $routePath = "/components/tile/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
             param($Data)
@@ -2517,7 +2558,7 @@ function New-PodeWebFileStream
 
     $element = @{
         ComponentType = 'Element'
-        ElementType = 'FileStream'
+        ObjectType = 'FileStream'
         Parent = $ElementData
         Name = $Name
         ID = $Id
@@ -2559,11 +2600,12 @@ function New-PodeWebIFrame
 
     return @{
         ComponentType = 'Element'
-        ElementType = 'iFrame'
+        ObjectType = 'iFrame'
         Parent = $ElementData
         Name = $Name
         ID = (Get-PodeWebElementId -Tag iFrame -Id $Id -Name $Name)
         Url = $Url
         Title = $Title
+        NoEvents = $true
     }
 }

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -20,8 +20,10 @@ function Register-PodeWebEvent
         [object[]]
         $ArgumentList,
 
+        [Parameter()]
+        [Alias('NoAuth')]
         [switch]
-        $PassThru
+        $NoAuthentication
     )
 
     # does component support events?
@@ -46,7 +48,7 @@ function Register-PodeWebEvent
     $routePath = "/components/$($Component.ObjectType.ToLowerInvariant())/$($Component.ID)/events/$($Type.ToLowerInvariant())"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
-        if (!$Component.NoAuthentication) {
+        if (!$NoAuthentication -and !$Component.NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
@@ -68,7 +70,5 @@ function Register-PodeWebEvent
     }
 
     # return the component back
-    if ($PassThru) {
-        return $Component
-    }
+    return $Component
 }

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -8,7 +8,7 @@ function Register-PodeWebEvent
         $Component,
 
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Change', 'Focus', 'Blur', 'Click', 'Load', 'MouseOver', 'MouseOut', 'KeyDown', 'KeyUp')]
+        [ValidateSet('Change', 'Focus', 'FocusOut', 'Click', 'MouseOver', 'MouseOut', 'KeyDown', 'KeyUp')]
         [string]
         $Type,
 
@@ -24,6 +24,11 @@ function Register-PodeWebEvent
         $PassThru
     )
 
+    # does component support events?
+    if ($Component.NoEvents -or ($Component.ComponentType -ine 'element')) {
+        throw "Component with ID '$($Component.ID)' does not support events"
+    }
+
     # add events map if not present
     if ($null -eq $Component.Events) {
         $Component.Events = @()
@@ -38,10 +43,7 @@ function Register-PodeWebEvent
     $Component.Events += $Type.ToLowerInvariant()
 
     # setup the route
-    $compType = $Component.ComponentType.ToLowerInvariant()
-    $innerType = $Component["$($Component.ComponentType)Type"].ToLowerInvariant()
-
-    $routePath = "/$($compType)s/$($innerType)/$($Component.ID)/events/$($Type.ToLowerInvariant())"
+    $routePath = "/components/$($Component.ObjectType.ToLowerInvariant())/$($Component.ID)/events/$($Type.ToLowerInvariant())"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$Component.NoAuthentication) {

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -26,7 +26,7 @@ function Register-PodeWebEvent
 
     # does component support events?
     if ($Component.NoEvents -or ($Component.ComponentType -ine 'element')) {
-        throw "Component with ID '$($Component.ID)' does not support events"
+        throw "$($Component.ObjectType) $($Component.ComponentType) with ID '$($Component.ID)' does not support events"
     }
 
     # add events map if not present
@@ -36,7 +36,7 @@ function Register-PodeWebEvent
 
     # ensure not already defined
     if ($Component.Events -icontains $Type) {
-        throw "Component with ID '$($Component.ID)' already has the $($Type) event defined"
+        throw "$($Component.ObjectType) $($Component.ComponentType) with ID '$($Component.ID)' already has the $($Type) event defined"
     }
 
     # add event type

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -2,6 +2,10 @@ function New-PodeWebGrid
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Cells,
@@ -18,7 +22,7 @@ function New-PodeWebGrid
         $Vertical
     )
 
-    if (!(Test-PodeWebContent -Content $Cells -ComponentType Layout -LayoutType Cell)) {
+    if (!(Test-PodeWebContent -Content $Cells -ComponentType Layout -ObjectType Cell)) {
         throw 'A Grid can only contain Cell layouts'
     }
 
@@ -28,9 +32,10 @@ function New-PodeWebGrid
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Grid'
+        ObjectType = 'Grid'
         Cells = $Cells
         Width = $Width
+        ID = (Get-PodeWebElementId -Tag Grid -Id $Id -RandomToken)
         CssClasses = ($CssClass -join ' ')
     }
 }
@@ -39,6 +44,10 @@ function New-PodeWebCell
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Content,
@@ -55,9 +64,10 @@ function New-PodeWebCell
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Cell'
+        ObjectType = 'Cell'
         Content = $Content
         Width = $Width
+        ID = (Get-PodeWebElementId -Tag Cell -Id $Id -RandomToken)
     }
 }
 
@@ -65,6 +75,10 @@ function New-PodeWebTabs
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Tabs,
@@ -81,7 +95,7 @@ function New-PodeWebTabs
         $Cycle
     )
 
-    if (!(Test-PodeWebContent -Content $Tabs -ComponentType Layout -LayoutType Tab)) {
+    if (!(Test-PodeWebContent -Content $Tabs -ComponentType Layout -ObjectType Tab)) {
         throw 'Tabs can only contain Tab layouts'
     }
 
@@ -91,7 +105,8 @@ function New-PodeWebTabs
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Tabs'
+        ObjectType = 'Tabs'
+        ID = (Get-PodeWebElementId -Tag Tabs -Id $Id -RandomToken)
         Tabs = $Tabs
         CssClasses = ($CssClass -join ' ')
         Cycle = @{
@@ -105,6 +120,10 @@ function New-PodeWebTab
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
@@ -124,9 +143,9 @@ function New-PodeWebTab
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Tab'
+        ObjectType = 'Tab'
         Name = $Name
-        ID = (Get-PodeWebElementId -Tag Tab -Name $Name)
+        ID = (Get-PodeWebElementId -Tag Tab -Id $Id -Name $Name)
         Layouts = $Layouts
         Icon = $Icon
     }
@@ -169,7 +188,7 @@ function New-PodeWebCard
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Card'
+        ObjectType = 'Card'
         Name = $Name
         ID = (Get-PodeWebElementId -Tag Card -Id $Id -Name $Name -NameAsToken)
         Content = $Content
@@ -209,7 +228,7 @@ function New-PodeWebContainer
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Container'
+        ObjectType = 'Container'
         ID = (Get-PodeWebElementId -Tag Container -Id $Id -NameAsToken)
         Content = $Content
         CssClasses = ($CssClass -join ' ')
@@ -285,7 +304,7 @@ function New-PodeWebModal
     # generate ID
     $Id = Get-PodeWebElementId -Tag Modal -Id $Id -Name $Name
 
-    $routePath = "/layouts/modal/$($Id)"
+    $routePath = "/components/modal/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -310,7 +329,7 @@ function New-PodeWebModal
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Modal'
+        ObjectType = 'Modal'
         Name = $Name
         ID = $Id
         Icon = $Icon
@@ -328,6 +347,10 @@ function New-PodeWebHero
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [string]
         $Title,
@@ -351,7 +374,8 @@ function New-PodeWebHero
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Hero'
+        ObjectType = 'Hero'
+        ID = (Get-PodeWebElementId -Tag Hero -Id $Id -RandomToken)
         Title = [System.Net.WebUtility]::HtmlEncode($Title)
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
         Content = $Content
@@ -363,6 +387,10 @@ function New-PodeWebCarousel
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Slides,
@@ -372,13 +400,13 @@ function New-PodeWebCarousel
         $CssClass
     )
 
-    if (!(Test-PodeWebContent -Content $Slides -ComponentType Layout -LayoutType Slide)) {
+    if (!(Test-PodeWebContent -Content $Slides -ComponentType Layout -ObjectType Slide)) {
         throw 'A Carousel can only contain Slide layouts'
     }
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Carousel'
+        ObjectType = 'Carousel'
         ID = (Get-PodeWebElementId -Tag Carousel -Id $Id -NameAsToken)
         Slides = $Slides
         CssClasses = ($CssClass -join ' ')
@@ -408,8 +436,9 @@ function New-PodeWebSlide
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Slide'
+        ObjectType = 'Slide'
         Content = $Content
+        ID = (Get-PodeWebElementId -Tag Slide -RandomToken)
         Title = [System.Net.WebUtility]::HtmlEncode($Title)
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
     }
@@ -453,7 +482,7 @@ function New-PodeWebSteps
         $NoAuthentication
     )
 
-    if (!(Test-PodeWebContent -Content $Steps -ComponentType Layout -LayoutType Step)) {
+    if (!(Test-PodeWebContent -Content $Steps -ComponentType Layout -ObjectType Step)) {
         throw 'Steps can only contain Step layouts'
     }
 
@@ -461,7 +490,7 @@ function New-PodeWebSteps
     $Id = Get-PodeWebElementId -Tag Steps -Id $Id -Name $Name
 
     # add route
-    $routePath = "/layouts/steps/$($Id)"
+    $routePath = "/components/steps/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -486,7 +515,7 @@ function New-PodeWebSteps
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Steps'
+        ObjectType = 'Steps'
         ID = $Id
         Steps = $Steps
         CssClasses = ($CssClass -join ' ')
@@ -535,7 +564,7 @@ function New-PodeWebStep
     $Id = Get-PodeWebElementId -Tag Step -Name $Name
 
     # add route
-    $routePath = "/layouts/step/$($Id)"
+    $routePath = "/components/step/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
@@ -560,7 +589,7 @@ function New-PodeWebStep
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Step'
+        ObjectType = 'Step'
         Name = $Name
         ID = $Id
         Content = $Content
@@ -582,7 +611,7 @@ function Set-PodeWebBreadcrumb
         $Items = @()
     }
 
-    if (!(Test-PodeWebContent -Content $Items -ComponentType Layout -LayoutType BreadcrumbItem)) {
+    if (!(Test-PodeWebContent -Content $Items -ComponentType Layout -ObjectType BreadcrumbItem)) {
         throw 'A Breadcrumb can only contain breadcrumb item layouts'
     }
 
@@ -597,8 +626,9 @@ function Set-PodeWebBreadcrumb
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Breadcrumb'
+        ObjectType = 'Breadcrumb'
         Items = $Items
+        NoEvents = $true
     }
 }
 
@@ -620,10 +650,11 @@ function New-PodeWebBreadcrumbItem
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'BreadcrumbItem'
+        ObjectType = 'BreadcrumbItem'
         Name = $Name
         Url = $Url
         Active = $Active.IsPresent
+        NoEvents = $true
     }
 }
 
@@ -656,7 +687,7 @@ function New-PodeWebAccordion
         $Cycle
     )
 
-    if (!(Test-PodeWebContent -Content $Bellows -ComponentType Layout -LayoutType Bellow)) {
+    if (!(Test-PodeWebContent -Content $Bellows -ComponentType Layout -ObjectType Bellow)) {
         throw 'Accordions can only contain Bellow layouts'
     }
 
@@ -666,7 +697,7 @@ function New-PodeWebAccordion
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Accordion'
+        ObjectType = 'Accordion'
         ID = (Get-PodeWebElementId -Tag Accordion -Id $Id -NameAsToken)
         Bellows = $Bellows
         CssClasses = ($CssClass -join ' ')
@@ -701,7 +732,7 @@ function New-PodeWebBellow
 
     return @{
         ComponentType = 'Layout'
-        LayoutType = 'Bellow'
+        ObjectType = 'Bellow'
         Name = $Name
         ID = (Get-PodeWebElementId -Tag Bellow -Name $Name)
         Content = $Content

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -34,7 +34,7 @@ function Out-PodeWebTable
         # table output
         return @{
             Operation = 'Output'
-            ElementType = 'Table'
+            ObjectType = 'Table'
             Data = $items
             Sort = $Sort.IsPresent
             Columns = $_columns
@@ -154,7 +154,7 @@ function Update-PodeWebTable
         # table output
         return @{
             Operation = 'Update'
-            ElementType = 'Table'
+            ObjectType = 'Table'
             Data = $items
             ID = $Id
             Name = $Name
@@ -184,7 +184,7 @@ function Sync-PodeWebTable
 
     return @{
         Operation = 'Sync'
-        ElementType = 'Table'
+        ObjectType = 'Table'
         ID = $Id
         Name = $Name
     }
@@ -205,7 +205,7 @@ function Clear-PodeWebTable
 
     return @{
         Operation = 'Clear'
-        ElementType = 'Table'
+        ObjectType = 'Table'
         ID = $Id
         Name = $Name
     }
@@ -249,7 +249,7 @@ function Update-PodeWebTableRow
 
     return @{
         Operation = 'Update'
-        ElementType = 'TableRow'
+        ObjectType = 'TableRow'
         ID = $Id
         Name = $Name
         Row = @{
@@ -299,7 +299,7 @@ function Out-PodeWebChart
     end {
         return @{
             Operation = 'Output'
-            ElementType = 'Chart'
+            ObjectType = 'Chart'
             Data = $items
             ChartType = $Type
         }
@@ -345,7 +345,7 @@ function Update-PodeWebChart
     end {
         return @{
             Operation = 'Update'
-            ElementType = 'Chart'
+            ObjectType = 'Chart'
             Data = $items
             ID = $Id
             Name = $Name
@@ -409,7 +409,7 @@ function Sync-PodeWebChart
 
     return @{
         Operation = 'Sync'
-        ElementType = 'Chart'
+        ObjectType = 'Chart'
         ID = $Id
         Name = $Name
     }
@@ -430,7 +430,7 @@ function Clear-PodeWebChart
 
     return @{
         Operation = 'Clear'
-        ElementType = 'Chart'
+        ObjectType = 'Chart'
         ID = $Id
         Name = $Name
     }
@@ -485,7 +485,7 @@ function Out-PodeWebTextbox
 
         return @{
             Operation = 'Output'
-            ElementType = 'Textbox'
+            ObjectType = 'Textbox'
             Value = $items
             AsJson = $AsJson.IsPresent
             Multiline = $Multiline.IsPresent
@@ -536,7 +536,7 @@ function Update-PodeWebTextbox
 
         return @{
             Operation = 'Update'
-            ElementType = 'Textbox'
+            ObjectType = 'Textbox'
             Value = $items
             ID = $Id
             Name = $Name
@@ -565,7 +565,7 @@ function Clear-PodeWebTextbox
 
     return @{
         Operation = 'Clear'
-        ElementType = 'Textbox'
+        ObjectType = 'Textbox'
         ID = $Id
         Name = $Name
         Multiline = $Multiline.IsPresent
@@ -600,7 +600,7 @@ function Show-PodeWebToast
 
     return @{
         Operation = 'Show'
-        ElementType = 'Toast'
+        ObjectType = 'Toast'
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
         Title = [System.Net.WebUtility]::HtmlEncode($Title)
         Duration = $Duration
@@ -627,7 +627,7 @@ function Out-PodeWebValidation
 
     return @{
         Operation = 'Output'
-        ElementType = 'Validation'
+        ObjectType = 'Validation'
         Name = $Name
         ID = $Id
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
@@ -649,7 +649,7 @@ function Reset-PodeWebForm
 
     return @{
         Operation = 'Reset'
-        ElementType = 'Form'
+        ObjectType = 'Form'
         ID = $Id
         Name = $Name
     }
@@ -670,7 +670,7 @@ function Update-PodeWebText
 
     return @{
         Operation = 'Update'
-        ElementType = 'Text'
+        ObjectType = 'Text'
         ID = $Id
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
     }
@@ -695,7 +695,7 @@ function Set-PodeWebSelect
 
     return @{
         Operation = 'Set'
-        ElementType = 'Select'
+        ObjectType = 'Select'
         Name = $Name
         ID = $Id
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
@@ -730,7 +730,7 @@ function Update-PodeWebSelect
     end {
         return @{
             Operation = 'Update'
-            ElementType = 'Select'
+            ObjectType = 'Select'
             Name = $Name
             ID = $Id
             Options = $items
@@ -753,7 +753,7 @@ function Clear-PodeWebSelect
 
     return @{
         Operation = 'Clear'
-        ElementType = 'Select'
+        ObjectType = 'Select'
         Name = $Name
         ID = $Id
     }
@@ -774,7 +774,7 @@ function Sync-PodeWebSelect
 
     return @{
         Operation = 'Sync'
-        ElementType = 'Select'
+        ObjectType = 'Select'
         Name = $Name
         ID = $Id
     }
@@ -802,7 +802,7 @@ function Update-PodeWebBadge
 
     return @{
         Operation = 'Update'
-        ElementType = 'Badge'
+        ObjectType = 'Badge'
         ID = $Id
         Colour = $Colour
         ColourType = $ColourType.ToLowerInvariant()
@@ -833,7 +833,7 @@ function Update-PodeWebCheckbox
 
     return @{
         Operation = 'Update'
-        ElementType = 'Checkbox'
+        ObjectType = 'Checkbox'
         ID = $Id
         Name = $Name
         OptionId = $OptionId
@@ -864,7 +864,7 @@ function Show-PodeWebModal
 
     return @{
         Operation = 'Show'
-        ElementType = 'Modal'
+        ObjectType = 'Modal'
         ID = $Id
         Name = $Name
         DataValue = $DataValue
@@ -887,7 +887,7 @@ function Hide-PodeWebModal
 
     return @{
         Operation = 'Hide'
-        ElementType = 'Modal'
+        ObjectType = 'Modal'
         ID = $Id
         Name = $Name
     }
@@ -904,7 +904,7 @@ function Out-PodeWebError
 
     return @{
         Operation = 'Output'
-        ElementType = 'Error'
+        ObjectType = 'Error'
         Message = $Message
     }
 }
@@ -928,7 +928,7 @@ function Show-PodeWebNotification
 
     return @{
         Operation = 'Show'
-        ElementType = 'Notification'
+        ObjectType = 'Notification'
         Title = $Title
         Body = $Body
         Icon = $Icon
@@ -963,7 +963,7 @@ function Move-PodeWebPage
 
     return @{
         Operation = 'Move'
-        ElementType = 'Href'
+        ObjectType = 'Href'
         Url = $page
         NewTab = $NewTab.IsPresent
     }
@@ -983,7 +983,7 @@ function Move-PodeWebUrl
 
     return @{
         Operation = 'Move'
-        ElementType = 'Href'
+        ObjectType = 'Href'
         Url = $Url
         NewTab = $NewTab.IsPresent
     }
@@ -1004,7 +1004,7 @@ function Move-PodeWebTab
 
     return @{
         Operation = 'Move'
-        ElementType = 'Tab'
+        ObjectType = 'Tab'
         ID = $Id
         Name = $Name
     }
@@ -1025,7 +1025,7 @@ function Move-PodeWebAccordion
 
     return @{
         Operation = 'Move'
-        ElementType = 'Accordion'
+        ObjectType = 'Accordion'
         ID = $Id
         Name = $Name
     }
@@ -1038,7 +1038,7 @@ function Reset-PodeWebPage
 
     return @{
         Operation = 'Reset'
-        ElementType = 'Page'
+        ObjectType = 'Page'
     }
 }
 
@@ -1066,7 +1066,7 @@ function Out-PodeWebBreadcrumb
 
     return @{
         Operation = 'Output'
-        ElementType = 'Breadcrumb'
+        ObjectType = 'Breadcrumb'
         Items = $Items
     }
 }
@@ -1097,7 +1097,7 @@ function Update-PodeWebProgress
 
     return @{
         Operation = 'Update'
-        ElementType = 'Progress'
+        ObjectType = 'Progress'
         ID = $Id
         Name = $Name
         Colour = $Colour
@@ -1132,7 +1132,7 @@ function Update-PodeWebTile
 
     return @{
         Operation = 'Update'
-        ElementType = 'Tile'
+        ObjectType = 'Tile'
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         ID = $Id
         Name = $Name
@@ -1156,7 +1156,7 @@ function Sync-PodeWebTile
 
     return @{
         Operation = 'Sync'
-        ElementType = 'Tile'
+        ObjectType = 'Tile'
         ID = $Id
         Name = $Name
     }
@@ -1177,7 +1177,7 @@ function Update-PodeWebTheme
 
     return @{
         Operation = 'Update'
-        ElementType = 'Theme'
+        ObjectType = 'Theme'
         Name = $Name.ToLowerInvariant()
     }
 }
@@ -1189,6 +1189,6 @@ function Reset-PodeWebTheme
 
     return @{
         Operation = 'Reset'
-        ElementType = 'Theme'
+        ObjectType = 'Theme'
     }
 }

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -391,7 +391,7 @@ function Add-PodeWebPage
             $filteredLayouts = @()
 
             foreach ($item in $layouts) {
-                if ($item.LayoutType -ieq 'breadcrumb') {
+                if ($item.ObjectType -ieq 'breadcrumb') {
                     if ($null -ne $breadcrumb) {
                         throw "Cannot set two brecrumb trails on one page"
                     }

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -341,7 +341,7 @@ function setupSteppers() {
             if (isDynamic(step)) {
                 // serialize any step-form data
                 var data = serializeInputs(step);
-                var url = `/layouts/step/${step.attr('id')}`;
+                var url = getComponentUrl(step);
 
                 // send ajax req, and call next on no validation errors
                 sendAjaxReq(url, data, step, true, (res, sender) => {
@@ -373,14 +373,14 @@ function setupSteppers() {
             if (isDynamic(step)) {
                 // serialize any step-form data
                 var data = serializeInputs(step);
-                var url = `/layouts/step/${step.attr('id')}`;
+                var url = getComponentUrl(step);
 
                 // send ajax req, if not validation errors, send ajax for all steps
                 sendAjaxReq(url, data, step, true, (res, sender) => {
                     if (!hasValidationErrors(sender)) {
                         var _steps = sender.attr('for');
                         var _data = sender.closest('form.pode-stepper-form').serialize();
-                        var _url = `/layouts/steps/${_steps}`;
+                        var _url = getComponentUrl(_steps);
 
                         sendAjaxReq(_url, _data, sender, true);
                     }
@@ -389,7 +389,7 @@ function setupSteppers() {
             else {
                 var steps = step.attr('for');
                 var data = step.closest('form.pode-stepper-form').serialize();
-                var url = `/layouts/steps/${steps}`;
+                var url = getComponentUrl(steps);
 
                 sendAjaxReq(url, data, step, true);
             }
@@ -473,7 +473,10 @@ function sendAjaxReq(url, data, sender, useActions, successCallback, opts) {
         success: function(res, status, xhr) {
             // attempt to hide any spinners
             hideSpinner(sender);
-            unfocus(sender);
+
+            if (!opts.keepFocus) {
+                unfocus(sender);
+            }
 
             // attempt to get a filename, for downloading
             var filename = getAjaxFileName(xhr);
@@ -498,7 +501,11 @@ function sendAjaxReq(url, data, sender, useActions, successCallback, opts) {
         },
         error: function(err, msg, stack) {
             hideSpinner(sender);
-            unfocus(sender);
+
+            if (!opts.keepFocus) {
+                unfocus(sender);
+            }
+
             console.log(err);
             console.log(stack);
         }
@@ -642,7 +649,7 @@ function bindCodeEditors() {
         var button = getButton(e);
         var editorId = button.attr('for');
 
-        var url = `/elements/code-editor/${editorId}/upload`;
+        var url = `${getComponentUrl(editorId)}/upload`;
         var data = JSON.stringify({
             language: $(`#${editorId} .code-editor`).attr('pode-language'),
             value: _editors[editorId].getValue()
@@ -698,7 +705,7 @@ function bindTimers() {
 }
 
 function invokeTimer(timerId) {
-    sendAjaxReq(`/elements/timer/${timerId}`, null, null, true);
+    sendAjaxReq(getComponentUrl(timerId), null, null, true);
 }
 
 function bindSidebarToggle() {
@@ -1046,7 +1053,7 @@ function loadTable(tableId, opts) {
 
     // things get funky here if we have a table with a 'for' attr
     // if so, we need to serialize the form, and then send the request to the form instead
-    var url = `/elements/table/${tableId}`;
+    var url = getComponentUrl(table);
 
     if (table.attr('for')) {
         var form = $(`#${table.attr('for')}`);
@@ -1064,7 +1071,7 @@ function loadTable(tableId, opts) {
 
 function loadAutoCompletes() {
     $(`input[pode-autocomplete='True']`).each((i, e) => {
-        sendAjaxReq(`/elements/autocomplete/${$(e).attr('id')}`, null, null, false, (res) => {
+        sendAjaxReq(`${getComponentUrl($(e))}/autocomplete`, null, null, false, (res) => {
             $(e).autocomplete({ source: res.Values });
         });
     });
@@ -1083,7 +1090,7 @@ function loadTile(tileId, firstLoad = false) {
 
     var tile = $(`div.pode-tile[pode-dynamic="True"]#${tileId}`);
     if (tile.length > 0) {
-        sendAjaxReq(`/elements/tile/${tileId}`, null, tile, true);
+        sendAjaxReq(getComponentUrl(tile), null, tile, true);
     }
     else if (!firstLoad) {
         $(`div.pode-tile[pode-dynamic="False"]#${tileId} .pode-tile-body .pode-refresh-btn`).each((i, e) => {
@@ -1105,7 +1112,7 @@ function loadSelect(selectId) {
 
     var select = $(`select[pode-dynamic="True"]#${selectId}`);
     if (select.length > 0) {
-        sendAjaxReq(`/elements/select/${selectId}`, null, select, true);
+        sendAjaxReq(getComponentUrl(select), null, select, true);
     }
 }
 
@@ -1148,7 +1155,7 @@ function bindTileClick() {
         var tileId = $(e.target).closest('div.pode-tile').attr('id');
         var tile = $(`div.pode-tile#${tileId}`);
 
-        var url = `/elements/tile/${tileId}/click`;
+        var url = `${getComponentUrl(tile)}/click`;
         sendAjaxReq(url, null, tile, true);
     });
 }
@@ -1174,7 +1181,7 @@ function loadChart(chartId) {
 
     // things get funky here if we have a chart with a 'for' attr
     // if so, we need to serialize the form, and then send the request to the form instead
-    var url = `/elements/chart/${chartId}`;
+    var url = getComponentUrl(chart);
 
     if (chart.attr('for')) {
         var form = $(`#${chart.attr('for')}`);
@@ -1197,7 +1204,7 @@ function invokeActions(actions, sender) {
     actions = convertToArray(actions);
 
     actions.forEach((action) => {
-        var _type = action.ElementType;
+        var _type = action.ObjectType;
         if (_type) {
             _type = _type.toLowerCase();
         }
@@ -1307,7 +1314,7 @@ function buildElements(elements) {
     elements = convertToArray(elements);
 
     elements.forEach((ele) => {
-        var _type = ele.ElementType;
+        var _type = ele.ObjectType;
         if (_type) {
             _type = _type.toLowerCase();
         }
@@ -1477,7 +1484,7 @@ function bindButtons() {
             }
         }
 
-        var url = `/elements/button/${button.attr('id')}`;
+        var url = getComponentUrl(button);
         sendAjaxReq(url, data, button, true);
     });
 }
@@ -1648,7 +1655,7 @@ function bindTableButtons() {
         var table = $(`table#${tableId}`);
         var csv = exportTableAsCSV(tableId);
 
-        var url = `/elements/table/${tableId}/button/${button.attr('name')}`;
+        var url = `${getComponentUrl(table)}/button/${button.attr('name')}`;
         sendAjaxReq(url, csv, table, true, null, { contentType: 'text/csv' });
     });
 }
@@ -1724,7 +1731,7 @@ function updateTableRow(action) {
             var _html = '';
             var _value = action.Data[key];
 
-            if (Array.isArray(_value) || _value.ElementType) {
+            if (Array.isArray(_value) || _value.ObjectType) {
                 _html += buildElements(_value);
             }
             else {
@@ -1790,7 +1797,7 @@ function bindTableClickableRows(tableId) {
         }
 
         if (table.attr('pode-click-dynamic') == 'True') {
-            var url = `/elements/table/${table.attr('id')}/click`;
+            var url = `${getComponentUrl(table)}/click`;
             sendAjaxReq(url, data, null, true);
         }
         else {
@@ -1962,7 +1969,7 @@ function updateTable(action, sender) {
                 _value += `<td pode-column='${key}'>`;
             }
 
-            if (Array.isArray(item[key]) || (item[key] && item[key].ElementType)) {
+            if (Array.isArray(item[key]) || (item[key] && item[key].ObjectType)) {
                 _value += buildElements(item[key]);
             }
             else if (item[key]) {
@@ -3199,12 +3206,15 @@ function convertToArray(element) {
 }
 
 function invokeEvent(type, sender) {
-    // !!!
-    // could it be worth just making all layout/element urls: "/component/<type>/<id>" ?
-    // easier?
-    // and make it so every layout can contain anything. screw restrictions.
-
     sender = $(sender);
-    var url = `/${sender.attr('pode-comp-type')}s/${sender.attr('pode-comp-obj')}/${sender.attr('id')}/events/${type}`;
-    sendAjaxReq(url, null, sender, true);
+    var url = `${getComponentUrl(sender)}/events/${type}`;
+    sendAjaxReq(url, null, sender, true, null, { keepFocus: true });
+}
+
+function getComponentUrl(component) {
+    if (typeof component === 'string') {
+        component = $(`#${component}`);
+    }
+
+    return `/components/${component.attr('pode-object').toLowerCase()}/${component.attr('id')}`;
 }

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -3197,3 +3197,14 @@ function convertToArray(element) {
 
     return element;
 }
+
+function invokeEvent(type, sender) {
+    // !!!
+    // could it be worth just making all layout/element urls: "/component/<type>/<id>" ?
+    // easier?
+    // and make it so every layout can contain anything. screw restrictions.
+
+    sender = $(sender);
+    var url = `/${sender.attr('pode-comp-type')}s/${sender.attr('pode-comp-obj')}/${sender.attr('id')}/events/${type}`;
+    sendAjaxReq(url, null, sender, true);
+}

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -3208,7 +3208,7 @@ function convertToArray(element) {
 function invokeEvent(type, sender) {
     sender = $(sender);
     var url = `${getComponentUrl(sender)}/events/${type}`;
-    sendAjaxReq(url, null, sender, true, null, { keepFocus: true });
+    sendAjaxReq(url, sender.serialize(), sender, true, null, { keepFocus: true });
 }
 
 function getComponentUrl(component) {

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2917,10 +2917,10 @@ function buildButton(element) {
     }
 
     if (element.IconOnly) {
-        return `<button type='button' class='btn btn-icon-only pode-button' id='${element.ID}' pode-data-value='${element.DataValue}' title='${element.Name}' data-toggle='tooltip'>${icon}</button>`;
+        return `<button type='button' class='btn btn-icon-only pode-button' id='${element.ID}' pode-data-value='${element.DataValue}' title='${element.Name}' data-toggle='tooltip' pode-object='${element.ObjectType}'>${icon}</button>`;
     }
 
-    return `<button type='button' class='btn btn-${element.ColourType} pode-button' id='${element.ID}' pode-data-value='${element.DataValue}'>
+    return `<button type='button' class='btn btn-${element.ColourType} pode-button' id='${element.ID}' pode-data-value='${element.DataValue}' pode-object='${element.ObjectType}'>
         <span class='spinner-border spinner-border-sm' role='status' aria-hidden='true' style='display: none'></span>
         ${icon}${element.Name}
     </button>`;
@@ -2952,11 +2952,11 @@ function buildIcon(element) {
         rotate = `mdi-rotate-${element.Rotate}`;
     }
 
-    return `<span class='mdi mdi-${element.Name.toLowerCase()} ${spin} ${flip} ${rotate} mdi-size-20' ${colour} ${title}></span>`;
+    return `<span id='${element.ID}' class='mdi mdi-${element.Name.toLowerCase()} ${spin} ${flip} ${rotate} mdi-size-20' pode-object='${element.ObjectType}' ${colour} ${title} ${buildEvents(element.Events)}></span>`;
 }
 
 function buildBadge(element) {
-    return `<span id='${element.ID}' class='badge badge-${element.ColourType}'>${element.Value}</span>`;
+    return `<span id='${element.ID}' class='badge badge-${element.ColourType}' pode-object='${element.ObjectType}' ${buildEvents(element.Events)}>${element.Value}</span>`;
 }
 
 function buildSpinner(element) {
@@ -2970,7 +2970,7 @@ function buildSpinner(element) {
         title = `title='${element.Title}' data-toggle='tooltip'`;
     }
 
-    return `<span class="spinner-border spinner-border-sm" role="status" ${colour} ${title}></span>`;
+    return `<span id='${element.ID}' class="spinner-border spinner-border-sm" role="status" pode-object='${element.ObjectType}' ${colour} ${title}></span>`;
 }
 
 function buildLink(element) {
@@ -2979,7 +2979,7 @@ function buildLink(element) {
         target = '_blank';
     }
 
-    return `<a href='${element.Source}' id='${element.ID}' target='${target}'>${element.Value}</a>`;
+    return `<a href='${element.Source}' id='${element.ID}' target='${target}' pode-object='${element.ObjectType}' ${buildEvents(element.Events)}>${element.Value}</a>`;
 }
 
 function actionNotification(action) {
@@ -3217,4 +3217,19 @@ function getComponentUrl(component) {
     }
 
     return `/components/${component.attr('pode-object').toLowerCase()}/${component.attr('id')}`;
+}
+
+function buildEvents(events) {
+    if (!events) {
+        return '';
+    }
+
+    events = convertToArray(events);
+    var strEvents = '';
+
+    events.forEach((evt) => {
+        strEvents += `on${evt}="invokeEvent('${evt}', this);"`;
+    });
+
+    return strEvents;
 }

--- a/src/Templates/Views/elements/alert.pode
+++ b/src/Templates/Views/elements/alert.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="alert alert-$($data.ClassType) $($data.CssClasses)" role="alert">
+<div id="$($data.ID)" class="alert alert-$($data.ClassType) $($data.CssClasses)" pode-object="$($data.ObjectType)" role="alert" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     <h6 class='pode-alert-header'>
         <span class="mdi mdi-$($data.IconType)"></span>
         <strong>$($data.Type)</strong>

--- a/src/Templates/Views/elements/badge.pode
+++ b/src/Templates/Views/elements/badge.pode
@@ -1,3 +1,3 @@
-<span id="$($data.ID)" class="badge badge-$($data.ColourType) $($data.CssClasses)">
+<span id="$($data.ID)" class="badge badge-$($data.ColourType) $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     $($data.Value)
 </span>

--- a/src/Templates/Views/elements/button.pode
+++ b/src/Templates/Views/elements/button.pode
@@ -16,26 +16,26 @@
 
         if ($data.IconOnly) {
             if ($data.IsDynamic) {
-                "<button type='button' class='btn btn-icon-only pode-button $($data.CssClasses)' id='$($data.ID)' pode-data-value='$($data.DataValue)' title='$($data.Name)' data-toggle='tooltip'>
+                "<button type='button' class='btn btn-icon-only pode-button $($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)' pode-data-value='$($data.DataValue)' title='$($data.Name)' data-toggle='tooltip'>
                     $($icon)
                 </button>"
             }
             else {
-                "<a id='$($data.ID)' class='btn btn-icon-only pode-link-button $($data.CssClasses)' href='$($data.Url)' target='$($target)' role='button' title='$($data.Name)' data-toggle='tooltip'>
+                "<a id='$($data.ID)' class='btn btn-icon-only pode-link-button $($data.CssClasses)' pode-object='$($data.ObjectType)' href='$($data.Url)' target='$($target)' role='button' title='$($data.Name)' data-toggle='tooltip'>
                     $($icon)
                 </a>"
             }
         }
         else {
             if ($data.IsDynamic) {
-                "<button type='button' class='btn btn-$($data.ColourType) pode-button $($data.CssClasses)' id='$($data.ID)' pode-data-value='$($data.DataValue)'>
+                "<button type='button' class='btn btn-$($data.ColourType) pode-button $($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)' pode-data-value='$($data.DataValue)'>
                     <span class='spinner-border spinner-border-sm' role='status' aria-hidden='true' style='display: none'></span>
                     $($icon)
                     $($data.Name)
                 </button>"
             }
             else {
-                "<a id='$($data.ID)' class='btn pode-link-button btn-$($data.ColourType) $($data.CssClasses)' href='$($data.Url)' target='$($target)' role='button'>
+                "<a id='$($data.ID)' class='btn pode-link-button btn-$($data.ColourType) $($data.CssClasses)' pode-object='$($data.ObjectType)' href='$($data.Url)' target='$($target)' role='button'>
                     $($icon)
                     $($data.Name)
                 </a>"

--- a/src/Templates/Views/elements/chart.pode
+++ b/src/Templates/Views/elements/chart.pode
@@ -18,6 +18,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
         id="$($data.ID)"
         name="$($data.Name)"
         style="$(if ($data.Height -gt 0) { "height:$($data.Height)px;" })"
+        pode-object="$($data.ObjectType)"
         pode-chart-type="$($data.ChartType)"
         pode-dynamic="$($data.IsDynamic)"
         pode-append="$($data.Append)"

--- a/src/Templates/Views/elements/checkbox.pode
+++ b/src/Templates/Views/elements/checkbox.pode
@@ -17,10 +17,12 @@
                 $checked = 'checked'
             }
 
+            $events = ConvertTo-PodeWebEvents -Events $data.Events
+
             for ($i = 0; $i -lt $data.Options.Length; $i++) {
                 if ($data.AsSwitch) {
                     "<div class='custom-control custom-switch $($inline)'>
-                        <input type='checkbox' class='custom-control-input' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked)>
+                        <input type='checkbox' class='custom-control-input' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' pode-object='$($data.ObjectType)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked) $($events)>
                         <label class='custom-control-label' for='$($data.ID)_option$($i)'>
                             $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })
                         </label>
@@ -28,7 +30,7 @@
                 }
                 else {
                     "<div class='form-check $($inline)'>
-                        <input class='form-check-input' type='checkbox' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked)>
+                        <input class='form-check-input' type='checkbox' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' pode-object='$($data.ObjectType)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked) $($events)>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
                             $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })
                         </label>

--- a/src/Templates/Views/elements/code-editor.pode
+++ b/src/Templates/Views/elements/code-editor.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="pode-code-editor $($data.CssClasses)">
+<div id="$($data.ID)" class="pode-code-editor $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     $(if ($data.Uploadable) {
         "<button class='btn btn-inbuilt-theme pode-upload mBottom1' type='button' title='Upload' data-toggle='tooltip' for='$($data.ID)'>
             <span class='mdi mdi-upload mRight02'></span>

--- a/src/Templates/Views/elements/code.pode
+++ b/src/Templates/Views/elements/code.pode
@@ -1,1 +1,1 @@
-<code id="$($data.ID)" class="$($data.CssClasses)">$($data.Value)</code>
+<code id="$($data.ID)" class="$($data.CssClasses)" pode-object="$($data.ObjectType)">$($data.Value)</code>

--- a/src/Templates/Views/elements/codeblock.pode
+++ b/src/Templates/Views/elements/codeblock.pode
@@ -10,7 +10,7 @@ $(
         <span class='mdi mdi-clipboard-text-multiple-outline mdi-size-20 mRight02'></span>
     </button>
 
-    <code id="$($data.ID)" class="$($data.Language)">
+    <code id="$($data.ID)" class="$($data.Language)" pode-object="$($data.ObjectType)">
         $($data.Value)
     </code>
 </pre>

--- a/src/Templates/Views/elements/comment.pode
+++ b/src/Templates/Views/elements/comment.pode
@@ -1,4 +1,4 @@
-<div class="media $($data.CssClasses)">
+<div id="$($data.ID)" class="media $($data.CssClasses)" pode-object="$($data.ObjectType)">
     <img src="$($data.Icon)" class="align-self-start mr-3" alt="$($data.Username) icon">
     <div class="media-body">
         <div class="media-head">

--- a/src/Templates/Views/elements/credential.pode
+++ b/src/Templates/Views/elements/credential.pode
@@ -14,7 +14,7 @@
 
             $placeholder = [string]::Empty
 
-            "<div class='form-row' id='$($data.ID)' name='$($data.Name)'>
+            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>
                 <div class='form-group col-md-6'>"
                     if (!$data.NoLabels) {
                         "<label for='$($data.ID)_username'>Username</label>"

--- a/src/Templates/Views/elements/datetime.pode
+++ b/src/Templates/Views/elements/datetime.pode
@@ -12,7 +12,7 @@
                 $readOnly = "readonly"
             }
 
-            "<div class='form-row' id='$($data.ID)' name='$($data.Name)'>
+            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>
                 <div class='form-group col-md-6'>"
                     if (!$data.NoLabels) {
                         "<label for='$($data.ID)_date'>Date</label>"

--- a/src/Templates/Views/elements/filestream.pode
+++ b/src/Templates/Views/elements/filestream.pode
@@ -35,9 +35,11 @@
                 pode-interval="$($data.Interval)"
                 pode-streaming="1"
                 id="$($data.ID)"
+                pode-object="$($data.ObjectType)"
                 name="$($data.Name)"
                 rows="$($data.Height)"
-                readonly></textarea>
+                readonly
+                $(ConvertTo-PodeWebEvents -Events $data.Events)></textarea>
         </pre>
     </div>
 </div>

--- a/src/Templates/Views/elements/fileupload.pode
+++ b/src/Templates/Views/elements/fileupload.pode
@@ -1,7 +1,7 @@
 <div class="form-group row pode-form-upload $($data.CssClasses)">
     <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
     <div class="col-sm-10">
-        <input type='file' class='form-control-file' id="$($data.ID)" name="$($data.Name)">
+        <input type='file' class='form-control-file' id="$($data.ID)" name="$($data.Name)" pode-object="$($data.ObjectType)">
         <div id="$($data.ID)_validation" class="invalid-feedback"></div>
     </div>
 </div>

--- a/src/Templates/Views/elements/form.pode
+++ b/src/Templates/Views/elements/form.pode
@@ -2,7 +2,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
     "<p class='card-text'>$($data.Message)</p>"
 })
 
-<form id="$($data.ID)" name="$($data.Name)" class="pode-form $($data.CssClasses)" action="POST" method="/elements/form/$($data.ID)">
+<form id="$($data.ID)" name="$($data.Name)" class="pode-form $($data.CssClasses)" action="POST" method="/components/form/$($data.ID)" pode-object="$($data.ObjectType)">
     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })
     <button class="btn btn-inbuilt-theme" type="submit">
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none"></span>

--- a/src/Templates/Views/elements/header.pode
+++ b/src/Templates/Views/elements/header.pode
@@ -1,6 +1,6 @@
 $(
     $value = $data.Value
-    $header = "<h$($data.Size) id='$($data.ID)' class='$($data.CssClasses)'>$($value)"
+    $header = "<h$($data.Size) id='$($data.ID)' class='$($data.CssClasses)' pode-object='$($data.ObjectType)'>$($value)"
 
     if (![string]::IsNullOrWhiteSpace($data.Secondary)) {
         $sub = $data.Secondary

--- a/src/Templates/Views/elements/hidden.pode
+++ b/src/Templates/Views/elements/hidden.pode
@@ -1,5 +1,5 @@
 <div class="form-group row pode-form-hidden $($data.CssClasses)">
     <div class="col-sm-10">
-        <input type="hidden" class="form-control" id="$($data.ID)" name="$($data.Name)" value="$($data.Value)">
+        <input type="hidden" class="form-control" id="$($data.ID)" name="$($data.Name)" value="$($data.Value)" pode-object="$($data.ObjectType)">
     </div>
 </div>

--- a/src/Templates/Views/elements/icon.pode
+++ b/src/Templates/Views/elements/icon.pode
@@ -24,5 +24,5 @@ $(
         $rotate = "mdi-rotate-$($data.Rotate)"
     }
 
-    "<span class='mdi mdi-$($data.Name) $($spin) $($flip) $($rotate) $($data.CssClasses)' $($colour) $($title)></span>"
+    "<span id='$($data.ID)' class='mdi mdi-$($data.Name) pode-object='$($data.ObjectType)' $($spin) $($flip) $($rotate) $($data.CssClasses)' $($colour) $($title) $(ConvertTo-PodeWebEvents -Events $data.Events)></span>"
 )

--- a/src/Templates/Views/elements/iframe.pode
+++ b/src/Templates/Views/elements/iframe.pode
@@ -1,1 +1,7 @@
-<iframe src="$($data.Url)" title="$($data.Title)" id="$($data.ID)" name="$($data.Name)"></iframe>
+<iframe
+    src="$($data.Url)"
+    title="$($data.Title)"
+    id="$($data.ID)"
+    name="$($data.Name)"
+    pode-object="$($data.ObjectType)">
+</iframe>

--- a/src/Templates/Views/elements/image.pode
+++ b/src/Templates/Views/elements/image.pode
@@ -37,5 +37,5 @@ $(
         $title = "title='$($data.Title)' data-toggle='tooltip' data-placement='bottom'"
     }
 
-    "<img src='$($data.Source)' id='$($data.ID)' class='$($fluid) rounded $($loc) $($data.CssClasses)' $($title) $($dim)>"
+    "<img src='$($data.Source)' id='$($data.ID)' class='$($fluid) rounded $($loc) $($data.CssClasses)' pode-object='$($data.ObjectType)' $($title) $($dim) $(ConvertTo-PodeWebEvents -Events $data.Events)>"
 )

--- a/src/Templates/Views/elements/line.pode
+++ b/src/Templates/Views/elements/line.pode
@@ -1,1 +1,1 @@
-<hr class="my-4 $($data.CssClasses)">
+<hr id="$($data.ID)" class="my-4 $($data.CssClasses)" pode-object="$($data.ObjectType)">

--- a/src/Templates/Views/elements/link.pode
+++ b/src/Templates/Views/elements/link.pode
@@ -4,5 +4,5 @@ $(
         $target = '_blank'
     }
 
-    "<a href='$($data.Source)' id='$($data.ID)' target='$($target)' class='$($data.CssClasses)'>$($data.Value)</a>"
+    "<a href='$($data.Source)' id='$($data.ID)' target='$($target)' class='$($data.CssClasses)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>$($data.Value)</a>"
 )

--- a/src/Templates/Views/elements/list.pode
+++ b/src/Templates/Views/elements/list.pode
@@ -4,7 +4,7 @@ $(
         $tag = 'ol'
     }
 
-    "<$($tag) class='$($data.CssClasses)' id='$($data.ID)'>"
+    "<$($tag) class='$($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)'>"
 
     if (($null -ne $data.Items) -and ($data.Items.Length -gt 0)) {
         foreach ($item in $data.Items) {

--- a/src/Templates/Views/elements/minmax.pode
+++ b/src/Templates/Views/elements/minmax.pode
@@ -34,7 +34,7 @@
                 }
             }
 
-            "<div class='form-row' id='$($data.ID)' name='$($data.Name)'>
+            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>
                 <div class='form-group col-md-6'>"
                     if (!$data.NoLabels) {
                         "<label for='$($data.ID)_min'>Minimum</label>"

--- a/src/Templates/Views/elements/paragraph.pode
+++ b/src/Templates/Views/elements/paragraph.pode
@@ -1,4 +1,4 @@
-<p id="$($data.ID)" class="text-$($data.Alignment) $($data.CssClasses)">
+<p id="$($data.ID)" class="text-$($data.Alignment) $($data.CssClasses)" pode-object="$($data.ObjectType)">
     $(if (![string]::IsNullOrWhiteSpace($data.Value)) {
         $data.Value
     }

--- a/src/Templates/Views/elements/progress.pode
+++ b/src/Templates/Views/elements/progress.pode
@@ -19,11 +19,13 @@ $(
                 class='progress-bar bg-$($data.ColourType) $($showValue) $($striped) $($animated)'
                 id='$($data.ID)'
                 name='$($data.Name)'
+                pode-object='$($data.ObjectType)'
                 role='progressbar'
                 style='width: $($data.Percentage)%;'
                 aria-valuenow='$($data.Value)'
                 aria-valuemin='$($data.Min)'
-                aria-valuemax='$($data.Max)'>
+                aria-valuemax='$($data.Max)'
+                $(ConvertTo-PodeWebEvents -Events $data.Events)>
             </div>
         </div>"
 

--- a/src/Templates/Views/elements/quote.pode
+++ b/src/Templates/Views/elements/quote.pode
@@ -1,7 +1,7 @@
 $(
     $value = $data.Value
 
-    $quote = "<blockquote class='blockquote text-$($data.Alignment) $($data.CssClasses)' id='$($data.ID)'>
+    $quote = "<blockquote class='blockquote text-$($data.Alignment) $($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)'>
         <p class='pode-text mb-0'>$($value)</p>"
 
     if (![string]::IsNullOrWhiteSpace($data.Source)) {

--- a/src/Templates/Views/elements/radio.pode
+++ b/src/Templates/Views/elements/radio.pode
@@ -10,7 +10,7 @@
 
                 for ($i = 0; $i -lt $data.Options.Length; $i++) {
                     "<div class='form-check $($inline)'>
-                        <input class='form-check-input' type='radio' name='$($data.Name)' id='$($data.ID)_option$($i)' value='$($data.Options[$i])' $(if ($i -eq 0) { 'checked' }) $(if ($data.Disabled) { 'disabled' })>
+                        <input class='form-check-input' type='radio' name='$($data.Name)' id='$($data.ID)_option$($i)' value='$($data.Options[$i])' pode-object='$($data.ObjectType)' $(if ($i -eq 0) { 'checked' }) $(if ($data.Disabled) { 'disabled' }) $(ConvertTo-PodeWebEvents -Events $data.Events)>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
                             $($data.Options[$i])
                         </label>

--- a/src/Templates/Views/elements/range.pode
+++ b/src/Templates/Views/elements/range.pode
@@ -7,7 +7,7 @@
                 $showValue = 'pode-range-value'
             }
 
-            "<input type='range' class='form-control-range $($showValue)' id='$($data.ID)' name='$($data.Name)' value='$($data.Value)' min='$($data.Min)' max='$($data.Max)' $(if ($data.Disabled) { 'disabled' })>"
+            "<input type='range' class='form-control-range $($showValue)' id='$($data.ID)' pode-object='$($data.ObjectType)' name='$($data.Name)' value='$($data.Value)' min='$($data.Min)' max='$($data.Max)' $(if ($data.Disabled) { 'disabled' }) $(ConvertTo-PodeWebEvents -Events $data.Events)>"
 
             if ($data.ShowValue) {
                 "<input type='number' class='form-control $($showValue)' id='$($data.ID)_value' for='$($data.ID)' value='$($data.Value)' min='$($data.Min)' max='$($data.Max)'>"

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -7,7 +7,14 @@
                 $multiple = "multiple size='$($data.Size)'"
             }
 
-            "<select class='custom-select' id='$($data.ID)' name='$($data.Name)' pode-dynamic='$($data.IsDynamic)' $($multiple)>"
+            $events = [string]::Empty
+            if ($null -ne $data.Events) {
+                foreach ($evt in $data.Events) {
+                    $events += " on$($evt)=`"invokeEvent('$($evt)', this);`""
+                }
+            }
+
+            "<select class='custom-select' id='$($data.ID)' pode-comp-type='$($data.ComponentType)' pode-comp-obj='$($data.ElementType)' name='$($data.Name)' pode-dynamic='$($data.IsDynamic)' $($multiple) $($events)>"
 
             foreach ($option in $data.Options) {
                 if ([string]::IsNullOrWhiteSpace($option)) {

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -7,14 +7,15 @@
                 $multiple = "multiple size='$($data.Size)'"
             }
 
-            $events = [string]::Empty
-            if ($null -ne $data.Events) {
-                foreach ($evt in $data.Events) {
-                    $events += " on$($evt)=`"invokeEvent('$($evt)', this);`""
-                }
-            }
-
-            "<select class='custom-select' id='$($data.ID)' pode-comp-type='$($data.ComponentType)' pode-comp-obj='$($data.ElementType)' name='$($data.Name)' pode-dynamic='$($data.IsDynamic)' $($multiple) $($events)>"
+            "<select
+                class='custom-select'
+                id='$($data.ID)'
+                name='$($data.Name)'
+                pode-object='$($data.ObjectType)'
+                pode-dynamic='$($data.IsDynamic)'
+                $($multiple)
+                $(ConvertTo-PodeWebEvents -Events $data.Events)
+            >"
 
             foreach ($option in $data.Options) {
                 if ([string]::IsNullOrWhiteSpace($option)) {

--- a/src/Templates/Views/elements/spinner.pode
+++ b/src/Templates/Views/elements/spinner.pode
@@ -9,5 +9,5 @@ $(
         $title = "title='$($data.Title)' data-toggle='tooltip'"
     }
 
-    "<span class='spinner-border spinner-border-sm $($data.CssClasses)' role='status' $($colour) $($title)></span>"
+    "<span id='$($data.ID)' class='spinner-border spinner-border-sm $($data.CssClasses)' pode-object='$($data.ObjectType)' role='status' $($colour) $($title)></span>"
 )

--- a/src/Templates/Views/elements/table.pode
+++ b/src/Templates/Views/elements/table.pode
@@ -20,6 +20,7 @@ $(if ($data.Filter.Enabled) {
             "<table
                 id='$($data.ID)'
                 name='$($data.Name)'
+                pode-object='$($data.ObjectType)'
                 class='table table-striped table-hover $($click)'
                 pode-dynamic='$($data.IsDynamic)'
                 pode-click-dynamic='$($data.ClickIsDynamic)'

--- a/src/Templates/Views/elements/text.pode
+++ b/src/Templates/Views/elements/text.pode
@@ -1,10 +1,5 @@
 $(
-    $id = [string]::Empty
-    if (![string]::IsNullOrWhiteSpace($data.ID)) {
-        $id = "id='$($data.ID)'"
-    }
-
-    $value = "<span class='pode-text $($data.CssClasses)' $($id)>$($data.Value)</span>"
+    $value = "<span id='$($data.ID)' class='pode-text $($data.CssClasses)' pode-object='$($data.ObjectType)'>$($data.Value)</span>"
 
     switch ($data.Style.ToLowerInvariant()) {
         'underlined' {

--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -24,8 +24,10 @@
                 $width = "width: $($data.Width)%;"
             }
 
+            $events = ConvertTo-PodeWebEvents -Events $data.Events
+
             if ($data.Multiline) {
-                $element = "<textarea class='form-control' id='$($data.ID)' name='$($data.Name)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width)' $($describedBy) $($readOnly) $($value)></textarea>"
+                $element = "<textarea class='form-control' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width)' $($describedBy) $($readOnly) $($value) $($events)></textarea>"
             }
             else {
                 if ($data.Prepend.Enabled -or $data.Append.Enabled) {
@@ -46,7 +48,7 @@
                     $_type = 'datetime-local'
                 }
 
-                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control' id='$($data.ID)' name='$($data.Name)' style='$($width)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($value)>"
+                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' style='$($width)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($value) $($events)>"
 
                 if ($data.Append.Enabled) {
                     if (![string]::IsNullOrWhiteSpace($data.Append.Text)) {

--- a/src/Templates/Views/elements/tile.pode
+++ b/src/Templates/Views/elements/tile.pode
@@ -2,7 +2,7 @@ $(if ($data.NewLine) {
     "<br/>"
 })
 
-<div id="$($data.ID)" class="container pode-tile alert-$($data.ColourType) rounded $($data.CssClasses)" name="$($data.Name)" pode-dynamic="$($data.IsDynamic)" pode-click="$($data.Click)" pode-auto-refresh="$($data.AutoRefresh)" pode-refresh-interval="$($data.RefreshInterval)">
+<div id="$($data.ID)" class="container pode-tile alert-$($data.ColourType) rounded $($data.CssClasses)" pode-object="$($data.ObjectType)" name="$($data.Name)" pode-dynamic="$($data.IsDynamic)" pode-click="$($data.Click)" pode-auto-refresh="$($data.AutoRefresh)" pode-refresh-interval="$($data.RefreshInterval)">
     <h6 class="pode-tile-header">
         $(if (![string]::IsNullOrWhiteSpace($data.Icon)) {
             "<span class='mdi mdi-$($data.Icon.ToLowerInvariant())'></span>"

--- a/src/Templates/Views/elements/timer.pode
+++ b/src/Templates/Views/elements/timer.pode
@@ -1,1 +1,6 @@
-<span id="$($data.ID)" class="hide pode-timer $($data.CssClasses)" pode-interval="$($data.Interval)"></span>
+<span
+    id="$($data.ID)"
+    class="hide pode-timer $($data.CssClasses)"
+    pode-interval="$($data.Interval)"
+    pode-object="$($data.ObjectType)">
+</span>

--- a/src/Templates/Views/layouts/accordion.pode
+++ b/src/Templates/Views/layouts/accordion.pode
@@ -16,7 +16,7 @@
         }
 
         "<div class='card bellow' id='$($bellow.ID)' name='$($bellow.Name)' pode-object='$($bellow.ObjectType)'>
-            <div class='card-header bellow-head' id='$($bellow.ID)_head'>
+            <div class='card-header bellow-header' id='$($bellow.ID)_head'>
                 <h2 class='mb-0'>
                     <button class='btn btn-link btn-block text-left $($collapsed)' type='button' data-toggle='collapse' data-target='#$($bellow.ID)_body' aria-expanded='$($expanded)' aria-controls='$($bellow.ID)_body'>"
                         if (![string]::IsNullOrWhiteSpace($bellow.Icon)) {

--- a/src/Templates/Views/layouts/accordion.pode
+++ b/src/Templates/Views/layouts/accordion.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="accordion $($data.CssClasses)" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)" pode-mode="$($data.Mode.ToLowerInvariant())">
+<div id="$($data.ID)" class="accordion $($data.CssClasses)" pode-object="$($data.ObjectType)" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)" pode-mode="$($data.Mode.ToLowerInvariant())">
 
     $(for ($i = 0; $i -lt $data.Bellows.Length; $i++) {
         $bellow = $data.Bellows[$i]
@@ -15,7 +15,7 @@
             $arrow = 'down'
         }
 
-        "<div class='card bellow' id='$($bellow.ID)' name='$($bellow.Name)'>
+        "<div class='card bellow' id='$($bellow.ID)' name='$($bellow.Name)' pode-object='$($bellow.ObjectType)'>
             <div class='card-header bellow-head' id='$($bellow.ID)_head'>
                 <h2 class='mb-0'>
                     <button class='btn btn-link btn-block text-left $($collapsed)' type='button' data-toggle='collapse' data-target='#$($bellow.ID)_body' aria-expanded='$($expanded)' aria-controls='$($bellow.ID)_body'>"

--- a/src/Templates/Views/layouts/card.pode
+++ b/src/Templates/Views/layouts/card.pode
@@ -1,4 +1,4 @@
-<div class="card pode-card $($data.CssClasses)">
+<div id="$($data.ID)" class="card pode-card $($data.CssClasses)" pode-object="$($data.ObjectType)">
     $(if ((!$data.NoTitle -and $data.Name) -or !$data.NoHide) {
         $icon = [string]::Empty
         if (![string]::IsNullOrWhiteSpace($data.Icon)) {

--- a/src/Templates/Views/layouts/carousel.pode
+++ b/src/Templates/Views/layouts/carousel.pode
@@ -7,7 +7,7 @@
 
     <div class="carousel-inner">
         $(for ($i = 0; $i -lt $data.Slides.Length; $i++) {
-            "<div class='carousel-item $(if ($i -eq 0) { "active" })'>"
+            "<div id='$($data.Slides[$i].ID)' pode-object='$($data.Slides[$i].ObjectType)' class='carousel-item $(if ($i -eq 0) { "active" })'>"
 
                 "<div class='d-flex w-100 h-100'>"
                 Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Slides[$i].Content }

--- a/src/Templates/Views/layouts/container.pode
+++ b/src/Templates/Views/layouts/container.pode
@@ -1,3 +1,4 @@
-<div class="container pode-container $($data.CssClasses)" pode-transparent="$($data.NoBackground)" pode-hidden="$($data.Hide)">
+
+<div id="$($data.ID)" class="container pode-container $($data.CssClasses)" pode-object="$($data.ObjectType)" pode-transparent="$($data.NoBackground)" pode-hidden="$($data.Hide)">
     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })
 </div>

--- a/src/Templates/Views/layouts/grid.pode
+++ b/src/Templates/Views/layouts/grid.pode
@@ -1,4 +1,4 @@
-<div class="container pode-grid $($data.CssClasses)">
+<div id="$($data.ID)" class="container pode-grid $($data.CssClasses)" pode-object="$($data.ObjectType)">
     <div class='row'>
 
     $(
@@ -17,7 +17,7 @@
                 $width = "col-$($cell.Width)"
             }
 
-            "<div class='$($width)'>"
+            "<div id='$($cell.ID)' class='$($width)' pode-object='$($cell.ObjectType)'>"
                 Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $cell.Content }
             "</div>"
         }

--- a/src/Templates/Views/layouts/hero.pode
+++ b/src/Templates/Views/layouts/hero.pode
@@ -1,4 +1,4 @@
-<div class="jumbotron $($data.CssClasses)">
+<div id="$($data.ID)" class="jumbotron $($data.CssClasses)" pode-object="$($data.ObjectType)">
     <h1 class="display-4">$($data.Title)</h1>
     <p class="lead">$($data.Message)</p>
 

--- a/src/Templates/Views/layouts/modal.pode
+++ b/src/Templates/Views/layouts/modal.pode
@@ -1,4 +1,4 @@
-<div class="modal fade $($data.CssClasses)" id="$($data.ID)" name="$($data.Name)" tabindex="-1" aria-labelledby="$($data.ID)_lbl" aria-hidden="true" pode-data-value="">
+<div class="modal fade $($data.CssClasses)" id="$($data.ID)" pode-object="$($data.ObjectType)" name="$($data.Name)" tabindex="-1" aria-labelledby="$($data.ID)_lbl" aria-hidden="true" pode-data-value="">
     <div class="modal-dialog modal-dialog-scrollable pode-modal-$($data.Size.ToLowerInvariant())">
         <div class="modal-content">
 
@@ -32,7 +32,7 @@
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">$($data.CloseText)</button>
 
                 $(if ($data.ShowSubmit) {
-                    "<button type='button' class='btn btn-inbuilt-theme pode-modal-submit' pode-url='/layouts/modal/$($data.ID)' pode-modal-form='$($data.AsForm)'>$($data.SubmitText)</button>"
+                    "<button type='button' class='btn btn-inbuilt-theme pode-modal-submit' pode-url='/components/modal/$($data.ID)' pode-modal-form='$($data.AsForm)'>$($data.SubmitText)</button>"
                 })
             </div>
 

--- a/src/Templates/Views/layouts/steps.pode
+++ b/src/Templates/Views/layouts/steps.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="bs-stepper linear $($data.CssClasses)" role="stepper">
+<div id="$($data.ID)" class="bs-stepper linear $($data.CssClasses)" role="stepper" pode-object="$($data.ObjectType)">
 
     <div class="bs-stepper-header" role="tablist">
         $(for ($i = 0; $i -lt $data.Steps.Length; $i++) {
@@ -30,7 +30,7 @@
             $(for ($i = 0; $i -lt $data.Steps.Length; $i++) {
                 $step = $data.Steps[$i]
 
-                "<div id='$($step.ID)' role='tabpanel' class='bs-stepper-pane content fade $(if ($i -eq 0) { "active" })' aria-labelledby='$($step.ID)-trigger' for='$($data.ID)' pode-dynamic='$($step.IsDynamic)'>"
+                "<div id='$($step.ID)' pode-object='$($step.ObjectType)' role='tabpanel' class='bs-stepper-pane content fade $(if ($i -eq 0) { "active" })' aria-labelledby='$($step.ID)-trigger' for='$($data.ID)' pode-dynamic='$($step.IsDynamic)'>"
                     Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $step.Content }
 
                     if ($i -gt 0) {

--- a/src/Templates/Views/layouts/tabs.pode
+++ b/src/Templates/Views/layouts/tabs.pode
@@ -1,4 +1,4 @@
-<ul class="nav nav-tabs $($data.CssClasses)" role="tablist" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)">
+<ul id="$($data.ID)" class="nav nav-tabs $($data.CssClasses)" pode-object="$($data.ObjectType)" role="tablist" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)">
     $(for ($i = 0; $i -lt $data.Tabs.Length; $i++) {
         $tab = $data.Tabs[$i]
 
@@ -12,6 +12,7 @@
                 id='$($tab.ID)'
                 name='$($tab.Name)'
                 class='nav-link $(if ($i -eq 0) { "active" })'
+                pode-object='$($tab.ObjectType)'
                 data-toggle='tab' href='#$($tab.ID)_content'
                 role='tab'
                 pode-prev='$($data.Tabs[$i - 1].ID)'

--- a/src/Templates/Views/shared/_load.pode
+++ b/src/Templates/Views/shared/_load.pode
@@ -5,11 +5,11 @@ $(foreach ($item in $data.Content) {
 
     switch ($item.ComponentType.ToLowerInvariant()) {
         'layout' {
-            Use-PodeWebPartialView -Path "layouts/$($item.LayoutType.ToLowerInvariant())" -Data $item
+            Use-PodeWebPartialView -Path "layouts/$($item.ObjectType.ToLowerInvariant())" -Data $item
         }
 
         'element' {
-            Use-PodeWebPartialView -Path "elements/$($item.ElementType.ToLowerInvariant())" -Data $item
+            Use-PodeWebPartialView -Path "elements/$($item.ObjectType.ToLowerInvariant())" -Data $item
         }
 
         'navigation' {


### PR DESCRIPTION
### Description of the Change
Add support for most elements to be able to have JS events registered. This is done via a new `Register-PodeWebEvent`, that you can pipe your element into. The supported events are:

* Change
* Focus
* FocusOut
* Click
* MouseOver
* MouseOut
* KeyDown
* KeyUp

Similar to say a Button's click scriptblock, these events can run whatever logic you like, including returning output actions for Pode.Web to action against on the frontend.

### Related Issue
Resolves #156 

### Examples
Let's say you want to have a Select element, but not in a form. When the Select's current value is changed, you want to run a script to show a message:

```powershell
New-PodeWebSelect -Name 'Role' -Options @('Choose...', 'User', 'Admin', 'Operations') |
    Register-PodeWebEvent -Type Change -ScriptBlock {
        Show-PodeWebToast -Message "The value was changed: $($WebEvent.Data['Role'])"
    }
```

If the element the event triggers for is a form input element, the value will be serialised and available in `$WebEvent.Data`.