### PR TITLE
Add better support for initialising empty tables

### DIFF
--- a/examples/tables.ps1
+++ b/examples/tables.ps1
@@ -1,0 +1,25 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer -Threads 2 {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Tables' -Theme Dark
+
+    # set the home page controls
+    $card1 = New-PodeWebTable `
+        -Name 'Empty Table' `
+        -ScriptBlock {} `
+        -AsCard `
+        -Columns @(
+            Initialize-PodeWebTableColumn -Key 'Name'
+            Initialize-PodeWebTableColumn -Key 'ID'
+            Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory'
+            Initialize-PodeWebTableColumn -Key 'CPU'
+        )
+
+    Set-PodeWebHomePage -Layouts $card1 -Title 'Tables'
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2199,6 +2199,10 @@ function Initialize-PodeWebTableColumn
         $Icon
     )
 
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        $Name = $Key
+    }
+
     return @{
         Key = $Key
         Width = $Width

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -84,7 +84,7 @@ function Update-PodeWebTable
 
     end {
         # columns
-        $_columns = @{}
+        $_columns = [ordered]@{}
         if (($null -ne $Columns) -and ($Columns.Length -gt 0)) {
             foreach ($col in $Columns) {
                 $_columns[$col.Key] = $col


### PR DESCRIPTION
### Description of the Change
Add better support for initialising empty tables, where by you can use an empty scriptblock - or a scriptblock that returns nothing - and use the `-Columns` parameter with `Initialize-PodeWebTableColumn` to build the table's columns.

### Examples
```powershell
New-PodeWebTable `
    -Name 'Empty Table' `
    -ScriptBlock {} `
    -AsCard `
    -Columns @(
        Initialize-PodeWebTableColumn -Key 'Name'
        Initialize-PodeWebTableColumn -Key 'ID'
        Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory'
        Initialize-PodeWebTableColumn -Key 'CPU'
    )
```

Will render an empty table, with just the column headers showing.