### PR TITLE
Add -CssStyle parameter onto components

### DIFF
--- a/docs/Tutorials/ClassAndStyles.md
+++ b/docs/Tutorials/ClassAndStyles.md
@@ -4,7 +4,7 @@ Nearly every component in Pode.Web has a `-CssClass` and a `-CssStyle` parameter
 
 ## Classes
 
-The `-CssClass` parameter accepts an array of strings, which are set on the `class` property on the parent element of approparite component. The classes by themselves don't do anything, but you can use them to build custom CSS files and import them via [`Import-PodeWebStylesheet`]; you can also use the custom classes as references in custom JavaScript files, and import these via [`Import-PodeWebJavaScript`].
+The `-CssClass` parameter accepts an array of strings, which are set on the `class` property on the parent element of approparite component. The classes by themselves don't do anything, but you can use them to build custom CSS files and import them via [`Import-PodeWebStylesheet`](../../Functions/Utilities/Import-PodeWebStylesheet); you can also use the custom classes as references in custom JavaScript files, and import these via [`Import-PodeWebJavaScript`](../../Functions/Utilities/Import-PodeWebJavaScript).
 
 For example, the following would apply the `my-custom-textbox` class to a textbox:
 
@@ -22,7 +22,7 @@ Then you could create some `/public/my-styles.css` file with the following, to s
 
 and import it via: `Import-PodeWebStylesheet -Url '/my-styles.css'`.
 
-or, you can create some JavaScript file at `/public/my-scritps.js` with an event to write to console on keyup. jQuery works here, as Pode.Web uses jQuery. Also, we have to reference the class then the input control, as the class is at the paraent level of the textbox element; this allows for more fine grained control of a component as a whole.
+or, you can create some JavaScript file at `/public/my-scritps.js` with an event to write to console on keyup. jQuery works here, as Pode.Web uses jQuery. Also, we have to reference the class then the input control, as the class is at the paraent level of the textbox element; this allows for more fine grained control of a component as a whole - such as a textbox's labels, divs, spans, etc.
 
 ```js
 $('.my-custom-textbox input').off('keyup').on('keyup', (e) => {
@@ -31,6 +31,8 @@ $('.my-custom-textbox input').off('keyup').on('keyup', (e) => {
 ```
 
 and import it via: `Import-PodeWebJavaScript -Url '/my-scripts.js'`.
+
+You can add/remove classes on components using the [Class output actions](../Outputs/Components#classes). (This will add classes onto the component itself, not the parent).
 
 ## Styles
 
@@ -45,3 +47,5 @@ New-PodeWebParagraph -CssStyle @{ Color = 'Yellow' } -Elements @(
     New-PodeWebText -Value ' that takes you to Google'
 )
 ```
+
+You can set/remove CSS style properties on components using the [Style output actions](../Outputs/Components#styles).

--- a/docs/Tutorials/ClassAndStyles.md
+++ b/docs/Tutorials/ClassAndStyles.md
@@ -1,0 +1,47 @@
+# Classes and Styles
+
+Nearly every component in Pode.Web has a `-CssClass` and a `-CssStyle` parameter. These parameters allow you to add custom classes/styles onto the components, so you can control their look and functionality.
+
+## Classes
+
+The `-CssClass` parameter accepts an array of strings, which are set on the `class` property on the parent element of approparite component. The classes by themselves don't do anything, but you can use them to build custom CSS files and import them via [`Import-PodeWebStylesheet`]; you can also use the custom classes as references in custom JavaScript files, and import these via [`Import-PodeWebJavaScript`].
+
+For example, the following would apply the `my-custom-textbox` class to a textbox:
+
+```powershell
+New-PodeWebTextbox -Name 'Message' -CssClass 'my-custom-textbox'
+```
+
+Then you could create some `/public/my-styles.css` file with the following, to set the textbox's text colour to purple:
+
+```css
+.my-custom-textbox {
+    color: purple
+}
+```
+
+and import it via: `Import-PodeWebStylesheet -Url '/my-styles.css'`.
+
+or, you can create some JavaScript file at `/public/my-scritps.js` with an event to write to console on keyup. jQuery works here, as Pode.Web uses jQuery. Also, we have to reference the class then the input control, as the class is at the paraent level of the textbox element; this allows for more fine grained control of a component as a whole.
+
+```js
+$('.my-custom-textbox input').off('keyup').on('keyup', (e) => {
+    console.log($(e.target).val());
+})
+```
+
+and import it via: `Import-PodeWebJavaScript -Url '/my-scripts.js'`.
+
+## Styles
+
+The `-CssStyle` parameter accepts a hashtable where the key is the name of a CSS property, with an appropriate value for that property. These styles are applied directly onto the main component.
+
+For example, the following would display a paragraph with yellow text:
+
+```powershell
+New-PodeWebParagraph -CssStyle @{ Color = 'Yellow' } -Elements @(
+    New-PodeWebText -Value 'And then here is some more text, that also includes a '
+    New-PodeWebLink -Value 'link' -Source 'https://google.com'
+    New-PodeWebText -Value ' that takes you to Google'
+)
+```

--- a/docs/Tutorials/Outputs/Components.md
+++ b/docs/Tutorials/Outputs/Components.md
@@ -28,7 +28,33 @@ Show-PodeWebComponent -Type 'Card' -Name 'SomeCardName'
 Show-PodeWebComponent -Id 'card_somename'
 ```
 
-## Style
+## Classes
+
+### Add
+
+You can add a class onto a component via [`Add-PodeWebComponentClass`](../../../Functions/Outputs/Add-PodeWebComponentClass). You can update a component either by `-Id`, or by the component's `-Name` and `-Type`:
+
+```powershell
+Add-PodeWebComponentClass -Type 'Textbox' -Name 'SomeTextboxName' -Class 'my-custom-class'
+
+# or
+
+Add-PodeWebComponentClass -Id 'textbox_somename' -Class 'my-custom-class'
+```
+
+### Remove
+
+You can remove a class from a component via [`Remove-PodeWebComponentClass`](../../../Functions/Outputs/Remove-PodeWebComponentClass). You can update a component either by `-Id`, or by the component's `-Name` and `-Type`:
+
+```powershell
+Remove-PodeWebComponentClass -Type 'Textbox' -Name 'SomeTextboxName' -Class 'my-custom-class'
+
+# or
+
+Remove-PodeWebComponentClass -Id 'textbox_somename' -Class 'my-custom-class'
+```
+
+## Styles
 
 ### Set
 

--- a/examples/class_and_style.ps1
+++ b/examples/class_and_style.ps1
@@ -1,0 +1,27 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Classy Styles' -Theme Dark
+
+    # import the custom css/js
+    Import-PodeWebStylesheet -Url '/my-styles.css'
+    Import-PodeWebJavaScript -Url '/my-scripts.js'
+
+    # set the home page controls
+    $container = New-PodeWebContainer -Content @(
+        New-PodeWebTextbox -Name 'Message' -CssClass 'my-custom-textbox'
+        New-PodeWebParagraph -CssStyle @{ Color = 'Yellow' } -Elements @(
+            New-PodeWebText -Value 'And then here is some more text, that also includes a '
+            New-PodeWebLink -Value 'link' -Source 'https://google.com'
+            New-PodeWebText -Value ' that takes you to Google'
+        )
+    )
+
+    Set-PodeWebHomePage -Layouts $container -Title 'Page with STYLE'
+}

--- a/examples/public/my-scripts.js
+++ b/examples/public/my-scripts.js
@@ -1,0 +1,3 @@
+$('.my-custom-textbox input').off('keyup').on('keyup', (e) => {
+    console.log($(e.target).val());
+})

--- a/examples/public/my-styles.css
+++ b/examples/public/my-styles.css
@@ -1,0 +1,3 @@
+.my-custom-textbox {
+    color: purple
+}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -674,3 +674,24 @@ function ConvertTo-PodeWebEvents
 
     return $js_events
 }
+
+function ConvertTo-PodeWebStyles
+{
+    param(
+        [Parameter()]
+        [hashtable]
+        $Style
+    )
+
+    $styles = [string]::Empty
+
+    if (($null -eq $Style) -or ($Style.Count -eq 0)) {
+        return $styles
+    }
+
+    foreach ($key in $Style.Keys) {
+        $styles += " $($key.ToLowerInvariant()): $($Style[$key].ToLowerInvariant()) !important;"
+    }
+
+    return $styles
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -61,6 +61,10 @@ function New-PodeWebTextbox
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [string[]]
         $EndpointName,
 
@@ -116,6 +120,7 @@ function New-PodeWebTextbox
         IsAutoComplete = ($null -ne $AutoComplete)
         Value = $Value
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Prepend = @{
             Enabled = (![string]::IsNullOrWhiteSpace($PrependText) -or ![string]::IsNullOrWhiteSpace($PrependIcon))
             Text = $PrependText
@@ -174,6 +179,10 @@ function New-PodeWebFileUpload
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $NoForm
     )
@@ -187,6 +196,7 @@ function New-PodeWebFileUpload
         Name = $Name
         ID = $Id
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
         NoForm = $NoForm.IsPresent
     }
@@ -215,7 +225,11 @@ function New-PodeWebParagraph
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     # ensure elements are correct
@@ -234,6 +248,7 @@ function New-PodeWebParagraph
         Elements = $Elements
         Alignment = $Alignment.ToLowerInvariant()
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -257,6 +272,10 @@ function New-PodeWebCodeBlock
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [switch]
         $Scrollable,
@@ -282,6 +301,7 @@ function New-PodeWebCodeBlock
         Language = $Language.ToLowerInvariant()
         Scrollable = $Scrollable.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -300,7 +320,11 @@ function New-PodeWebCode
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     $Id = Get-PodeWebElementId -Tag Code -Id $Id -RandomToken
@@ -312,6 +336,7 @@ function New-PodeWebCode
         ID = $Id
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -335,6 +360,10 @@ function New-PodeWebCheckbox
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter(ParameterSetName='Multiple')]
         [switch]
@@ -371,6 +400,7 @@ function New-PodeWebCheckbox
         Checked = $Checked.IsPresent
         Disabled = $Disabled.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoForm = $NoForm.IsPresent
     }
 }
@@ -395,6 +425,10 @@ function New-PodeWebRadio
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $Inline,
 
@@ -417,6 +451,7 @@ function New-PodeWebRadio
         Inline = $Inline.IsPresent
         Disabled = $Disabled.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoForm = $NoForm.IsPresent
     }
 }
@@ -456,6 +491,10 @@ function New-PodeWebSelect
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $Multiple,
 
@@ -482,6 +521,7 @@ function New-PodeWebSelect
         Multiple = $Multiple.IsPresent
         Size = $Size
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoAuthentication = $NoAuthentication.IsPresent
         NoForm = $NoForm.IsPresent
     }
@@ -546,6 +586,10 @@ function New-PodeWebRange
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $Disabled,
 
@@ -578,6 +622,7 @@ function New-PodeWebRange
         Disabled = $Disabled.IsPresent
         ShowValue = $ShowValue.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoForm = $NoForm.IsPresent
     }
 }
@@ -614,6 +659,10 @@ function New-PodeWebProgress
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [switch]
         $ShowValue,
@@ -657,6 +706,7 @@ function New-PodeWebProgress
         Colour = $Colour
         ColourType = $ColourType
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -692,7 +742,11 @@ function New-PodeWebImage
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     $Id = Get-PodeWebElementId -Tag Img -Id $Id -RandomToken
@@ -716,6 +770,7 @@ function New-PodeWebImage
         Height = $Height
         Width = $Width
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -742,7 +797,11 @@ function New-PodeWebHeader
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     $Id = Get-PodeWebElementId -Tag Header -Id $Id -RandomToken
@@ -756,6 +815,7 @@ function New-PodeWebHeader
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Secondary = [System.Net.WebUtility]::HtmlEncode($Secondary)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -783,7 +843,11 @@ function New-PodeWebQuote
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     $Id = Get-PodeWebElementId -Tag Quote -Id $Id -RandomToken
@@ -797,6 +861,7 @@ function New-PodeWebQuote
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Source = [System.Net.WebUtility]::HtmlEncode($Source)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -821,6 +886,10 @@ function New-PodeWebList
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $Numbered
     )
@@ -842,6 +911,7 @@ function New-PodeWebList
         Items = $Items
         Numbered = $Numbered.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -852,7 +922,15 @@ function New-PodeWebListItem
     param(
         [Parameter(Mandatory=$true)]
         [hashtable[]]
-        $Content
+        $Content,
+
+        [Parameter()]
+        [string[]]
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -865,6 +943,8 @@ function New-PodeWebListItem
         ID = (Get-PodeWebElementId -Tag ListItem -RandomToken)
         Content = $Content
         NoEvents = $true
+        CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -888,6 +968,10 @@ function New-PodeWebLink
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $NewTab
     )
@@ -903,6 +987,7 @@ function New-PodeWebLink
         Value = $Value
         NewTab = $NewTab.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -932,6 +1017,10 @@ function New-PodeWebText
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [Parameter(ParameterSetName='Paragraph')]
         [switch]
         $InParagraph
@@ -947,6 +1036,7 @@ function New-PodeWebText
         InParagraph = $InParagraph.IsPresent
         Alignment = $Alignment.ToLowerInvariant()
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -961,7 +1051,11 @@ function New-PodeWebLine
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     return @{
@@ -970,6 +1064,7 @@ function New-PodeWebLine
         Parent = $ElementData
         ID = (Get-PodeWebElementId -Tag Line -Id $Id -RandomToken)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -992,7 +1087,11 @@ function New-PodeWebHidden
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     $Id = Get-PodeWebElementId -Tag Hidden -Id $Id -Name $Name
@@ -1005,6 +1104,7 @@ function New-PodeWebHidden
         ID = $Id
         Value = $Value
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -1029,6 +1129,10 @@ function New-PodeWebCredential
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $ReadOnly,
 
@@ -1048,6 +1152,7 @@ function New-PodeWebCredential
         ReadOnly = $ReadOnly.IsPresent
         NoLabels = $NoLabels.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1071,6 +1176,10 @@ function New-PodeWebDateTime
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $ReadOnly,
 
@@ -1090,6 +1199,7 @@ function New-PodeWebDateTime
         ReadOnly = $ReadOnly.IsPresent
         NoLabels = $NoLabels.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1137,6 +1247,10 @@ function New-PodeWebMinMax
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $ReadOnly,
 
@@ -1160,6 +1274,7 @@ function New-PodeWebMinMax
         ReadOnly = $ReadOnly.IsPresent
         NoLabels = $NoLabels.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Prepend = @{
             Enabled = (![string]::IsNullOrWhiteSpace($PrependText) -or ![string]::IsNullOrWhiteSpace($PrependIcon))
             Text = $PrependText
@@ -1233,6 +1348,10 @@ function New-PodeWebButton
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [string[]]
         $EndpointName,
 
@@ -1269,6 +1388,7 @@ function New-PodeWebButton
         Colour = $Colour
         ColourType = $ColourType
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NewLine = $NewLine.IsPresent
         NewTab = $NewTab.IsPresent
         NoEvents = $true
@@ -1329,7 +1449,11 @@ function New-PodeWebAlert
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     # ensure content are correct
@@ -1352,6 +1476,7 @@ function New-PodeWebAlert
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Content = $Content
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1374,6 +1499,10 @@ function New-PodeWebIcon
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter()]
         [string]
@@ -1407,6 +1536,7 @@ function New-PodeWebIcon
         Name = $Name
         Colour = $Colour
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Title = $Title
         Flip = $Flip
         Rotate = $Rotate
@@ -1431,6 +1561,10 @@ function New-PodeWebSpinner
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [string]
         $Title
     )
@@ -1446,6 +1580,7 @@ function New-PodeWebSpinner
         ID = (Get-PodeWebElementId -Tag Spinner -Id $Id -RandomToken)
         Colour = $Colour
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Title = $Title
         NoEvents = $true
     }
@@ -1470,7 +1605,11 @@ function New-PodeWebBadge
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     $Id = Get-PodeWebElementId -Tag Alert -Id $Id -RandomToken
@@ -1485,6 +1624,7 @@ function New-PodeWebBadge
         ColourType = $ColourType.ToLowerInvariant()
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1514,7 +1654,11 @@ function New-PodeWebComment
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     $Id = Get-PodeWebElementId -Tag Comment -Id $Id -RandomToken
@@ -1529,6 +1673,7 @@ function New-PodeWebComment
         Message = $Message
         TimeStamp = $TimeStamp
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -1578,6 +1723,10 @@ function New-PodeWebChart
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter()]
         [string[]]
@@ -1650,6 +1799,7 @@ function New-PodeWebChart
         NoRefresh = $NoRefresh.IsPresent
         NoLegend = $NoLegend.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Min = @{
             X = $MinX
             Y = $MinY
@@ -1715,6 +1865,10 @@ function New-PodeWebCounterChart
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [int]
         $MaxItems = 30,
 
@@ -1763,6 +1917,7 @@ function New-PodeWebCounterChart
         -TimeLabels `
         -AutoRefresh `
         -CssClass $CssClass `
+        -CssStyle $CssStyle `
         -MinX $MinX `
         -MinY $MinY `
         -MaxX $MaxX `
@@ -1823,6 +1978,10 @@ function New-PodeWebTable
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter()]
         [string[]]
@@ -1914,6 +2073,7 @@ function New-PodeWebTable
         NoRefresh = $NoRefresh.IsPresent
         NoAuthentication = $NoAuthentication.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Paging = @{
             Enabled = $Paginate.IsPresent
             Size = $PageSize
@@ -2133,6 +2293,10 @@ function New-PodeWebCodeEditor
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [scriptblock]
         $Upload,
 
@@ -2171,6 +2335,7 @@ function New-PodeWebCodeEditor
         ReadOnly = $ReadOnly.IsPresent
         Uploadable = $uploadable
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoAuthentication = $NoAuthentication.IsPresent
     }
 
@@ -2240,6 +2405,10 @@ function New-PodeWebForm
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [string[]]
         $EndpointName,
 
@@ -2270,6 +2439,7 @@ function New-PodeWebForm
         Content = $Content
         NoHeader = $NoHeader.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
         NoAuthentication = $NoAuthentication.IsPresent
     }
@@ -2335,6 +2505,10 @@ function New-PodeWebTimer
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [string[]]
         $EndpointName,
 
@@ -2358,6 +2532,7 @@ function New-PodeWebTimer
         ID = $Id
         Interval = ($Interval * 1000)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
         NoAuthentication = $NoAuthentication.IsPresent
     }
@@ -2424,6 +2599,10 @@ function New-PodeWebTile
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [string[]]
         $EndpointName,
 
@@ -2481,6 +2660,7 @@ function New-PodeWebTile
         Colour = $Colour
         ColourType = $ColourType
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         AutoRefresh = $AutoRefresh.IsPresent
         RefreshInterval = ($RefreshInterval * 1000)
         NoRefresh = $NoRefresh.IsPresent
@@ -2568,6 +2748,10 @@ function New-PodeWebFileStream
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [int]
         $Interval = 10,
 
@@ -2600,6 +2784,7 @@ function New-PodeWebFileStream
         Interval = ($Interval * 1000)
         Icon = $Icon
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoHeader = $NoHeader.IsPresent
     }
 
@@ -2624,7 +2809,15 @@ function New-PodeWebIFrame
 
         [Parameter()]
         [string]
-        $Title
+        $Title,
+
+        [Parameter()]
+        [string[]]
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if ([string]::IsNullOrWhiteSpace($Title)) {
@@ -2640,5 +2833,7 @@ function New-PodeWebIFrame
         Url = $Url
         Title = $Title
         NoEvents = $true
+        CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -18,6 +18,10 @@ function New-PodeWebGrid
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $Vertical
     )
@@ -37,6 +41,7 @@ function New-PodeWebGrid
         Width = $Width
         ID = (Get-PodeWebElementId -Tag Grid -Id $Id -RandomToken)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -60,7 +65,15 @@ function New-PodeWebCell
         [Parameter()]
         [ValidateSet('Left', 'Right', 'Center')]
         [string]
-        $Alignment = 'Left'
+        $Alignment = 'Left',
+
+        [Parameter()]
+        [string[]]
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -74,6 +87,8 @@ function New-PodeWebCell
         Width = $Width
         ID = (Get-PodeWebElementId -Tag Cell -Id $Id -RandomToken)
         Alignment = $Alignment.ToLowerInvariant()
+        CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -92,6 +107,10 @@ function New-PodeWebTabs
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter()]
         [int]
@@ -115,6 +134,7 @@ function New-PodeWebTabs
         ID = (Get-PodeWebElementId -Tag Tabs -Id $Id -RandomToken)
         Tabs = $Tabs
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Cycle = @{
             Enabled = $Cycle.IsPresent
             Interval = ($CycleInterval * 1000)
@@ -140,7 +160,15 @@ function New-PodeWebTab
 
         [Parameter()]
         [string]
-        $Icon
+        $Icon,
+
+        [Parameter()]
+        [string[]]
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if (!(Test-PodeWebContent -Content $Tabs -ComponentType Layout)) {
@@ -154,6 +182,8 @@ function New-PodeWebTab
         ID = (Get-PodeWebElementId -Tag Tab -Id $Id -Name $Name)
         Layouts = $Layouts
         Icon = $Icon
+        CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -176,6 +206,10 @@ function New-PodeWebCard
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter()]
         [string]
@@ -201,6 +235,7 @@ function New-PodeWebCard
         NoTitle = $NoTitle.IsPresent
         NoHide  = $NoHide.IsPresent
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Icon = $Icon
     }
 }
@@ -221,6 +256,10 @@ function New-PodeWebContainer
         [string[]]
         $CssClass,
 
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
+
         [switch]
         $NoBackground,
 
@@ -238,6 +277,7 @@ function New-PodeWebContainer
         ID = (Get-PodeWebElementId -Tag Container -Id $Id -NameAsToken)
         Content = $Content
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoBackground = $NoBackground.IsPresent
         Hide = $Hide.IsPresent
     }
@@ -289,6 +329,10 @@ function New-PodeWebModal
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter()]
         [string[]]
@@ -346,6 +390,7 @@ function New-PodeWebModal
         AsForm = $AsForm.IsPresent
         ShowSubmit = ($null -ne $ScriptBlock)
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -371,7 +416,11 @@ function New-PodeWebHero
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -386,6 +435,7 @@ function New-PodeWebHero
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
         Content = $Content
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -403,7 +453,11 @@ function New-PodeWebCarousel
 
         [Parameter()]
         [string[]]
-        $CssClass
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if (!(Test-PodeWebContent -Content $Slides -ComponentType Layout -ObjectType Slide)) {
@@ -416,6 +470,7 @@ function New-PodeWebCarousel
         ID = (Get-PodeWebElementId -Tag Carousel -Id $Id -NameAsToken)
         Slides = $Slides
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -433,7 +488,15 @@ function New-PodeWebSlide
 
         [Parameter()]
         [string]
-        $Message
+        $Message,
+
+        [Parameter()]
+        [string[]]
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -447,6 +510,8 @@ function New-PodeWebSlide
         ID = (Get-PodeWebElementId -Tag Slide -RandomToken)
         Title = [System.Net.WebUtility]::HtmlEncode($Title)
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
+        CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -469,6 +534,10 @@ function New-PodeWebSteps
         [Parameter()]
         [string[]]
         $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter(Mandatory=$true)]
         [scriptblock]
@@ -525,6 +594,7 @@ function New-PodeWebSteps
         ID = $Id
         Steps = $Steps
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -555,6 +625,14 @@ function New-PodeWebStep
         [Parameter()]
         [string[]]
         $EndpointName,
+
+        [Parameter()]
+        [string[]]
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle,
 
         [Parameter()]
         [Alias('NoAuth')]
@@ -601,6 +679,8 @@ function New-PodeWebStep
         Content = $Content
         Icon = $Icon
         IsDynamic = ($null -ne $ScriptBlock)
+        CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -681,6 +761,10 @@ function New-PodeWebAccordion
         $CssClass,
 
         [Parameter()]
+        [hashtable]
+        $CssStyle,
+
+        [Parameter()]
         [int]
         $CycleInterval = 15,
 
@@ -707,6 +791,7 @@ function New-PodeWebAccordion
         ID = (Get-PodeWebElementId -Tag Accordion -Id $Id -NameAsToken)
         Bellows = $Bellows
         CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Mode = $Mode
         Cycle = @{
             Enabled = $Cycle.IsPresent
@@ -729,7 +814,15 @@ function New-PodeWebBellow
 
         [Parameter()]
         [string]
-        $Icon
+        $Icon,
+
+        [Parameter()]
+        [string[]]
+        $CssClass,
+
+        [Parameter()]
+        [hashtable]
+        $CssStyle
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -743,5 +836,7 @@ function New-PodeWebBellow
         ID = (Get-PodeWebElementId -Tag Bellow -Name $Name)
         Content = $Content
         Icon = $Icon
+        CssClasses = ($CssClass -join ' ')
+        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1306,3 +1306,65 @@ function Remove-PodeWebComponentStyle
         Property = $Property
     }
 }
+
+function Add-PodeWebComponentClass
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Class
+    )
+
+    return @{
+        Operation = 'Add'
+        ObjectType = 'Component-Class'
+        ID = $Id
+        Type = $Type
+        Name = $Name
+        Class = $Class
+    }
+}
+
+function Remove-PodeWebComponentClass
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Class
+    )
+
+    return @{
+        Operation = 'Remove'
+        ObjectType = 'Component-Class'
+        ID = $Id
+        Type = $Type
+        Name = $Name
+        Class = $Class
+    }
+}

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -112,8 +112,8 @@ function bindFileStreams() {
                 error: function() {
                     hideSpinner($(e).closest('div.file-stream'));
                     clearInterval(_fileStreams[getId(e)]);
-                    $(e).closest('div.file-stream').addClass('stream-error');
-                    $(e).closest('div.file-stream').find('div.card-header div div.btn-group').hide();
+                    addClass($(e).closest('div.file-stream'), 'stream-error');
+                    hide($(e).closest('div.file-stream').find('div.card-header div div.btn-group'));
                 }
             });
         }, $(e).attr('pode-interval'));
@@ -244,7 +244,7 @@ function mapElementThemes() {
     types.forEach((type) => {
         $(`.${type}-inbuilt-theme`).each((i, e) => {
             $(e).removeClass(`${type}-inbuilt-theme`);
-            $(e).addClass(`${type}-${defTheme}`);
+            addClass($(e), `${type}-${defTheme}`);
         });
     });
 }
@@ -426,17 +426,17 @@ function setValidationError(element) {
         return;
     }
 
-    element.addClass('is-invalid');
+    addClass(element, 'is-invalid');
 
     // form-row? flag inside inputs
     if (element.hasClass('form-row')) {
-        element.find('input').addClass('is-invalid');
+        addClass(element.find('input'), 'is-invalid');
     }
 
     // input? find parent input-group/form-row
     if (testTagName(element, 'input')) {
-        element.closest('div.input-group').addClass('is-invalid');
-        element.closest('div.form-row').addClass('is-invalid');
+        addClass(element.closest('div.input-group'), 'is-invalid');
+        addClass(element.closest('div.form-row'), 'is-invalid');
     }
 }
 
@@ -575,10 +575,7 @@ function showSpinner(sender) {
         return;
     }
 
-    var spinner = sender.find('span.spinner-border');
-    if (spinner) {
-        spinner.show();
-    }
+    show(sender.find('span.spinner-border'));
 }
 
 function hideSpinner(sender) {
@@ -586,10 +583,7 @@ function hideSpinner(sender) {
         return;
     }
 
-    var spinner = sender.find('span.spinner-border');
-    if (spinner) {
-        spinner.hide();
-    }
+    hide(sender.find('span.spinner-border'));
 }
 
 function unfocus(sender) {
@@ -1118,7 +1112,7 @@ function loadSelect(selectId) {
 
 function bindTileRefresh() {
     $("div.pode-tile .pode-tile-body .pode-refresh-btn").each((i, e) => {
-        $(e).hide();
+        hide($(e));
     });
 
     $("div.pode-tile span.pode-tile-refresh").off('click').on('click', function(e) {
@@ -1304,6 +1298,10 @@ function invokeActions(actions, sender) {
 
             case 'component-style':
                 actionComponentStyle(action);
+                break;
+
+            case 'component-class':
+                actionComponentClass(action);
                 break;
 
             default:
@@ -1584,8 +1582,8 @@ function filterTable(filter) {
     var tableId = filter.attr('for');
     var value = filter.val();
 
-    $(`table#${tableId} tbody tr:not(:icontains('${value}'))`).hide();
-    $(`table#${tableId} tbody tr:icontains('${value}')`).show();
+    hide($(`table#${tableId} tbody tr:not(:icontains('${value}'))`));
+    show($(`table#${tableId} tbody tr:icontains('${value}')`));
 }
 
 function bindSidebarFilter() {
@@ -1598,15 +1596,15 @@ function bindSidebarFilter() {
 
         if (value) {
             $('div.collapse').collapse('show');
-            $(`ul#${listId} li.nav-group-title`).hide();
+            hide($(`ul#${listId} li.nav-group-title`));
         }
         else {
             $('div.collapse').collapse('hide');
-            $(`ul#${listId} li.nav-group-title`).show();
+            show($(`ul#${listId} li.nav-group-title`));
         }
 
-        $(`ul#${listId} li.nav-page-item:not(:icontains('${value}'))`).hide();
-        $(`ul#${listId} li.nav-page-item:icontains('${value}')`).show();
+        hide($(`ul#${listId} li.nav-page-item:not(:icontains('${value}'))`));
+        show($(`ul#${listId} li.nav-page-item:icontains('${value}')`));
     });
 }
 
@@ -2251,7 +2249,7 @@ function updateTile(action, sender) {
     // change colour
     if (action.Colour) {
         removeClass(tile, 'alert-\\w+');
-        tile.addClass(`alert-${action.ColourType}`);
+        addClass(tile, `alert-${action.ColourType}`);
     }
 }
 
@@ -2262,6 +2260,40 @@ function syncTile(action) {
     }
 
     loadTile(getId(tile));
+}
+
+function actionComponentClass(action) {
+    if (!action) {
+        return;
+    }
+
+    switch (action.Operation.toLowerCase()) {
+        case 'add':
+            addComponentClass(action);
+            break;
+
+        case 'remove':
+            removeComponentClass(action);
+            break;
+    }
+}
+
+function addComponentClass(action) {
+    var obj = getElementByNameOrId(action);
+    if (!obj) {
+        return;
+    }
+
+    addClass(obj, action.Class);
+}
+
+function removeComponentClass(action) {
+    var obj = getElementByNameOrId(action);
+    if (!obj) {
+        return;
+    }
+
+    removeClass(obj, action.Class, true);
 }
 
 function actionComponentStyle(action) {
@@ -3099,7 +3131,7 @@ function actionBadge(action) {
     // change colour
     if (action.Colour) {
         removeClass(badge, 'badge-\\w+');
-        badge.addClass(`badge-${action.ColourType}`);
+        addClass(badge, `badge-${action.ColourType}`);
     }
 }
 
@@ -3126,7 +3158,7 @@ function actionProgress(action) {
     // change colour
     if (action.Colour) {
         removeClass(progress, 'bg-\\w+');
-        progress.addClass(`bg-${action.ColourType}`);
+        addClass(progress, `bg-${action.ColourType}`);
     }
 }
 
@@ -3139,7 +3171,7 @@ function getClass(element, filter) {
     return (result ? result[0] : null);
 }
 
-function removeClass(element, filter) {
+function removeClass(element, filter, raw) {
     if (!element) {
         return;
     }
@@ -3148,8 +3180,36 @@ function removeClass(element, filter) {
         element.removeClass();
     }
     else {
-        element.removeClass(getClass(element, filter));
+        element.removeClass((raw ? filter : getClass(element, filter)));
     }
+}
+
+function addClass(element, _class) {
+    if (!element) {
+        return;
+    }
+
+    if (element.hasClass(_class)) {
+        return;
+    }
+
+    element.addClass(_class);
+}
+
+function hide(element) {
+    if (!element) {
+        return;
+    }
+
+    element.hide();
+}
+
+function show(element) {
+    if (!element) {
+        return;
+    }
+
+    element.show();
 }
 
 function actionTab(action) {

--- a/src/Templates/Views/elements/alert.pode
+++ b/src/Templates/Views/elements/alert.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="alert alert-$($data.ClassType) $($data.CssClasses)" pode-object="$($data.ObjectType)" role="alert" $(ConvertTo-PodeWebEvents -Events $data.Events)>
+<div id="$($data.ID)" class="alert alert-$($data.ClassType) $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)" role="alert" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     <h6 class='pode-alert-header'>
         <span class="mdi mdi-$($data.IconType)"></span>
         <strong>$($data.Type)</strong>

--- a/src/Templates/Views/elements/badge.pode
+++ b/src/Templates/Views/elements/badge.pode
@@ -1,3 +1,3 @@
-<span id="$($data.ID)" class="badge badge-$($data.ColourType) $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
+<span id="$($data.ID)" class="badge badge-$($data.ColourType) $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     $($data.Value)
 </span>

--- a/src/Templates/Views/elements/button.pode
+++ b/src/Templates/Views/elements/button.pode
@@ -16,26 +16,26 @@
 
         if ($data.IconOnly) {
             if ($data.IsDynamic) {
-                "<button type='button' class='btn btn-icon-only pode-button $($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)' pode-data-value='$($data.DataValue)' title='$($data.Name)' data-toggle='tooltip'>
+                "<button type='button' class='btn btn-icon-only pode-button $($data.CssClasses)' style='$($data.CssStyles)' id='$($data.ID)' pode-object='$($data.ObjectType)' pode-data-value='$($data.DataValue)' title='$($data.Name)' data-toggle='tooltip'>
                     $($icon)
                 </button>"
             }
             else {
-                "<a id='$($data.ID)' class='btn btn-icon-only pode-link-button $($data.CssClasses)' pode-object='$($data.ObjectType)' href='$($data.Url)' target='$($target)' role='button' title='$($data.Name)' data-toggle='tooltip'>
+                "<a id='$($data.ID)' class='btn btn-icon-only pode-link-button $($data.CssClasses)' style='$($data.CssStyles)' pode-object='$($data.ObjectType)' href='$($data.Url)' target='$($target)' role='button' title='$($data.Name)' data-toggle='tooltip'>
                     $($icon)
                 </a>"
             }
         }
         else {
             if ($data.IsDynamic) {
-                "<button type='button' class='btn btn-$($data.ColourType) pode-button $($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)' pode-data-value='$($data.DataValue)'>
+                "<button type='button' class='btn btn-$($data.ColourType) pode-button $($data.CssClasses)' style='$($data.CssStyles)' id='$($data.ID)' pode-object='$($data.ObjectType)' pode-data-value='$($data.DataValue)'>
                     <span class='spinner-border spinner-border-sm' role='status' aria-hidden='true' style='display: none'></span>
                     $($icon)
                     $($data.Name)
                 </button>"
             }
             else {
-                "<a id='$($data.ID)' class='btn pode-link-button btn-$($data.ColourType) $($data.CssClasses)' pode-object='$($data.ObjectType)' href='$($data.Url)' target='$($target)' role='button'>
+                "<a id='$($data.ID)' class='btn pode-link-button btn-$($data.ColourType) $($data.CssClasses)' style='$($data.CssStyles)' pode-object='$($data.ObjectType)' href='$($data.Url)' target='$($target)' role='button'>
                     $($icon)
                     $($data.Name)
                 </a>"

--- a/src/Templates/Views/elements/chart.pode
+++ b/src/Templates/Views/elements/chart.pode
@@ -17,7 +17,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
         class="my-4 w-100"
         id="$($data.ID)"
         name="$($data.Name)"
-        style="$(if ($data.Height -gt 0) { "height:$($data.Height)px;" })"
+        style="$(if ($data.Height -gt 0) { "height:$($data.Height)px;" }) $($data.CssStyles)"
         pode-object="$($data.ObjectType)"
         pode-chart-type="$($data.ChartType)"
         pode-dynamic="$($data.IsDynamic)"

--- a/src/Templates/Views/elements/checkbox.pode
+++ b/src/Templates/Views/elements/checkbox.pode
@@ -21,7 +21,7 @@
 
             for ($i = 0; $i -lt $data.Options.Length; $i++) {
                 if ($data.AsSwitch) {
-                    "<div class='custom-control custom-switch $($inline)'>
+                    "<div class='custom-control custom-switch $($inline)' style='$($data.CssStyles)'>
                         <input type='checkbox' class='custom-control-input' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked)>
                         <label class='custom-control-label' for='$($data.ID)_option$($i)'>
                             $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })
@@ -29,7 +29,7 @@
                     </div>"
                 }
                 else {
-                    "<div class='form-check $($inline)'>
+                    "<div class='form-check $($inline)' style='$($data.CssStyles)'>
                         <input class='form-check-input' type='checkbox' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked)>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
                             $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })

--- a/src/Templates/Views/elements/code-editor.pode
+++ b/src/Templates/Views/elements/code-editor.pode
@@ -7,6 +7,7 @@
 
     <div
         class="code-editor"
+        style="$($data.CssStyles)"
         for="$($data.ID)"
         pode-language="$($data.Language)"
         pode-theme="$($data.Theme)"

--- a/src/Templates/Views/elements/code.pode
+++ b/src/Templates/Views/elements/code.pode
@@ -1,1 +1,1 @@
-<code id="$($data.ID)" class="$($data.CssClasses)" pode-object="$($data.ObjectType)">$($data.Value)</code>
+<code id="$($data.ID)" class="$($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">$($data.Value)</code>

--- a/src/Templates/Views/elements/codeblock.pode
+++ b/src/Templates/Views/elements/codeblock.pode
@@ -10,7 +10,7 @@ $(
         <span class='mdi mdi-clipboard-text-multiple-outline mdi-size-20 mRight02'></span>
     </button>
 
-    <code id="$($data.ID)" class="$($data.Language)" pode-object="$($data.ObjectType)">
+    <code id="$($data.ID)" class="$($data.Language)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
         $($data.Value)
     </code>
 </pre>

--- a/src/Templates/Views/elements/comment.pode
+++ b/src/Templates/Views/elements/comment.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="media $($data.CssClasses)" pode-object="$($data.ObjectType)">
+<div id="$($data.ID)" class="media $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
     <img src="$($data.Icon)" class="align-self-start mr-3" alt="$($data.Username) icon">
     <div class="media-body">
         <div class="media-head">

--- a/src/Templates/Views/elements/credential.pode
+++ b/src/Templates/Views/elements/credential.pode
@@ -22,7 +22,7 @@
                     else {
                         $placeholder = "placeholder='Username'"
                     }
-                    "<input type='text' class='form-control' id='$($data.ID)_username' name='$($data.Name)_Username' $($describedBy) $($readOnly) $($placeholder)>
+                    "<input type='text' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_username' name='$($data.Name)_Username' $($describedBy) $($readOnly) $($placeholder)>
                 </div>
                 <div class='form-group col-md-6'>"
                     if (!$data.NoLabels) {
@@ -33,7 +33,7 @@
                     }
                     "<div class='input-group mb-2'>
                         <div class='input-group-prepend'><div class='input-group-text'><span class='mdi mdi-lock'></span></div></div>
-                        <input type='password' class='form-control' id='$($data.ID)_password' name='$($data.Name)_Password' $($describedBy) $($readOnly) $($placeholder)>
+                        <input type='password' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_password' name='$($data.Name)_Password' $($describedBy) $($readOnly) $($placeholder)>
                     </div>
                 </div>
             </div>"

--- a/src/Templates/Views/elements/datetime.pode
+++ b/src/Templates/Views/elements/datetime.pode
@@ -17,13 +17,13 @@
                     if (!$data.NoLabels) {
                         "<label for='$($data.ID)_date'>Date</label>"
                     }
-                    "<input type='date' class='form-control' id='$($data.ID)_date' name='$($data.Name)_Date' $($describedBy) $($readOnly)>
+                    "<input type='date' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_date' name='$($data.Name)_Date' $($describedBy) $($readOnly)>
                 </div>
                 <div class='form-group col-md-6'>"
                     if (!$data.NoLabels) {
                         "<label for='$($data.ID)_time'>Time</label>"
                     }
-                    "<input type='time' class='form-control' id='$($data.ID)_time' name='$($data.Name)_Time' $($describedBy) $($readOnly)>
+                    "<input type='time' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_time' name='$($data.Name)_Time' $($describedBy) $($readOnly)>
                 </div>
             </div>"
         )

--- a/src/Templates/Views/elements/filestream.pode
+++ b/src/Templates/Views/elements/filestream.pode
@@ -1,4 +1,4 @@
-<div class="card file-stream">
+<div class="card file-stream $($data.CssClasses)">
     $(if (!$data.NoHeader) {
         "<div class='card-header d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom'>
             <h5>"
@@ -30,6 +30,7 @@
         <pre>
             <textarea
                 class="form-control"
+                style="$($data.CssStyles)"
                 pode-file="$($data.Url)"
                 pode-length="0"
                 pode-interval="$($data.Interval)"

--- a/src/Templates/Views/elements/fileupload.pode
+++ b/src/Templates/Views/elements/fileupload.pode
@@ -3,7 +3,7 @@
         "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
     })
     <div class="col-sm-10">
-        <input type='file' class="form-control-file $(if ($data.NoForm) { 'no-form' })" id="$($data.ID)" name="$($data.Name)" pode-object="$($data.ObjectType)">
+        <input type='file' class="form-control-file $(if ($data.NoForm) { 'no-form' })" id="$($data.ID)" name="$($data.Name)" pode-object="$($data.ObjectType)" style="$($data.CssStyles)">
         <div id="$($data.ID)_validation" class="invalid-feedback"></div>
     </div>
 </div>

--- a/src/Templates/Views/elements/form.pode
+++ b/src/Templates/Views/elements/form.pode
@@ -2,7 +2,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
     "<p class='card-text'>$($data.Message)</p>"
 })
 
-<form id="$($data.ID)" name="$($data.Name)" class="pode-form $($data.CssClasses)" action="POST" method="/components/form/$($data.ID)" pode-object="$($data.ObjectType)">
+<form id="$($data.ID)" name="$($data.Name)" class="pode-form $($data.CssClasses)" style="$($data.CssStyles)" action="POST" method="/components/form/$($data.ID)" pode-object="$($data.ObjectType)">
     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })
     <button class="btn btn-inbuilt-theme" type="submit">
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none"></span>

--- a/src/Templates/Views/elements/header.pode
+++ b/src/Templates/Views/elements/header.pode
@@ -1,6 +1,6 @@
 $(
     $value = $data.Value
-    $header = "<h$($data.Size) id='$($data.ID)' class='$($data.CssClasses)' pode-object='$($data.ObjectType)'>$($value)"
+    $header = "<h$($data.Size) id='$($data.ID)' class='$($data.CssClasses)' style='$($data.CssStyles)' pode-object='$($data.ObjectType)'>$($value)"
 
     if (![string]::IsNullOrWhiteSpace($data.Secondary)) {
         $sub = $data.Secondary

--- a/src/Templates/Views/elements/hidden.pode
+++ b/src/Templates/Views/elements/hidden.pode
@@ -1,4 +1,4 @@
-<div class="form-group row pode-form-hidden $($data.CssClasses)">
+<div class="form-group row pode-form-hidden $($data.CssClasses)" style="$($data.CssStyles)">
     <div class="col-sm-10">
         <input type="hidden" class="form-control" id="$($data.ID)" name="$($data.Name)" value="$($data.Value)" pode-object="$($data.ObjectType)">
     </div>

--- a/src/Templates/Views/elements/icon.pode
+++ b/src/Templates/Views/elements/icon.pode
@@ -1,7 +1,7 @@
 $(
     $colour = [string]::Empty
     if (![string]::IsNullOrWhiteSpace($data.Colour)) {
-        $colour = "style='color:$($data.Colour);'"
+        $colour = "color:$($data.Colour);"
     }
 
     $title = [string]::Empty
@@ -24,5 +24,5 @@ $(
         $rotate = "mdi-rotate-$($data.Rotate)"
     }
 
-    "<span id='$($data.ID)' class='mdi mdi-$($data.Name) pode-object='$($data.ObjectType)' $($spin) $($flip) $($rotate) $($data.CssClasses)' $($colour) $($title) $(ConvertTo-PodeWebEvents -Events $data.Events)></span>"
+    "<span id='$($data.ID)' class='mdi mdi-$($data.Name) $($spin) $($flip) $($rotate) $($data.CssClasses)' style='$($colour) $($data.CssStyles)' pode-object='$($data.ObjectType)' $($title) $(ConvertTo-PodeWebEvents -Events $data.Events)></span>"
 )

--- a/src/Templates/Views/elements/iframe.pode
+++ b/src/Templates/Views/elements/iframe.pode
@@ -2,6 +2,8 @@
     src="$($data.Url)"
     title="$($data.Title)"
     id="$($data.ID)"
+    class="$($data.CssClasses)"
+    style="$($data.CssStyles)"
     name="$($data.Name)"
     pode-object="$($data.ObjectType)">
 </iframe>

--- a/src/Templates/Views/elements/image.pode
+++ b/src/Templates/Views/elements/image.pode
@@ -18,14 +18,14 @@ $(
     $fluid = [string]::Empty
 
     if ($data.Height -gt 0 -and $data.Width -gt 0) {
-        $dim = "style='height:$($data.Height)px;width:$($data.Width)px'"
+        $dim = "height:$($data.Height)px;width:$($data.Width)px;"
     }
     elseif ($data.Height -gt 0) {
-        $dim = "style='height:$($data.Height)px'"
+        $dim = "height:$($data.Height)px;"
         $fluid = 'img-fluid'
     }
     elseif ($data.Width -gt 0) {
-        $dim = "style='width:$($data.Width)px'"
+        $dim = "width:$($data.Width)px;"
         $fluid = 'img-fluid'
     }
     else {
@@ -37,5 +37,5 @@ $(
         $title = "title='$($data.Title)' data-toggle='tooltip' data-placement='bottom'"
     }
 
-    "<img src='$($data.Source)' id='$($data.ID)' class='$($fluid) rounded $($loc) $($data.CssClasses)' pode-object='$($data.ObjectType)' $($title) $($dim) $(ConvertTo-PodeWebEvents -Events $data.Events)>"
+    "<img src='$($data.Source)' id='$($data.ID)' class='$($fluid) rounded $($loc) $($data.CssClasses)' style='$($dim) $($data.CssStyles)' pode-object='$($data.ObjectType)' $($title) $(ConvertTo-PodeWebEvents -Events $data.Events)>"
 )

--- a/src/Templates/Views/elements/line.pode
+++ b/src/Templates/Views/elements/line.pode
@@ -1,1 +1,1 @@
-<hr id="$($data.ID)" class="my-4 $($data.CssClasses)" pode-object="$($data.ObjectType)">
+<hr id="$($data.ID)" class="my-4 $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">

--- a/src/Templates/Views/elements/link.pode
+++ b/src/Templates/Views/elements/link.pode
@@ -4,5 +4,5 @@ $(
         $target = '_blank'
     }
 
-    "<a href='$($data.Source)' id='$($data.ID)' target='$($target)' class='$($data.CssClasses)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>$($data.Value)</a>"
+    "<a href='$($data.Source)' id='$($data.ID)' target='$($target)' class='$($data.CssClasses)' style='$($data.CssStyles)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>$($data.Value)</a>"
 )

--- a/src/Templates/Views/elements/list.pode
+++ b/src/Templates/Views/elements/list.pode
@@ -4,11 +4,11 @@ $(
         $tag = 'ol'
     }
 
-    "<$($tag) class='$($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)'>"
+    "<$($tag) class='$($data.CssClasses)' style='$($data.CssStyles)' id='$($data.ID)' pode-object='$($data.ObjectType)'>"
 
     if (($null -ne $data.Items) -and ($data.Items.Length -gt 0)) {
         foreach ($item in $data.Items) {
-            "<li id='$($item.ID)'>"
+            "<li id='$($item.ID)' class='$($item.CssClasses)' style='$($item.CssStyles)'>"
                 Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $item.Content }
             "</li>"
         }

--- a/src/Templates/Views/elements/minmax.pode
+++ b/src/Templates/Views/elements/minmax.pode
@@ -46,7 +46,7 @@
                     }
 
                     $element += $prepend
-                    $element += "<input type='number' class='form-control' id='$($data.ID)_min' name='$($data.Name)_Min' value='$($data.Values.Min)' $($describedBy) $($readOnly)>"
+                    $element += "<input type='number' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_min' name='$($data.Name)_Min' value='$($data.Values.Min)' $($describedBy) $($readOnly)>"
                     $element += $append
 
                     if ($wrapped) {
@@ -66,7 +66,7 @@
                     }
 
                     $element += $prepend
-                    $element += "<input type='number' class='form-control' id='$($data.ID)_max' name='$($data.Name)_Max' value='$($data.Values.Max)' $($describedBy) $($readOnly)>"
+                    $element += "<input type='number' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_max' name='$($data.Name)_Max' value='$($data.Values.Max)' $($describedBy) $($readOnly)>"
                     $element += $append
 
                     if ($wrapped) {

--- a/src/Templates/Views/elements/paragraph.pode
+++ b/src/Templates/Views/elements/paragraph.pode
@@ -1,4 +1,4 @@
-<p id="$($data.ID)" class="text-$($data.Alignment) $($data.CssClasses)" pode-object="$($data.ObjectType)">
+<p id="$($data.ID)" class="text-$($data.Alignment) $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
     $(if (![string]::IsNullOrWhiteSpace($data.Value)) {
         $data.Value
     }

--- a/src/Templates/Views/elements/progress.pode
+++ b/src/Templates/Views/elements/progress.pode
@@ -14,7 +14,7 @@ $(
         $animated = 'progress-bar-animated'
     }
 
-    $progress = "<div class='progress $($data.CssClasses)'>
+    $progress = "<div class='progress $($data.CssClasses)' style='$($data.CssStyles)'>
             <div
                 class='progress-bar bg-$($data.ColourType) $($showValue) $($striped) $($animated)'
                 id='$($data.ID)'

--- a/src/Templates/Views/elements/quote.pode
+++ b/src/Templates/Views/elements/quote.pode
@@ -1,7 +1,7 @@
 $(
     $value = $data.Value
 
-    $quote = "<blockquote class='blockquote text-$($data.Alignment) $($data.CssClasses)' id='$($data.ID)' pode-object='$($data.ObjectType)'>
+    $quote = "<blockquote class='blockquote text-$($data.Alignment) $($data.CssClasses)' style='$($data.CssStyles)' id='$($data.ID)' pode-object='$($data.ObjectType)'>
         <p class='pode-text mb-0'>$($value)</p>"
 
     if (![string]::IsNullOrWhiteSpace($data.Source)) {

--- a/src/Templates/Views/elements/radio.pode
+++ b/src/Templates/Views/elements/radio.pode
@@ -11,7 +11,7 @@
                 }
 
                 for ($i = 0; $i -lt $data.Options.Length; $i++) {
-                    "<div class='form-check $($inline)'>
+                    "<div class='form-check $($inline)' style='$($data.CssStyles)'>
                         <input class='form-check-input' type='radio' name='$($data.Name)' id='$($data.ID)_option$($i)' value='$($data.Options[$i])' $(if ($i -eq 0) { 'checked' }) $(if ($data.Disabled) { 'disabled' })>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
                             $($data.Options[$i])

--- a/src/Templates/Views/elements/range.pode
+++ b/src/Templates/Views/elements/range.pode
@@ -9,7 +9,7 @@
                 $showValue = 'pode-range-value'
             }
 
-            "<input type='range' class='form-control-range $($showValue)' id='$($data.ID)' pode-object='$($data.ObjectType)' name='$($data.Name)' value='$($data.Value)' min='$($data.Min)' max='$($data.Max)' $(if ($data.Disabled) { 'disabled' }) $(ConvertTo-PodeWebEvents -Events $data.Events)>"
+            "<input type='range' class='form-control-range $($showValue)' style='$($data.CssStyles)' id='$($data.ID)' pode-object='$($data.ObjectType)' name='$($data.Name)' value='$($data.Value)' min='$($data.Min)' max='$($data.Max)' $(if ($data.Disabled) { 'disabled' }) $(ConvertTo-PodeWebEvents -Events $data.Events)>"
 
             if ($data.ShowValue) {
                 "<input type='number' class='form-control $($showValue)' id='$($data.ID)_value' for='$($data.ID)' value='$($data.Value)' min='$($data.Min)' max='$($data.Max)'>"

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -11,6 +11,7 @@
 
             "<select
                 class='custom-select $(if ($data.NoForm) { 'no-form' })'
+                style='$($data.CssStyles)'
                 id='$($data.ID)'
                 name='$($data.Name)'
                 pode-object='$($data.ObjectType)'

--- a/src/Templates/Views/elements/spinner.pode
+++ b/src/Templates/Views/elements/spinner.pode
@@ -1,7 +1,7 @@
 $(
     $colour = [string]::Empty
     if (![string]::IsNullOrWhiteSpace($data.Colour)) {
-        $colour = "style='color:$($data.Colour);'"
+        $colour = "color:$($data.Colour);"
     }
 
     $title = [string]::Empty
@@ -9,5 +9,5 @@ $(
         $title = "title='$($data.Title)' data-toggle='tooltip'"
     }
 
-    "<span id='$($data.ID)' class='spinner-border spinner-border-sm $($data.CssClasses)' pode-object='$($data.ObjectType)' role='status' $($colour) $($title)></span>"
+    "<span id='$($data.ID)' class='spinner-border spinner-border-sm $($data.CssClasses)' style='$($colour) $($data.CssStyles)' pode-object='$($data.ObjectType)' role='status' $($title)></span>"
 )

--- a/src/Templates/Views/elements/table.pode
+++ b/src/Templates/Views/elements/table.pode
@@ -22,6 +22,7 @@ $(if ($data.Filter.Enabled) {
                 name='$($data.Name)'
                 pode-object='$($data.ObjectType)'
                 class='table table-striped table-hover $($click)'
+                style='$($data.CssStyles)'
                 pode-dynamic='$($data.IsDynamic)'
                 pode-click-dynamic='$($data.ClickIsDynamic)'
                 pode-data-column='$($data.DataColumn)'

--- a/src/Templates/Views/elements/text.pode
+++ b/src/Templates/Views/elements/text.pode
@@ -1,5 +1,5 @@
 $(
-    $value = "<span id='$($data.ID)' class='pode-text $($data.CssClasses)' pode-object='$($data.ObjectType)'>$($data.Value)</span>"
+    $value = "<span id='$($data.ID)' class='pode-text $($data.CssClasses)' style='$($data.CssStyles)' pode-object='$($data.ObjectType)'>$($data.Value)</span>"
 
     switch ($data.Style.ToLowerInvariant()) {
         'underlined' {

--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -29,7 +29,7 @@
             $events = ConvertTo-PodeWebEvents -Events $data.Events
 
             if ($data.Multiline) {
-                $element = "<textarea class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width)' $($describedBy) $($readOnly) $($value) $($events)></textarea>"
+                $element = "<textarea class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width) $($data.CssStyles)' $($describedBy) $($readOnly) $($value) $($events)></textarea>"
             }
             else {
                 if ($data.Prepend.Enabled -or $data.Append.Enabled) {
@@ -50,7 +50,7 @@
                     $_type = 'datetime-local'
                 }
 
-                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' style='$($width)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($value) $($events)>"
+                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' style='$($width) $($data.CssStyles)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($value) $($events)>"
 
                 if ($data.Append.Enabled) {
                     if (![string]::IsNullOrWhiteSpace($data.Append.Text)) {

--- a/src/Templates/Views/elements/tile.pode
+++ b/src/Templates/Views/elements/tile.pode
@@ -2,7 +2,7 @@ $(if ($data.NewLine) {
     "<br/>"
 })
 
-<div id="$($data.ID)" class="container pode-tile alert-$($data.ColourType) rounded $($data.CssClasses)" pode-object="$($data.ObjectType)" name="$($data.Name)" pode-dynamic="$($data.IsDynamic)" pode-click="$($data.Click)" pode-auto-refresh="$($data.AutoRefresh)" pode-refresh-interval="$($data.RefreshInterval)">
+<div id="$($data.ID)" class="container pode-tile alert-$($data.ColourType) rounded $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)" name="$($data.Name)" pode-dynamic="$($data.IsDynamic)" pode-click="$($data.Click)" pode-auto-refresh="$($data.AutoRefresh)" pode-refresh-interval="$($data.RefreshInterval)">
     <h6 class="pode-tile-header">
         $(if (![string]::IsNullOrWhiteSpace($data.Icon)) {
             "<span class='mdi mdi-$($data.Icon.ToLowerInvariant())'></span>"

--- a/src/Templates/Views/elements/timer.pode
+++ b/src/Templates/Views/elements/timer.pode
@@ -1,6 +1,7 @@
 <span
     id="$($data.ID)"
     class="hide pode-timer $($data.CssClasses)"
+    style="$($data.CssStyles)"
     pode-interval="$($data.Interval)"
     pode-object="$($data.ObjectType)">
 </span>

--- a/src/Templates/Views/layouts/accordion.pode
+++ b/src/Templates/Views/layouts/accordion.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="accordion $($data.CssClasses)" pode-object="$($data.ObjectType)" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)" pode-mode="$($data.Mode.ToLowerInvariant())">
+<div id="$($data.ID)" class="accordion $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)" pode-mode="$($data.Mode.ToLowerInvariant())">
 
     $(for ($i = 0; $i -lt $data.Bellows.Length; $i++) {
         $bellow = $data.Bellows[$i]
@@ -15,7 +15,7 @@
             $arrow = 'down'
         }
 
-        "<div class='card bellow' id='$($bellow.ID)' name='$($bellow.Name)' pode-object='$($bellow.ObjectType)'>
+        "<div class='card bellow $($bellow.CssClasses)' style='$($bellow.CssStyles)' id='$($bellow.ID)' name='$($bellow.Name)' pode-object='$($bellow.ObjectType)'>
             <div class='card-header bellow-header' id='$($bellow.ID)_head'>
                 <h2 class='mb-0'>
                     <button class='btn btn-link btn-block text-left $($collapsed)' type='button' data-toggle='collapse' data-target='#$($bellow.ID)_body' aria-expanded='$($expanded)' aria-controls='$($bellow.ID)_body'>"

--- a/src/Templates/Views/layouts/card.pode
+++ b/src/Templates/Views/layouts/card.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="card pode-card $($data.CssClasses)" pode-object="$($data.ObjectType)">
+<div id="$($data.ID)" class="card pode-card $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
     $(if ((!$data.NoTitle -and $data.Name) -or !$data.NoHide) {
         $icon = [string]::Empty
         if (![string]::IsNullOrWhiteSpace($data.Icon)) {

--- a/src/Templates/Views/layouts/carousel.pode
+++ b/src/Templates/Views/layouts/carousel.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="carousel slide $($data.CssClasses)" data-ride="carousel">
+<div id="$($data.ID)" class="carousel slide $($data.CssClasses)" style="$($data.CssStyles)" data-ride="carousel">
     <ol class="carousel-indicators">
         $(for ($i = 0; $i -lt $data.Slides.Length; $i++) {
             "<li data-target='#$($data.ID)' data-slide-to='$($i)' class='$(if ($i -eq 0) { "active" })'></li>"
@@ -7,19 +7,21 @@
 
     <div class="carousel-inner">
         $(for ($i = 0; $i -lt $data.Slides.Length; $i++) {
-            "<div id='$($data.Slides[$i].ID)' pode-object='$($data.Slides[$i].ObjectType)' class='carousel-item $(if ($i -eq 0) { "active" })'>"
+            $slide = $data.Slides[$i]
+
+            "<div id='$($slide.ID)' pode-object='$($slide.ObjectType)' class='carousel-item $(if ($i -eq 0) { "active" }) $($slide.CssClasses)' style='$($slide.CssStyles)'>"
 
                 "<div class='d-flex w-100 h-100'>"
-                Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Slides[$i].Content }
+                Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $slide.Content }
                 "</div>"
 
                 "<div class='carousel-caption d-none d-md-block'>"
-                    if (![string]::IsNullOrWhiteSpace($data.Slides[$i].Title)) {
-                        "<h5>$($data.Slides[$i].Title)</h5>"
+                    if (![string]::IsNullOrWhiteSpace($slide.Title)) {
+                        "<h5>$($slide.Title)</h5>"
                     }
 
-                    if (![string]::IsNullOrWhiteSpace($data.Slides[$i].Message)) {
-                        "<p>$($data.Slides[$i].Message)</p>"
+                    if (![string]::IsNullOrWhiteSpace($slide.Message)) {
+                        "<p>$($slide.Message)</p>"
                     }
                 "</div>
             </div>"

--- a/src/Templates/Views/layouts/container.pode
+++ b/src/Templates/Views/layouts/container.pode
@@ -1,4 +1,4 @@
 
-<div id="$($data.ID)" class="container pode-container $($data.CssClasses)" pode-object="$($data.ObjectType)" pode-transparent="$($data.NoBackground)" pode-hidden="$($data.Hide)">
+<div id="$($data.ID)" class="container pode-container $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)" pode-transparent="$($data.NoBackground)" pode-hidden="$($data.Hide)">
     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })
 </div>

--- a/src/Templates/Views/layouts/grid.pode
+++ b/src/Templates/Views/layouts/grid.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="container pode-grid $($data.CssClasses)" pode-object="$($data.ObjectType)">
+<div id="$($data.ID)" class="container pode-grid $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
     <div class='row'>
 
     $(
@@ -17,7 +17,7 @@
                 $width = "col-$($cell.Width)"
             }
 
-            "<div id='$($cell.ID)' class='text-$($cell.Alignment) $($width)' pode-object='$($cell.ObjectType)'>"
+            "<div id='$($cell.ID)' class='text-$($cell.Alignment) $($width) $($cell.CssClasses)' style='$($cell.CssStyles)' pode-object='$($cell.ObjectType)'>"
                 Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $cell.Content }
             "</div>"
         }

--- a/src/Templates/Views/layouts/hero.pode
+++ b/src/Templates/Views/layouts/hero.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="jumbotron $($data.CssClasses)" pode-object="$($data.ObjectType)">
+<div id="$($data.ID)" class="jumbotron $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
     <h1 class="display-4">$($data.Title)</h1>
     <p class="lead">$($data.Message)</p>
 

--- a/src/Templates/Views/layouts/modal.pode
+++ b/src/Templates/Views/layouts/modal.pode
@@ -1,4 +1,4 @@
-<div class="modal fade $($data.CssClasses)" id="$($data.ID)" pode-object="$($data.ObjectType)" name="$($data.Name)" tabindex="-1" aria-labelledby="$($data.ID)_lbl" aria-hidden="true" pode-data-value="">
+<div class="modal fade $($data.CssClasses)" style="$($data.CssStyles)" id="$($data.ID)" pode-object="$($data.ObjectType)" name="$($data.Name)" tabindex="-1" aria-labelledby="$($data.ID)_lbl" aria-hidden="true" pode-data-value="">
     <div class="modal-dialog modal-dialog-scrollable pode-modal-$($data.Size.ToLowerInvariant())">
         <div class="modal-content">
 

--- a/src/Templates/Views/layouts/steps.pode
+++ b/src/Templates/Views/layouts/steps.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="bs-stepper linear $($data.CssClasses)" role="stepper" pode-object="$($data.ObjectType)">
+<div id="$($data.ID)" class="bs-stepper linear $($data.CssClasses)" style="$($data.CssStyles)" role="stepper" pode-object="$($data.ObjectType)">
 
     <div class="bs-stepper-header" role="tablist">
         $(for ($i = 0; $i -lt $data.Steps.Length; $i++) {
@@ -30,7 +30,7 @@
             $(for ($i = 0; $i -lt $data.Steps.Length; $i++) {
                 $step = $data.Steps[$i]
 
-                "<div id='$($step.ID)' pode-object='$($step.ObjectType)' role='tabpanel' class='bs-stepper-pane content fade $(if ($i -eq 0) { "active" })' aria-labelledby='$($step.ID)-trigger' for='$($data.ID)' pode-dynamic='$($step.IsDynamic)'>"
+                "<div id='$($step.ID)' pode-object='$($step.ObjectType)' role='tabpanel' class='bs-stepper-pane content fade $(if ($i -eq 0) { "active" }) $($step.CssClasses)' style='$($data.CssStyles)' aria-labelledby='$($step.ID)-trigger' for='$($data.ID)' pode-dynamic='$($step.IsDynamic)'>"
                     Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $step.Content }
 
                     if ($i -gt 0) {

--- a/src/Templates/Views/layouts/tabs.pode
+++ b/src/Templates/Views/layouts/tabs.pode
@@ -1,4 +1,4 @@
-<ul id="$($data.ID)" class="nav nav-tabs $($data.CssClasses)" pode-object="$($data.ObjectType)" role="tablist" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)">
+<ul id="$($data.ID)" class="nav nav-tabs $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)" role="tablist" pode-cycle="$($data.Cycle.Enabled)" pode-interval="$($data.Cycle.Interval)">
     $(for ($i = 0; $i -lt $data.Tabs.Length; $i++) {
         $tab = $data.Tabs[$i]
 
@@ -11,7 +11,8 @@
             <a
                 id='$($tab.ID)'
                 name='$($tab.Name)'
-                class='nav-link $(if ($i -eq 0) { "active" })'
+                class='nav-link $(if ($i -eq 0) { "active" }) $($tab.CssClasses)'
+                style='$($data.CssStyles)'
                 pode-object='$($tab.ObjectType)'
                 data-toggle='tab' href='#$($tab.ID)_content'
                 role='tab'


### PR DESCRIPTION
### Description of the Change
Adds a new `-CssStyle` parameter onto each component, so custom CSS style properties can be added.

This also adds `Add-PodeWebComponentClass` and `Remove-PodeWebComponentClass` output actions.

### Related Issue
Resolves #89 

### Examples
The following would display a paragraph with yellow text:

```powershell
New-PodeWebParagraph -CssStyle @{ Color = 'Yellow' } -Elements @(
    New-PodeWebText -Value 'And then here is some more text, that also includes a '
    New-PodeWebLink -Value 'link' -Source 'https://google.com'
    New-PodeWebText -Value ' that takes you to Google'
)
```
