### PR TITLE
Add -Hide switch to stop pages appearing in sidebar

### DIFF
--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -195,6 +195,18 @@ If you do this and you add all elements/layouts dynamically (via `-ScriptBlock`)
 
 If however you're added the elements/layouts using the `-Layouts` parameter, then certain elements/layouts will also need their `-NoAuth` switches to be supplied (such as charts, for example), otherwise data/actions will fail with a 401 response.
 
+### Hide
+
+When you add a page Pode.Web by default will show the page in the sidebar. You can stop pages/links from appearing in the sidebar by using the `-Hide` switch:
+
+```powershell
+Add-PodeWebPage -Name Charts -Hide -Layouts @(
+    New-PodeWebCard -Content @(
+        New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time'
+    )
+)
+```
+
 ## Convert Module
 
 Similar to how Pode has a function to convert a Module to a REST API; Pode.Web has one that can convert a Module into Web Pages: [`ConvertTo-PodeWebPage`](../../Functions/Pages/ConvertTo-PodeWebPage)!

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -288,7 +288,10 @@ function Add-PodeWebPage
         $NoBreadcrumb,
 
         [switch]
-        $NewTab
+        $NewTab,
+
+        [switch]
+        $Hide
     )
 
     # ensure layouts are correct
@@ -320,6 +323,7 @@ function Add-PodeWebPage
         Icon = $Icon
         Group = $Group
         Url = (Get-PodeWebPagePath -Name $Name -Group $Group)
+        Hide = $Hide.IsPresent
         NoAuthentication = $NoAuthentication.IsPresent
         Access = @{
             Groups = @($AccessGroups)
@@ -502,7 +506,10 @@ function Add-PodeWebPageLink
 
         [Parameter(ParameterSetName='Url')]
         [switch]
-        $NewTab
+        $NewTab,
+
+        [switch]
+        $Hide
     )
 
     # test if page/page-link exists
@@ -518,6 +525,7 @@ function Add-PodeWebPageLink
         Icon = $Icon
         Group = $Group
         Url = $Url
+        Hide = $Hide.IsPresent
         IsDynamic = ($null -ne $ScriptBlock)
         Access = @{
             Groups = @($AccessGroups)

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -122,6 +122,18 @@
                                 $pageGroups = (Get-PodeWebState -Name 'pages' | Group-Object -Property { $_.Group } | Sort-Object -Property Name)
 
                                 foreach ($pageGroup in $pageGroups) {
+                                    $pages = @(foreach ($page in $pageGroup.Group) {
+                                        if ($page.Hide -or !(Test-PodeWebPageAccess -PageAccess $page.Access -Auth $data.Auth)) {
+                                            continue
+                                        }
+
+                                        $page
+                                    })
+
+                                    if ($pages.Length -eq 0) {
+                                        continue
+                                    }
+
                                     if (![string]::IsNullOrWhiteSpace($pageGroup.Name)) {
                                         $chevron = 'right'
                                         $show = [string]::Empty
@@ -136,7 +148,7 @@
                                                 <div>
                                                     <span class='mdi mdi-chevron-$($chevron) mdi-size-22 mRight02'></span>
                                                     <span class='h6'>$($pageGroup.Name)</span>
-                                                    <span class='badge badge-inbuilt-theme'>$($pageGroup.Count)</span>
+                                                    <span class='badge badge-inbuilt-theme'>$($pages.Length)</span>
                                                 </div>
                                             </a>
                                         </li>"
@@ -144,11 +156,7 @@
                                         "<div class='collapse $($show)' id='nav-$($pageGroup.Name)'>"
                                     }
 
-                                    foreach ($page in ($pageGroup.Group | Sort-Object -Property { $_.Name })) {
-                                        if (!(Test-PodeWebPageAccess -PageAccess $page.Access -Auth $data.Auth)) {
-                                            continue
-                                        }
-
+                                    foreach ($page in ($pages | Sort-Object -Property { $_.Name })) {
                                         $href = [string]::Empty
                                         if (!$page.IsDynamic) {
                                             $href = "href='$($page.Url)'"


### PR DESCRIPTION
### Description of the Change
Adds a new `-Hide` switch to `Add-PodeWebPage` and `Add-PodeWebPageLink`, which will stop the page appearing in the sidebar.

This also fixes the "count" of pages next to Groups in the sidebar. Also, if all pages in a group are set to "hide" or aren't accessible by auth, then the group is hidden as well.

### Related Issue
Resolves #207 

### Examples
```powershell
Add-PodeWebPage -Name Charts -Hide -Layouts @(
    New-PodeWebCard -Content @(
        New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time'
    )
)
```
