### PR TITLE
The -Name parameter for a Timer should be optional

### DIFF
--- a/docs/Tutorials/Elements/Timer.md
+++ b/docs/Tutorials/Elements/Timer.md
@@ -9,7 +9,7 @@ A timer is a non-visible element, it sets up a javascript timer in the backgroun
 The below example sets up a timer that will update the badge's value and colour every 10 seconds:
 
 ```powershell
-New-PodeWebTimer -Name ExampleTimer -Interval 10 -ScriptBlock {
+New-PodeWebTimer -Interval 10 -ScriptBlock {
     $rand = Get-Random -Minimum 0 -Maximum 3
     $colour = (@('Green', 'Yellow', 'Cyan'))[$rand]
     Update-PodeWebBadge -Id 'bdg_example' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')) -Colour $colour
@@ -23,7 +23,7 @@ New-PodeWebCard -Content @(
 You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:
 
 ```powershell
-New-PodeWebTimer -Name 'Example' -Interval 10 -ArgumentList 'Value1', 2, $false -ScriptBlock {
+New-PodeWebTimer -Interval 10 -ArgumentList 'Value1', 2, $false -ScriptBlock {
     param($value1, $value2, $value3)
 
     # $value1 = 'Value1'

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2310,7 +2310,7 @@ function New-PodeWebTimer
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [string]
         $Name,
 
@@ -2344,7 +2344,7 @@ function New-PodeWebTimer
         $NoAuthentication
     )
 
-    $Id = Get-PodeWebElementId -Tag Timer -Id $Id -Name $Name
+    $Id = Get-PodeWebElementId -Tag Timer -Id $Id -Name $Name -NameAsToken
 
     if ($Interval -lt 10) {
         $Interval = 10


### PR DESCRIPTION
### Description of the Change
The `-Name` parameter on `New-PodeWebTimer` is now optional.

### Related Issue
Resolves #167 
