### PR TITLE
Adds output functions for hiding/showing and updating css on components

### DIFF
--- a/docs/Tutorials/Outputs/Components.md
+++ b/docs/Tutorials/Outputs/Components.md
@@ -1,0 +1,55 @@
+# Components
+
+This page details the available output actions available to all components of Pode.Web.
+
+## General
+
+### Hide
+
+To hide a component on the frontend, you use [`Hide-PodeWebComponent`](../../../Functions/Outputs/Hide-PodeWebComponent). You can hide a component either by `-Id`, or by the component's `-Name` and `-Type`:
+
+```powershell
+Hide-PodeWebComponent -Type 'Card' -Name 'SomeCardName'
+
+# or
+
+Hide-PodeWebComponent -Id 'card_somename'
+```
+
+### Show
+
+To show a component on the frontend, you use [`Show-PodeWebComponent`](../../../Functions/Outputs/Show-PodeWebComponent). You can show a component either by `-Id`, or by the component's `-Name` and `-Type`:
+
+```powershell
+Show-PodeWebComponent -Type 'Card' -Name 'SomeCardName'
+
+# or
+
+Show-PodeWebComponent -Id 'card_somename'
+```
+
+## Style
+
+### Set
+
+You can set/update the value of a CSS property on a component via [`Set-PodeWebComponentStyle`](../../../Functions/Outputs/Set-PodeWebComponentStyle). You can update a component either by `-Id`, or by the component's `-Name` and `-Type`:
+
+```powershell
+Set-PodeWebComponentStyle -Type 'Textbox' -Name 'SomeTextboxName' -Property 'color' -Value 'red'
+
+# or
+
+Set-PodeWebComponentStyle -Id 'textbox_somename' -Property 'color' -Value 'red'
+```
+
+### Remove
+
+You can remove a CSS property from a component via [`Remove-PodeWebComponentStyle`](../../../Functions/Outputs/Remove-PodeWebComponentStyle). You can update a component either by `-Id`, or by the component's `-Name` and `-Type`:
+
+```powershell
+Remove-PodeWebComponentStyle -Type 'Textbox' -Name 'SomeTextboxName' -Property 'color'
+
+# or
+
+Remove-PodeWebComponentStyle -Id 'textbox_somename' -Property 'color'
+```

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1188,7 +1188,7 @@ function Reset-PodeWebTheme
     }
 }
 
-function Show-PodeWebObject
+function Show-PodeWebComponent
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
@@ -1207,14 +1207,14 @@ function Show-PodeWebObject
 
     return @{
         Operation = 'Show'
-        ObjectType = 'Object'
+        ObjectType = 'Component'
         ID = $Id
         Type = $Type
         Name = $Name
     }
 }
 
-function Hide-PodeWebObject
+function Hide-PodeWebComponent
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
@@ -1233,14 +1233,14 @@ function Hide-PodeWebObject
 
     return @{
         Operation = 'Hide'
-        ObjectType = 'Object'
+        ObjectType = 'Component'
         ID = $Id
         Type = $Type
         Name = $Name
     }
 }
 
-function Set-PodeWebObjectStyle
+function Set-PodeWebComponentStyle
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
@@ -1267,7 +1267,7 @@ function Set-PodeWebObjectStyle
 
     return @{
         Operation = 'Set'
-        ObjectType = 'Object-Style'
+        ObjectType = 'Component-Style'
         ID = $Id
         Type = $Type
         Name = $Name
@@ -1276,7 +1276,7 @@ function Set-PodeWebObjectStyle
     }
 }
 
-function Remove-PodeWebObjectStyle
+function Remove-PodeWebComponentStyle
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
@@ -1299,7 +1299,7 @@ function Remove-PodeWebObjectStyle
 
     return @{
         Operation = 'Remove'
-        ObjectType = 'Object-Style'
+        ObjectType = 'Component-Style'
         ID = $Id
         Type = $Type
         Name = $Name

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1187,3 +1187,122 @@ function Reset-PodeWebTheme
         ObjectType = 'Theme'
     }
 }
+
+function Show-PodeWebObject
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Show'
+        ObjectType = 'Object'
+        ID = $Id
+        Type = $Type
+        Name = $Name
+    }
+}
+
+function Hide-PodeWebObject
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Hide'
+        ObjectType = 'Object'
+        ID = $Id
+        Type = $Type
+        Name = $Name
+    }
+}
+
+function Set-PodeWebObjectStyle
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Property,
+
+        [Parameter()]
+        [string]
+        $Value
+    )
+
+    return @{
+        Operation = 'Set'
+        ObjectType = 'Object-Style'
+        ID = $Id
+        Type = $Type
+        Name = $Name
+        Property = $Property
+        Value = $Value
+    }
+}
+
+function Remove-PodeWebObjectStyle
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Property
+    )
+
+    return @{
+        Operation = 'Remove'
+        ObjectType = 'Object-Style'
+        ID = $Id
+        Type = $Type
+        Name = $Name
+        Property = $Property
+    }
+}

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1298,6 +1298,14 @@ function invokeActions(actions, sender) {
                 actionTheme(action);
                 break;
 
+            case 'object':
+                actionObject(action);
+                break;
+
+            case 'object-style':
+                actionObjectStyle(action);
+                break;
+
             default:
                 break;
         }
@@ -1743,20 +1751,10 @@ function updateTableRow(action) {
     }
 
     // update the row's background colour
-    if (action.BackgroundColour) {
-        row[0].style.setProperty('background-color', action.BackgroundColour, 'important');
-    }
-    else {
-        row[0].style.setProperty('background-color', null);
-    }
+    setObjectStyle(row[0], 'background-color', action.BackgroundColour);
 
     // update the row's forecolour
-    if (action.Colour) {
-        row[0].style.setProperty('color', action.Colour, 'important');
-    }
-    else {
-        row[0].style.setProperty('color', null);
-    }
+    setObjectStyle(row[0], 'color', action.Colour);
 
     // binds sort/buttons/etc
     $('[data-toggle="tooltip"]').tooltip();
@@ -1845,14 +1843,12 @@ function clearTable(action) {
 }
 
 function syncTable(action) {
-    if (!action.ID && !action.Name) {
+    var table = getElementByNameOrId(action, 'table', null, '[pode-dynamic="True"]');
+    if (!table) {
         return;
     }
 
-    var table = getElementByNameOrId(action, 'table');
-    var id = getId(table);
-
-    loadTable(id);
+    loadTable(getId(table));
 }
 
 function updateTable(action, sender) {
@@ -2149,6 +2145,10 @@ function getElementByNameOrId(action, tag, sender, filter) {
 
     // by Name
     if (action.Name) {
+        if (!tag && action.Type) {
+            tag = `[pode-object="${action.Type}"]`;
+        }
+
         if (sender) {
             return sender.find(`${tag}[name="${action.Name}"]${filter}`);
         }
@@ -2256,12 +2256,70 @@ function updateTile(action, sender) {
 }
 
 function syncTile(action) {
-    var tile = getElementByNameOrId(action, 'div');
+    var tile = getElementByNameOrId(action, 'div', null, '[pode-dynamic="True"]');
     if (!tile) {
         return;
     }
 
     loadTile(getId(tile));
+}
+
+function actionObjectStyle(action) {
+    if (!action) {
+        return;
+    }
+
+    switch (action.Operation.toLowerCase()) {
+        case 'set':
+        case 'remove':
+            updateObjectStyle(action);
+            break;
+    }
+}
+
+function updateObjectStyle(action) {
+    var obj = getElementByNameOrId(action);
+    if (!obj) {
+        return;
+    }
+
+    setObjectStyle(obj[0], action.Property, action.Value);
+}
+
+function setObjectStyle(obj, property, value) {
+    if (value) {
+        obj.style.setProperty(property, value, 'important');
+    }
+    else {
+        obj.style.setProperty(property, null);
+    }
+}
+
+function actionObject(action) {
+    if (!action) {
+        return;
+    }
+
+    switch (action.Operation.toLowerCase()) {
+        case 'show':
+        case 'hide':
+            toggleObject(action, action.Operation.toLowerCase());
+            break;
+    }
+}
+
+function toggleObject(action, toggle) {
+    var obj = getElementByNameOrId(action);
+    if (!obj) {
+        return;
+    }
+
+    if (toggle == 'show') {
+        obj.show();
+    }
+    else {
+        obj.hide();
+    }
 }
 
 function actionTheme(action) {
@@ -2353,7 +2411,7 @@ function clearSelect(action) {
 }
 
 function syncSelect(action) {
-    var select = getElementByNameOrId(action, 'select');
+    var select = getElementByNameOrId(action, 'select', null, '[pode-dynamic="True"]');
     if (!select) {
         return;
     }
@@ -2594,14 +2652,12 @@ function clearChart(action) {
 }
 
 function syncChart(action) {
-    if (!action.ID && !action.Name) {
+    var chart = getElementByNameOrId(action, 'canvas', null, '[pode-dynamic="True"]');
+    if (!chart) {
         return;
     }
 
-    var chart = getElementByNameOrId(action, 'canvas');
-    var id = getId(chart);
-
-    loadChart(id);
+    loadChart(getId(chart));
 }
 
 var _charts = {};

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1298,12 +1298,12 @@ function invokeActions(actions, sender) {
                 actionTheme(action);
                 break;
 
-            case 'object':
-                actionObject(action);
+            case 'component':
+                actionComponent(action);
                 break;
 
-            case 'object-style':
-                actionObjectStyle(action);
+            case 'component-style':
+                actionComponentStyle(action);
                 break;
 
             default:
@@ -2264,7 +2264,7 @@ function syncTile(action) {
     loadTile(getId(tile));
 }
 
-function actionObjectStyle(action) {
+function actionComponentStyle(action) {
     if (!action) {
         return;
     }
@@ -2272,12 +2272,12 @@ function actionObjectStyle(action) {
     switch (action.Operation.toLowerCase()) {
         case 'set':
         case 'remove':
-            updateObjectStyle(action);
+            updateComponentStyle(action);
             break;
     }
 }
 
-function updateObjectStyle(action) {
+function updateComponentStyle(action) {
     var obj = getElementByNameOrId(action);
     if (!obj) {
         return;
@@ -2295,7 +2295,7 @@ function setObjectStyle(obj, property, value) {
     }
 }
 
-function actionObject(action) {
+function actionComponent(action) {
     if (!action) {
         return;
     }
@@ -2303,12 +2303,12 @@ function actionObject(action) {
     switch (action.Operation.toLowerCase()) {
         case 'show':
         case 'hide':
-            toggleObject(action, action.Operation.toLowerCase());
+            toggleComponent(action, action.Operation.toLowerCase());
             break;
     }
 }
 
-function toggleObject(action, toggle) {
+function toggleComponent(action, toggle) {
     var obj = getElementByNameOrId(action);
     if (!obj) {
         return;


### PR DESCRIPTION
### Description of the Change
Adds output functions for hiding/showing components, as well as setting/removing css style properties:

* `Hide-PodeWebComponent`
* `Show-PodeWebComponent`
* `Set-PodeWebComponentStyle`
* `Remove-PodeWebComponentStyle`

Each function can identify a component by its `-Id`, or by a `-Type` and `-Name` combo (for components that support a `-Name`). The `-Type` is like Table/Cell/Card/Textbox/Select/Bellow/etc.

### Related Issue
Resolves #164 

### Examples
To show a component:
```powershell
Show-PodeWebComponent -Type 'Card' -Name 'SomeCardName'
# or
Show-PodeWebComponent -Id 'card_somename'
```

To set a css style property:
```powershell
Set-PodeWebComponentStyle -Type 'Textbox' -Name 'SomeTextboxName' -Property 'color' -Value 'red'
# or
Set-PodeWebComponentStyle -Id 'textbox_somename' -Property 'color' -Value 'red'
```
