### PR TITLE
Add extra default chart colours, and support for customising them

### DIFF
--- a/docs/Tutorials/Elements/Charts.md
+++ b/docs/Tutorials/Elements/Charts.md
@@ -87,6 +87,23 @@ which renders a chart that looks like below:
 
 ![chart_bar_process](../../../images/chart_bar_process.png)
 
+## Colours
+
+A chart has 15 default colours that they can be rendered using. These colours can be customised if required, by suppling an array of hex colour codes to the `-Colours` parameter.
+
+For example, to render the below bar chart with reg/green bars, you could use:
+
+```powershell
+New-PodeWebContainer -Content @(
+    New-PodeWebChart -Name 'Top Processes' -Type Bar -AutoRefresh -Colours '#ff0000', '#00ff00' -ScriptBlock {
+        Get-Process |
+            Sort-Object -Property CPU -Descending |
+            Select-Object -First 10 |
+            ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU, Handles
+    }
+)
+```
+
 ## Append
 
 Now let's say we want `-AutoRefresh` a chart every minute, and we want it to display the current CPU usage, but only for the last 15 minutes. To do this, you have to supply `-Append` and any data returned from the `-ScriptBlock` will be appended to the chart instead. To restrict the data points to 15 minutes, we can supply `-MaxItems 15`.

--- a/examples/charts.ps1
+++ b/examples/charts.ps1
@@ -1,0 +1,44 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer -Threads 2 {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Charts' -Theme Dark
+
+    $chartData = {
+        $count = 1
+        if ($WebEvent.Data.FirstLoad -eq '1') {
+            $count = 4
+        }
+
+        return (1..$count | ForEach-Object {
+            @{
+                Key = $_
+                Values = @(foreach ($i in 1..15) {
+                    @{
+                        Key = "Example$($i)"
+                        Value = (Get-Random -Maximum 10)
+                    }
+                })
+            }
+        })
+    }
+
+    # set the home page controls
+    $card1 = New-PodeWebChart `
+        -Name 'Line Example' `
+        -Type Line `
+        -ScriptBlock $chartData `
+        -Append `
+        -TimeLabels `
+        -MaxItems 30 `
+        -AutoRefresh `
+        -AsCard `
+        -Colours '#ff0000', '#00ff00', '#0000ff'
+
+    Set-PodeWebHomePage -Layouts $card1 -Title 'Charts'
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1752,6 +1752,10 @@ function New-PodeWebChart
         [int]
         $RefreshInterval = 60,
 
+        [Parameter()]
+        [string[]]
+        $Colours,
+
         [switch]
         $Append,
 
@@ -1779,6 +1783,14 @@ function New-PodeWebChart
 
     if ($RefreshInterval -le 0) {
         $RefreshInterval = 60
+    }
+
+    if (($null -ne $Colours) -and ($Colours.Length -gt 0)) {
+        foreach ($clr in $Colours) {
+            if ($clr -inotmatch '^\s*#(([a-f\d])([a-f\d])([a-f\d])){1,2}\s*$') {
+                throw "Invalid colour supplied, should be hex format: $($clr)"
+            }
+        }
     }
 
     $element = @{
@@ -1810,6 +1822,7 @@ function New-PodeWebChart
         }
         NoEvents = $true
         NoAuthentication = $NoAuthentication.IsPresent
+        Colours = ($Colours -join ',')
     }
 
     $routePath = "/components/chart/$($Id)"
@@ -1889,6 +1902,10 @@ function New-PodeWebCounterChart
         $MaxY = 0,
 
         [Parameter()]
+        [string[]]
+        $Colours,
+
+        [Parameter()]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication,
@@ -1922,6 +1939,7 @@ function New-PodeWebCounterChart
         -MinY $MinY `
         -MaxX $MaxX `
         -MaxY $MaxY `
+        -Colours $Colours `
         -NoAuthentication:$NoAuthentication `
         -AsCard:$AsCard `
         -NoLegend:$NoLegend `

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2860,7 +2860,7 @@ function createTheChart(canvas, action, sender) {
     }
 
     // colours for lines/bars/segments
-    var palette = getChartColourPalette(theme);
+    var palette = getChartColourPalette(theme, canvas);
 
     // x-axis labels
     var xAxis = [];
@@ -2898,7 +2898,7 @@ function createTheChart(canvas, action, sender) {
     Object.keys(yAxises).forEach((key, index) => {
         switch (chartType.toLowerCase()) {
             case 'line':
-                yAxises[key].backgroundColor = palette[index % palette.length].replace(')', ', 0.2)');
+                yAxises[key].backgroundColor = palette[index % palette.length].replace('1.0)', '0.2)');
                 yAxises[key].borderColor = palette[index % palette.length];
                 yAxises[key].borderWidth = 3;
                 axesOpts.x = getChartAxesColours(theme, canvas, 'x');
@@ -2914,7 +2914,7 @@ function createTheChart(canvas, action, sender) {
                 break;
 
             case 'bar':
-                yAxises[key].backgroundColor = palette[index % palette.length].replace(')', ', 0.6)');
+                yAxises[key].backgroundColor = palette[index % palette.length].replace('1.0)', '0.6)');
                 yAxises[key].borderColor = palette[index % palette.length];
                 yAxises[key].borderWidth = 1;
                 axesOpts.x = getChartAxesColours(theme, canvas, 'x');
@@ -3034,24 +3034,54 @@ function getChartPieBorderColour(theme) {
     }
 }
 
-function getChartColourPalette(theme) {
+function getChartColourPalette(theme, canvas) {
+    // do the canvas have a defined set of colours?
+    var colours = canvas.attr('pode-colours');
+    if (colours) {
+        var converted = [];
+        colours.split(',').forEach((c) => { converted.push(hexToRgb(c.trim())); });
+        return converted;
+    }
+
+    // no colours, so use the defaults
     var first = [
-        'rgb(54, 162, 235)',    // blue
-        'rgb(255, 176, 0)'      // orange
+        hexToRgb('#36a2eb'), // cornflower blue
+        hexToRgb('#ffb000')  // orange
     ];
 
     if (theme == 'terminal') {
-        first = ['rgb(255, 176, 0)', 'rgb(54, 162, 235)'];
+        first = [hexToRgb('#ffb000'), hexToRgb('#36a2eb')]; // orange, blue
     }
 
-
     return first.concat([
-        'rgb(255, 99, 132)',    // red
-        'rgb(255, 205, 86)',    // yellow
-        'rgb(0, 163, 51)',      // green
-        'rgb(153, 102, 255)',   // purple
-        'rgb(201, 203, 207)'    // grey
+        hexToRgb('#ff6384'),    // red
+        hexToRgb('#ffcd56'),    // yellow
+        hexToRgb('#00a333'),    // green
+        hexToRgb('#9966ff'),    // purple
+        hexToRgb('#96b0c6'),    // grey
+        hexToRgb('#275c7b'),    // teal
+        hexToRgb('#665191'),    // purple
+        hexToRgb('#bc5090'),    // pink
+        hexToRgb('#f95d6a'),    // peach
+        hexToRgb('#488f31'),    // green
+        hexToRgb('#f1f1f1'),    // white
+        hexToRgb('#a9b450'),    // lime green
+        hexToRgb('#00d2ef')     // sky blue
     ]);
+}
+
+function hexToRgb(hex) {
+    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, function(m, r, g, b) {
+        return r + r + g + g + b + b;
+    });
+
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    if (!result) {
+        return "rgba(0, 0, 0, 1.0)";
+    }
+
+    return `rgba(${parseInt(result[1], 16)}, ${parseInt(result[2], 16)}, ${parseInt(result[3], 16)}, 1.0)`;
 }
 
 function writeChart(action, sender) {

--- a/src/Templates/Views/elements/chart.pode
+++ b/src/Templates/Views/elements/chart.pode
@@ -30,6 +30,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
         pode-min-y="$($data.Min.Y)"
         pode-max-x="$($data.Max.X)"
         pode-max-y="$($data.Max.Y)"
-        pode-legend="$(!$data.NoLegend)">
+        pode-legend="$(!$data.NoLegend)"
+        pode-colours="$($data.Colours)">
     </canvas>
 </div>


### PR DESCRIPTION
### Description of the Change
Adds more default colours for charts, and enables support to use custom colours via a new `-Colours` parameter on `New-PodeWebChart`.

### Related Issue
Resolves #153 

### Examples
For example, to render the below bar chart with reg/green bars, you could use:

```powershell
New-PodeWebContainer -Content @(
    New-PodeWebChart -Name 'Top Processes' -Type Bar -AutoRefresh -Colours '#ff0000', '#00ff00' -ScriptBlock {
        Get-Process |
            Sort-Object -Property CPU -Descending |
            Select-Object -First 10 |
            ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU, Handles
    }
)
```
