### PR TITLE
Add FileStream output actions

### DIFF
--- a/docs/Tutorials/Outputs/FileStream.md
+++ b/docs/Tutorials/Outputs/FileStream.md
@@ -1,0 +1,76 @@
+# FileStream
+
+This page details the available output actions available to FileStream elements.
+
+## Clear
+
+To clear the content of a FileStream, you can use [`Clear-PodeWebFileStream`](../../../Functions/Outputs/Clear-PodeWebFileStream):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Clear' -ScriptBlock {
+        Clear-PodeWebFileStream -Name 'Example'
+    }
+
+    New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
+)
+```
+
+## Start
+
+To start a FileStream that's paused, you can use [`Start-PodeWebFileSteam`](../../../Functions//Start-PodeWebFileSteam):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Start' -ScriptBlock {
+        Start-PodeWebFileStream -Name 'Example'
+    }
+
+    New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
+)
+```
+
+## Stop
+
+To stop/pause a FileStream that's running, you can use [`Stop-PodeWebFileSteam`](../../../Functions//Stop-PodeWebFileSteam):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Stop' -ScriptBlock {
+        Stop-PodeWebFileStream -Name 'Example'
+    }
+
+    New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
+)
+```
+
+## Restart
+
+To restart a FileStream, you can use [`Restart-PodeWebFileSteam`](../../../Functions//Restart-PodeWebFileSteam) and this will stop, clear, and the start the FileStream element:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Restart' -ScriptBlock {
+        Restart-PodeWebFileStream -Name 'Example'
+    }
+
+    New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
+)
+```
+
+## Update
+
+To update the Url that a FileStream is currently streaming data from, you can use [`Update-PodeWebFileStream`](../../../Functions/Outputs/Update-PodeWebFileStream). This will stop, clear, update the Url, and the start the FileStream element:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Update 1' -ScriptBlock {
+        Update-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
+    }
+    New-PodeWebButton -Name 'Update 2' -ScriptBlock {
+        Update-PodeWebFileStream -Name 'Example' -Url '/logs/error2.log'
+    }
+
+    New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
+)
+```

--- a/examples/file-stream.ps1
+++ b/examples/file-stream.ps1
@@ -11,7 +11,25 @@ Start-PodeServer -Threads 2 {
 
     # set the home page controls
     $con = New-PodeWebContainer -Content @(
-        New-PodeWebFileStream -Url '/logs/error.log' -Icon 'information'
+        New-PodeWebButton -Name 'Stop' -ScriptBlock {
+            Stop-PodeWebFileStream -Name 'Example'
+        }
+        New-PodeWebButton -Name 'Start' -ScriptBlock {
+            Start-PodeWebFileStream -Name 'Example'
+        }
+        New-PodeWebButton -Name 'Restart' -ScriptBlock {
+            Restart-PodeWebFileStream -Name 'Example'
+        }
+        New-PodeWebButton -Name 'Clear' -ScriptBlock {
+            Clear-PodeWebFileStream -Name 'Example'
+        }
+        New-PodeWebButton -Name 'Update 1' -ScriptBlock {
+            Update-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
+        }
+        New-PodeWebButton -Name 'Update 2' -ScriptBlock {
+            Update-PodeWebFileStream -Name 'Example' -Url '/logs/error2.log'
+        }
+        New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log' -Icon 'information'
     )
 
     Set-PodeWebHomePage -Layouts $con -Title 'File Stream'

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1368,3 +1368,113 @@ function Remove-PodeWebComponentClass
         Class = $Class
     }
 }
+
+function Start-PodeWebFileStream
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Start'
+        ObjectType = 'FileStream'
+        ID = $Id
+        Name = $Name
+    }
+}
+
+function Stop-PodeWebFileStream
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Stop'
+        ObjectType = 'FileStream'
+        ID = $Id
+        Name = $Name
+    }
+}
+
+function Restart-PodeWebFileStream
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Restart'
+        ObjectType = 'FileStream'
+        ID = $Id
+        Name = $Name
+    }
+}
+
+function Clear-PodeWebFileStream
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Clear'
+        ObjectType = 'FileStream'
+        ID = $Id
+        Name = $Name
+    }
+}
+
+function Update-PodeWebFileStream
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Url
+    )
+
+    return @{
+        Operation = 'Update'
+        ObjectType = 'FileStream'
+        ID = $Id
+        Name = $Name
+        Url = $Url
+    }
+}


### PR DESCRIPTION
### Description of the Change
Adds the following output actions to better control FileStream elements:

* `Clear-PodeWebFileStream`
* `Start-PodeWebFileStream`
* `Stop-PodeWebFileStream`
* `Restart-PodeWebFileStream`
* `Update-PodeWebFileStream`

### Examples
```powershell
New-PodeWebButton -Name 'Stop' -ScriptBlock {
    Stop-PodeWebFileStream -Name 'Example'
}
New-PodeWebButton -Name 'Start' -ScriptBlock {
    Start-PodeWebFileStream -Name 'Example'
}
New-PodeWebButton -Name 'Restart' -ScriptBlock {
    Restart-PodeWebFileStream -Name 'Example'
}
New-PodeWebButton -Name 'Clear' -ScriptBlock {
    Clear-PodeWebFileStream -Name 'Example'
}
New-PodeWebButton -Name 'Update 1' -ScriptBlock {
    Update-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
}
New-PodeWebButton -Name 'Update 2' -ScriptBlock {
    Update-PodeWebFileStream -Name 'Example' -Url '/logs/error2.log'
}
New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log' -Icon 'information'
```
