### PR TITLE
Add new -NoForm switch on most form elements

### DIFF
--- a/docs/Tutorials/Elements/Checkbox.md
+++ b/docs/Tutorials/Elements/Checkbox.md
@@ -39,3 +39,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![checkbox_multi](../../../images/checkbox_multi.png)
+
+## Inline
+
+You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.

--- a/docs/Tutorials/Elements/FileUpload.md
+++ b/docs/Tutorials/Elements/FileUpload.md
@@ -19,3 +19,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![file_upload](../../../images/file_upload.png)
+
+## Inline
+
+You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.

--- a/docs/Tutorials/Elements/Radio.md
+++ b/docs/Tutorials/Elements/Radio.md
@@ -19,3 +19,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![radio](../../../images/radio.png)
+
+## Inline
+
+You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.

--- a/docs/Tutorials/Elements/Range.md
+++ b/docs/Tutorials/Elements/Range.md
@@ -19,3 +19,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![range](../../../images/range.png)
+
+## Inline
+
+You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.

--- a/docs/Tutorials/Elements/Select.md
+++ b/docs/Tutorials/Elements/Select.md
@@ -58,3 +58,7 @@ New-PodeWebCard -Content @(
 ## Multiple
 
 You can render a multiple select element, where more than one option can be selected, by using the `-Multiple` switch. By default only the first 4 options are shown, this can be altered using the `-Size` parameter.
+
+## Inline
+
+You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.

--- a/docs/Tutorials/Elements/Textbox.md
+++ b/docs/Tutorials/Elements/Textbox.md
@@ -71,3 +71,7 @@ Which looks like below:
 ![textbox_multi](../../../images/textbox_multi.png)
 
 By default it shows the first 4 lines of text, this can be altered using the `-Size` parameter.
+
+## Inline
+
+You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.

--- a/examples/input_events.ps1
+++ b/examples/input_events.ps1
@@ -1,0 +1,114 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer -Threads 2 {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Input Events' -Theme Dark
+
+
+    # select event
+    $select = New-PodeWebContainer -Content @(
+        New-PodeWebText -Value 'Please select a value: '
+        New-PodeWebSelect -Name 'Bellows' -NoForm -Options 'Bellow 1', 'Bellow 2', 'Bellow 3' |
+            Register-PodeWebEvent -Type Change -ScriptBlock {
+                Move-PodeWebAccordion -Name $WebEvent.Data['Bellows']
+            }
+    )
+
+    $acc1 = New-PodeWebAccordion -Bellows @(
+        New-PodeWebBellow -Name 'Bellow 1' -Icon 'information' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebBellow -Name 'Bellow 2' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebBellow -Name 'Bellow 3' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+    )
+
+    Add-PodeWebPage -Name 'Select' -Layouts $select, $acc1
+
+
+    # textbox event
+    $textbox = New-PodeWebContainer -Content @(
+        New-PodeWebText -Value 'Search for processes: '
+        New-PodeWebTextbox -Name 'Filter' -NoForm |
+            Register-PodeWebEvent -Type KeyUp -ScriptBlock {
+                Get-Process -Name "*$($WebEvent.Data['Filter'])*" |
+                    Sort-Object -Property CPU -Descending |
+                    Select-Object -First 15 -Property Name, ID, WorkingSet, CPU |
+                    Update-PodeWebTable -Name 'Processes'
+            }
+        New-PodeWebLine
+        New-PodeWebTable -Name 'Processes'
+    )
+
+    Add-PodeWebPage -Name 'Textbox' -Layouts $textbox
+
+
+    # range event
+    $range = New-PodeWebContainer -Content @(
+        New-PodeWebText -Value 'Move the slider: '
+        New-PodeWebRange -Name 'Value' -NoForm |
+            Register-PodeWebEvent -Type Change -ScriptBlock {
+                Update-PodeWebText -Id 'txt_value' -Value $WebEvent.Data['Value']
+            }
+        New-PodeWebLine
+        New-PodeWebText -Id 'txt_value' -Style Bold -Value '0'
+    )
+
+    Add-PodeWebPage -Name 'Range' -Layouts $range
+
+
+    # radio event
+    $radio = New-PodeWebContainer -Content @(
+        New-PodeWebText -Value 'Select options: '
+        New-PodeWebRadio -Name 'Options' -NoForm -Options 'Bellow 1', 'Bellow 2', 'Bellow 3' |
+            Register-PodeWebEvent -Type Change -ScriptBlock {
+                Move-PodeWebAccordion -Name $WebEvent.Data['Options']
+            }
+    )
+
+    $acc2 = New-PodeWebAccordion -Bellows @(
+        New-PodeWebBellow -Name 'Bellow 1' -Icon 'information' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebBellow -Name 'Bellow 2' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebBellow -Name 'Bellow 3' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+    )
+
+    Add-PodeWebPage -Name 'Radio' -Layouts $radio, $acc2
+
+
+    # checkbox event
+    $checkbox = New-PodeWebContainer -Content @(
+        New-PodeWebText -Value 'Select options: '
+        New-PodeWebCheckbox -Name 'Options' -NoForm -Options 'Bellow 1', 'Bellow 2', 'Bellow 3' |
+            Register-PodeWebEvent -Type Change -ScriptBlock {
+                Move-PodeWebAccordion -Name $WebEvent.Data['Options']
+            }
+    )
+
+    $acc3 = New-PodeWebAccordion -Bellows @(
+        New-PodeWebBellow -Name 'Bellow 1' -Icon 'information' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebBellow -Name 'Bellow 2' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+        New-PodeWebBellow -Name 'Bellow 3' -Content @(
+            New-PodeWebText -Value 'Some random text' -InParagraph
+        )
+    )
+
+    Add-PodeWebPage -Name 'Checkbox' -Layouts $checkbox, $acc3
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -77,7 +77,10 @@ function New-PodeWebTextbox
         [Parameter(ParameterSetName='Single')]
         [Alias('NoAuth')]
         [switch]
-        $NoAuthentication
+        $NoAuthentication,
+
+        [switch]
+        $NoForm
     )
 
     $Id = Get-PodeWebElementId -Tag Textbox -Id $Id -Name $Name
@@ -124,6 +127,7 @@ function New-PodeWebTextbox
             Icon = $AppendIcon
         }
         NoAuthentication = $NoAuthentication.IsPresent
+        NoForm = $NoForm.IsPresent
     }
 
     # create autocomplete route
@@ -168,7 +172,10 @@ function New-PodeWebFileUpload
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [switch]
+        $NoForm
     )
 
     $Id = Get-PodeWebElementId -Tag File -Id $Id -Name $Name
@@ -181,6 +188,7 @@ function New-PodeWebFileUpload
         ID = $Id
         CssClasses = ($CssClass -join ' ')
         NoEvents = $true
+        NoForm = $NoForm.IsPresent
     }
 }
 
@@ -339,7 +347,10 @@ function New-PodeWebCheckbox
         $Checked,
 
         [switch]
-        $Disabled
+        $Disabled,
+
+        [switch]
+        $NoForm
     )
 
     $Id = Get-PodeWebElementId -Tag Checkbox -Id $Id -Name $Name
@@ -360,6 +371,7 @@ function New-PodeWebCheckbox
         Checked = $Checked.IsPresent
         Disabled = $Disabled.IsPresent
         CssClasses = ($CssClass -join ' ')
+        NoForm = $NoForm.IsPresent
     }
 }
 
@@ -387,7 +399,10 @@ function New-PodeWebRadio
         $Inline,
 
         [switch]
-        $Disabled
+        $Disabled,
+
+        [switch]
+        $NoForm
     )
 
     $Id = Get-PodeWebElementId -Tag Radio -Id $Id -Name $Name
@@ -402,6 +417,7 @@ function New-PodeWebRadio
         Inline = $Inline.IsPresent
         Disabled = $Disabled.IsPresent
         CssClasses = ($CssClass -join ' ')
+        NoForm = $NoForm.IsPresent
     }
 }
 
@@ -441,7 +457,10 @@ function New-PodeWebSelect
         $CssClass,
 
         [switch]
-        $Multiple
+        $Multiple,
+
+        [switch]
+        $NoForm
     )
 
     $Id = Get-PodeWebElementId -Tag Select -Id $Id -Name $Name
@@ -464,6 +483,7 @@ function New-PodeWebSelect
         Size = $Size
         CssClasses = ($CssClass -join ' ')
         NoAuthentication = $NoAuthentication.IsPresent
+        NoForm = $NoForm.IsPresent
     }
 
     $routePath = "/components/select/$($Id)"
@@ -530,7 +550,10 @@ function New-PodeWebRange
         $Disabled,
 
         [switch]
-        $ShowValue
+        $ShowValue,
+
+        [switch]
+        $NoForm
     )
 
     $Id = Get-PodeWebElementId -Tag Range -Id $Id -Name $Name
@@ -555,6 +578,7 @@ function New-PodeWebRange
         Disabled = $Disabled.IsPresent
         ShowValue = $ShowValue.IsPresent
         CssClasses = ($CssClass -join ' ')
+        NoForm = $NoForm.IsPresent
     }
 }
 

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -49,13 +49,11 @@ function Update-PodeWebTable
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         $Data,
 
-        [Parameter(Mandatory=$true, ParameterSetName='ID_and_AutoPage')]
-        [Parameter(Mandatory=$true, ParameterSetName='ID_and_DynamicPage')]
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
 
-        [Parameter(Mandatory=$true, ParameterSetName='Name_and_AutoPage')]
-        [Parameter(Mandatory=$true, ParameterSetName='Name_and_DynamicPage')]
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
         [string]
         $Name,
 
@@ -63,18 +61,15 @@ function Update-PodeWebTable
         [hashtable[]]
         $Columns,
 
-        [Parameter(ParameterSetName='ID_and_AutoPage')]
-        [Parameter(ParameterSetName='Name_and_AutoPage')]
+        [Parameter()]
         [switch]
         $Paginate,
 
-        [Parameter(Mandatory=$true, ParameterSetName='ID_and_DynamicPage')]
-        [Parameter(Mandatory=$true, ParameterSetName='Name_and_DynamicPage')]
+        [Parameter()]
         [int]
         $PageIndex,
 
-        [Parameter(Mandatory=$true, ParameterSetName='ID_and_DynamicPage')]
-        [Parameter(Mandatory=$true, ParameterSetName='Name_and_DynamicPage')]
+        [Parameter()]
         [int]
         $TotalItemCount
     )
@@ -116,8 +111,22 @@ function Update-PodeWebTable
             }
         }
 
+        # - dynamic paging
+        if (($PageIndex -gt 0) -and ($TotalItemCount -gt 0)) {
+            $totalItems = $TotalItemCount
+
+            $maxPages = [int][math]::Ceiling(($totalItems / $pageSize))
+            if ($pageIndex -gt $maxPages) {
+                $pageIndex = $maxPages
+            }
+
+            if ($items.Length -gt $pageSize) {
+                $items = $items[0 .. ($pageSize - 1)]
+            }
+        }
+
         # - auto-paging
-        if ($Paginate) {
+        elseif ($Paginate) {
             $pageIndex = 1
             $totalItems = $items.Length
 
@@ -135,20 +144,6 @@ function Update-PodeWebTable
             }
 
             $items = $items[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
-        }
-
-        # - dynamic paging
-        elseif (($PageIndex -gt 0) -and ($TotalItemCount -gt 0)) {
-            $totalItems = $TotalItemCount
-
-            $maxPages = [int][math]::Ceiling(($totalItems / $pageSize))
-            if ($pageIndex -gt $maxPages) {
-                $pageIndex = $maxPages
-            }
-
-            if ($items.Length -gt $pageSize) {
-                $items = $items[0 .. ($pageSize - 1)]
-            }
         }
 
         # table output

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -3208,7 +3208,13 @@ function convertToArray(element) {
 function invokeEvent(type, sender) {
     sender = $(sender);
     var url = `${getComponentUrl(sender)}/events/${type}`;
-    sendAjaxReq(url, sender.serialize(), sender, true, null, { keepFocus: true });
+
+    var data = sender.serialize();
+    if (!data) {
+        data = serializeInputs(sender);
+    }
+
+    sendAjaxReq(url, data, sender, true, null, { keepFocus: true });
 }
 
 function getComponentUrl(component) {

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -612,6 +612,18 @@ table tbody td {
     margin-top: -5px;
 }
 
+div.no-form {
+    display: inline-block;
+}
+
+.no-form {
+    width: auto;
+}
+
+.no-form.pode-form-checkbox {
+    width: inherit;
+}
+
 /* Fallback for Edge
 -------------------------------------------------- */
 @supports (-ms-ime-align: auto) {

--- a/src/Templates/Views/elements/checkbox.pode
+++ b/src/Templates/Views/elements/checkbox.pode
@@ -1,5 +1,7 @@
-<div class="form-group row pode-form-checkbox $($data.CssClasses)">
-    <div class="col-sm-2 col-form-label">$($data.Name)</div>
+<div id="$($data.ID)" class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-checkbox $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
+    $(if (!$data.NoForm) {
+        "<div class='col-sm-2 col-form-label'>$($data.Name)</div>"
+    })
     <div class="col-sm-10">
         $(
             $inline = [string]::Empty
@@ -17,12 +19,10 @@
                 $checked = 'checked'
             }
 
-            $events = ConvertTo-PodeWebEvents -Events $data.Events
-
             for ($i = 0; $i -lt $data.Options.Length; $i++) {
                 if ($data.AsSwitch) {
                     "<div class='custom-control custom-switch $($inline)'>
-                        <input type='checkbox' class='custom-control-input' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' pode-object='$($data.ObjectType)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked) $($events)>
+                        <input type='checkbox' class='custom-control-input' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked)>
                         <label class='custom-control-label' for='$($data.ID)_option$($i)'>
                             $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })
                         </label>
@@ -30,7 +30,7 @@
                 }
                 else {
                     "<div class='form-check $($inline)'>
-                        <input class='form-check-input' type='checkbox' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' pode-object='$($data.ObjectType)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked) $($events)>
+                        <input class='form-check-input' type='checkbox' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked)>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
                             $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })
                         </label>

--- a/src/Templates/Views/elements/fileupload.pode
+++ b/src/Templates/Views/elements/fileupload.pode
@@ -1,7 +1,9 @@
-<div class="form-group row pode-form-upload $($data.CssClasses)">
-    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
+<div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-upload $($data.CssClasses)">
+    $(if (!$data.NoForm) {
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+    })
     <div class="col-sm-10">
-        <input type='file' class='form-control-file' id="$($data.ID)" name="$($data.Name)" pode-object="$($data.ObjectType)">
+        <input type='file' class="form-control-file $(if ($data.NoForm) { 'no-form' })" id="$($data.ID)" name="$($data.Name)" pode-object="$($data.ObjectType)">
         <div id="$($data.ID)_validation" class="invalid-feedback"></div>
     </div>
 </div>

--- a/src/Templates/Views/elements/radio.pode
+++ b/src/Templates/Views/elements/radio.pode
@@ -1,6 +1,8 @@
-<fieldset class="form-group pode-form-radio $($data.CssClasses)">
-    <div class="row">
-        <legend class="col-form-label col-sm-2 pt-0">$($data.Name)</legend>
+<fieldset id="$($data.ID)" class="$(if (!$data.NoForm) { 'form-group' } else { 'no-form' }) pode-form-radio $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
+    $(if (!$data.NoForm) {
+        "<div class='row'>
+            <legend class='col-form-label col-sm-2 pt-0'>$($data.Name)</legend>"
+    })
         <div class="col-sm-10">
             $(
                 $inline = [string]::Empty
@@ -10,7 +12,7 @@
 
                 for ($i = 0; $i -lt $data.Options.Length; $i++) {
                     "<div class='form-check $($inline)'>
-                        <input class='form-check-input' type='radio' name='$($data.Name)' id='$($data.ID)_option$($i)' value='$($data.Options[$i])' pode-object='$($data.ObjectType)' $(if ($i -eq 0) { 'checked' }) $(if ($data.Disabled) { 'disabled' }) $(ConvertTo-PodeWebEvents -Events $data.Events)>
+                        <input class='form-check-input' type='radio' name='$($data.Name)' id='$($data.ID)_option$($i)' value='$($data.Options[$i])' $(if ($i -eq 0) { 'checked' }) $(if ($data.Disabled) { 'disabled' })>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
                             $($data.Options[$i])
                         </label>
@@ -20,5 +22,7 @@
 
             <div id="$($data.ID)_validation" class="invalid-feedback"></div>
         </div>
-    </div>
+    $(if (!$data.NoForm) {
+        "</div>"
+    })
 </fieldset>

--- a/src/Templates/Views/elements/range.pode
+++ b/src/Templates/Views/elements/range.pode
@@ -1,5 +1,7 @@
-<div class="form-group row pode-form-range $($data.CssClasses)">
-    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
+<div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-range $($data.CssClasses)">
+    $(if (!$data.NoForm) {
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+    })
     <div class="col-sm-10">
         $(
             $showValue = [string]::Empty

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -1,5 +1,7 @@
-<div class="form-group row pode-form-select $($data.CssClasses)">
-    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
+<div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-select $($data.CssClasses)">
+    $(if (!$data.NoForm) {
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+    })
     <div class="col-sm-10">
         $(
             $multiple = [string]::Empty
@@ -8,7 +10,7 @@
             }
 
             "<select
-                class='custom-select'
+                class='custom-select $(if ($data.NoForm) { 'no-form' })'
                 id='$($data.ID)'
                 name='$($data.Name)'
                 pode-object='$($data.ObjectType)'

--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -1,5 +1,7 @@
-<div class="form-group row pode-form-textbox $($data.CssClasses)">
-    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
+<div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-textbox $($data.CssClasses)">
+    $(if (!$data.NoForm) {
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+    })
     <div class="col-sm-10">
         $(
             $element = [string]::Empty
@@ -27,7 +29,7 @@
             $events = ConvertTo-PodeWebEvents -Events $data.Events
 
             if ($data.Multiline) {
-                $element = "<textarea class='form-control' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width)' $($describedBy) $($readOnly) $($value) $($events)></textarea>"
+                $element = "<textarea class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width)' $($describedBy) $($readOnly) $($value) $($events)></textarea>"
             }
             else {
                 if ($data.Prepend.Enabled -or $data.Append.Enabled) {
@@ -48,7 +50,7 @@
                     $_type = 'datetime-local'
                 }
 
-                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' style='$($width)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($value) $($events)>"
+                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' style='$($width)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($value) $($events)>"
 
                 if ($data.Append.Enabled) {
                     if (![string]::IsNullOrWhiteSpace($data.Append.Text)) {


### PR DESCRIPTION
### Description of the Change
A new `-NoForm` switch on most form elements could be used to display these elements more cleanly inline with other text elements.

### Related Issue
Resolves #162 

### Examples
```powershell
$select = New-PodeWebContainer -Content @(
    New-PodeWebText -Value 'Please select a value: '
    New-PodeWebSelect -Name 'Bellows' -NoForm -Options 'Bellow 1', 'Bellow 2', 'Bellow 3' |
        Register-PodeWebEvent -Type Change -ScriptBlock {
            Move-PodeWebAccordion -Name $WebEvent.Data['Bellows']
        }
)

$acc1 = New-PodeWebAccordion -Bellows @(
    New-PodeWebBellow -Name 'Bellow 1' -Icon 'information' -Content @(
        New-PodeWebText -Value 'Some random text' -InParagraph
    )
    New-PodeWebBellow -Name 'Bellow 2' -Content @(
        New-PodeWebText -Value 'Some random text' -InParagraph
    )
    New-PodeWebBellow -Name 'Bellow 3' -Content @(
        New-PodeWebText -Value 'Some random text' -InParagraph
    )
)

Add-PodeWebPage -Name 'Select' -Layouts $select, $acc1
```
