### PR TITLE
Bump bootstrap to v4.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jquery": "3.6.0",
     "jquery-ui-dist": "1.12.1",
     "popper.js": "1.16.1",
-    "bootstrap": "4.6.0",
+    "bootstrap": "4.6.1",
     "bs-stepper": "1.7.0",
     "@mdi/font": "6.5.95",
     "chart.js": "3.6.0",


### PR DESCRIPTION
### Description of the Change
Bump the version of bootstrap from v4.6.0 to v4.6.1