### PR TITLE
Add DisplayName and DisplayOptions parameters for form elements

### DIFF
--- a/docs/Tutorials/Elements/Checkbox.md
+++ b/docs/Tutorials/Elements/Checkbox.md
@@ -43,3 +43,11 @@ Which looks like below:
 ## Inline
 
 You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.
+
+## Display Options
+
+By default the options displayed are from the `-Options` parameter. Like the Name, you can change the values displayed by supplying the optional `-DisplayOptions` - values in the array should be in the same order as the values in `-Options`. These values are, like the Display Name, purely visual, and when the form is submitted the server receives the original values from `-Options`.

--- a/docs/Tutorials/Elements/Credentials.md
+++ b/docs/Tutorials/Elements/Credentials.md
@@ -20,3 +20,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![credentials](../../../images/credentials.png)
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Elements/DateTime.md
+++ b/docs/Tutorials/Elements/DateTime.md
@@ -20,3 +20,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![datetime](../../../images/datetime.png)
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Elements/FileUpload.md
+++ b/docs/Tutorials/Elements/FileUpload.md
@@ -23,3 +23,7 @@ Which looks like below:
 ## Inline
 
 You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Elements/MinMax.md
+++ b/docs/Tutorials/Elements/MinMax.md
@@ -20,3 +20,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![minmax](../../../images/minmax.png)
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Elements/Radio.md
+++ b/docs/Tutorials/Elements/Radio.md
@@ -23,3 +23,11 @@ Which looks like below:
 ## Inline
 
 You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.
+
+## Display Options
+
+By default the options displayed are from the `-Options` parameter. Like the Name, you can change the values displayed by supplying the optional `-DisplayOptions` - values in the array should be in the same order as the values in `-Options`. These values are, like the Display Name, purely visual, and when the form is submitted the server receives the original values from `-Options`.

--- a/docs/Tutorials/Elements/Range.md
+++ b/docs/Tutorials/Elements/Range.md
@@ -23,3 +23,7 @@ Which looks like below:
 ## Inline
 
 You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Elements/Select.md
+++ b/docs/Tutorials/Elements/Select.md
@@ -62,3 +62,11 @@ You can render a multiple select element, where more than one option can be sele
 ## Inline
 
 You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.
+
+## Display Options
+
+By default the options displayed are from the `-Options` parameter. Like the Name, you can change the values displayed by supplying the optional `-DisplayOptions` - values in the array should be in the same order as the values in `-Options`. These values are, like the Display Name, purely visual, and when the form is submitted the server receives the original values from `-Options`.

--- a/docs/Tutorials/Elements/Textbox.md
+++ b/docs/Tutorials/Elements/Textbox.md
@@ -75,3 +75,7 @@ By default it shows the first 4 lines of text, this can be altered using the `-S
 ## Inline
 
 You can render this element inline with other non-form elements by using the `-NoForm` switch. This will remove the form layout, and render the element more cleanly when used outside of a form.
+
+## Display Name
+
+By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Outputs/Select.md
+++ b/docs/Tutorials/Outputs/Select.md
@@ -71,3 +71,5 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+You can also optionally supply `-DisplayOptions` to alter the values displayed in the Select element, as well as also supply as `-SelectedValue`.

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -319,6 +319,51 @@ function Protect-PodeWebName
     return ($Name -ireplace '[^a-z0-9_]', '').Trim()
 }
 
+function Protect-PodeWebValue
+{
+    param(
+        [Parameter()]
+        [string]
+        $Value,
+
+        [Parameter()]
+        [string]
+        $Default
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $Default
+    }
+
+    return $Value
+}
+
+function Protect-PodeWebValues
+{
+    param(
+        [Parameter()]
+        [string[]]
+        $Value,
+
+        [Parameter()]
+        [string[]]
+        $Default,
+
+        [switch]
+        $EqualCount
+    )
+
+    if (($null -eq $Value) -or ($Value.Length -eq 0)) {
+        return $Default
+    }
+
+    if ($EqualCount -and ($Value.Length -ne $Default.Length)) {
+        throw "Expected an equal number of values in both arrays"
+    }
+
+    return $Value
+}
+
 function Test-PodeWebRoute
 {
     param(

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -8,6 +8,10 @@ function New-PodeWebTextbox
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter(ParameterSetName='Single')]
@@ -111,6 +115,7 @@ function New-PodeWebTextbox
         ObjectType = 'Textbox'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         Type = $Type
         Multiline = $Multiline.IsPresent
@@ -177,6 +182,10 @@ function New-PodeWebFileUpload
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter()]
@@ -201,6 +210,7 @@ function New-PodeWebFileUpload
         ObjectType = 'FileUpload'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         CssClasses = ($CssClass -join ' ')
         CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
@@ -359,11 +369,19 @@ function New-PodeWebCheckbox
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter(ParameterSetName='Multiple')]
         [string[]]
         $Options,
+
+        [Parameter(ParameterSetName='Multiple')]
+        [string[]]
+        $DisplayOptions,
 
         [Parameter()]
         [string[]]
@@ -404,8 +422,10 @@ function New-PodeWebCheckbox
         ObjectType = 'Checkbox'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         Options = @($Options)
+        DisplayOptions = @(Protect-PodeWebValues -Value $DisplayOptions -Default $Options -EqualCount)
         Inline = $Inline.IsPresent
         AsSwitch = $AsSwitch.IsPresent
         Checked = $Checked.IsPresent
@@ -427,11 +447,19 @@ function New-PodeWebRadio
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter(Mandatory=$true)]
         [string[]]
         $Options,
+
+        [Parameter()]
+        [string[]]
+        $DisplayOptions,
 
         [Parameter()]
         [string[]]
@@ -461,8 +489,10 @@ function New-PodeWebRadio
         ObjectType = 'Radio'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         Options = @($Options)
+        DisplayOptions = @(Protect-PodeWebValues -Value $DisplayOptions -Default $Options -EqualCount)
         Inline = $Inline.IsPresent
         Disabled = $Disabled.IsPresent
         CssClasses = ($CssClass -join ' ')
@@ -482,11 +512,19 @@ function New-PodeWebSelect
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter(ParameterSetName='Options')]
         [string[]]
         $Options,
+
+        [Parameter(ParameterSetName='Options')]
+        [string[]]
+        $DisplayOptions,
 
         [Parameter(ParameterSetName='ScriptBlock')]
         [scriptblock]
@@ -532,8 +570,10 @@ function New-PodeWebSelect
         ObjectType = 'Select'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         Options = @($Options)
+        DisplayOptions = @(Protect-PodeWebValues -Value $DisplayOptions -Default $Options -EqualCount)
         ScriptBlock = $ScriptBlock
         IsDynamic = ($null -ne $ScriptBlock)
         SelectedValue = $SelectedValue
@@ -588,6 +628,10 @@ function New-PodeWebRange
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter()]
@@ -638,6 +682,7 @@ function New-PodeWebRange
         ObjectType = 'Range'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         Value = $Value
         Min = $Min
@@ -1148,6 +1193,10 @@ function New-PodeWebCredential
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter()]
@@ -1161,6 +1210,14 @@ function New-PodeWebCredential
         [Parameter()]
         [hashtable]
         $CssStyle,
+
+        [Parameter()]
+        [string]
+        $PlaceholderUsername,
+
+        [Parameter()]
+        [string]
+        $PlaceholderPassword,
 
         [switch]
         $ReadOnly,
@@ -1179,12 +1236,17 @@ function New-PodeWebCredential
         ObjectType = 'Credential'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         HelpText = $HelpText
         ReadOnly = $ReadOnly.IsPresent
         NoLabels = $NoLabels.IsPresent
         CssClasses = ($CssClass -join ' ')
         CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
+        Placeholders = @{
+            Username = (Protect-PodeWebValue -Value $PlaceholderUsername -Default 'Username')
+            Password = (Protect-PodeWebValue -Value $PlaceholderPassword -Default 'Password')
+        }
         Required = $Required.IsPresent
     }
 }
@@ -1196,6 +1258,10 @@ function New-PodeWebDateTime
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
+
+        [Parameter()]
+        [string]
+        $DisplayName,
 
         [Parameter()]
         [string]
@@ -1230,6 +1296,7 @@ function New-PodeWebDateTime
         ObjectType = 'DateTime'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         HelpText = $HelpText
         ReadOnly = $ReadOnly.IsPresent
@@ -1247,6 +1314,10 @@ function New-PodeWebMinMax
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
+
+        [Parameter()]
+        [string]
+        $DisplayName,
 
         [Parameter()]
         [string]
@@ -1305,6 +1376,7 @@ function New-PodeWebMinMax
         ObjectType = 'MinMax'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name)
         ID = $Id
         Values = @{
             Min = $MinValue

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -711,7 +711,15 @@ function Update-PodeWebSelect
 
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string[]]
-        $Options
+        $Options,
+
+        [Parameter()]
+        [string[]]
+        $DisplayOptions,
+
+        [Parameter()]
+        [string]
+        $SelectedValue
     )
 
     begin {
@@ -729,6 +737,8 @@ function Update-PodeWebSelect
             Name = $Name
             ID = $Id
             Options = $items
+            DisplayOptions = @(Protect-PodeWebValues -Value $DisplayOptions -Default $items -EqualCount)
+            SelectedValue = [System.Net.WebUtility]::HtmlEncode($SelectedValue)
         }
     }
 }

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2529,7 +2529,15 @@ function setSelect(action) {
         return;
     }
 
-    select.val(decodeHTML(action.Value));
+    setSelectValue(select, action.Value);
+}
+
+function setSelectValue(select, value) {
+    if (!select || !value) {
+        return
+    }
+
+    select.val(decodeHTML(value));
 }
 
 function updateSelect(action) {
@@ -2545,9 +2553,13 @@ function updateSelect(action) {
         return;
     }
 
-    action.Options.forEach((opt) => {
-        select.append(`<option value="${opt}">${opt}</option>`);
+    action.DisplayOptions = convertToArray(action.DisplayOptions);
+
+    action.Options.forEach((opt, idx) => {
+        select.append(`<option value="${opt}">${action.DisplayOptions[idx]}</option>`);
     })
+
+    setSelectValue(select, action.SelectedValue);
 }
 
 function clearSelect(action) {

--- a/src/Templates/Views/elements/checkbox.pode
+++ b/src/Templates/Views/elements/checkbox.pode
@@ -1,6 +1,6 @@
 <div id="$($data.ID)" class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-checkbox $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     $(if (!$data.NoForm) {
-        "<div class='col-sm-2 col-form-label'>$($data.Name)</div>"
+        "<div class='col-sm-2 col-form-label'>$($data.DisplayName)</div>"
     })
     <div class="col-sm-10">
         $(
@@ -29,7 +29,7 @@
                     "<div class='custom-control custom-switch $($inline)' style='$($data.CssStyles)'>
                         <input type='checkbox' class='custom-control-input' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked) $($required)>
                         <label class='custom-control-label' for='$($data.ID)_option$($i)'>
-                            $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })
+                            $(if ($data.Options[$i] -ine 'true') { $data.DisplayOptions[$i] })
                         </label>
                     </div>"
                 }
@@ -37,7 +37,7 @@
                     "<div class='form-check $($inline)' style='$($data.CssStyles)'>
                         <input class='form-check-input' type='checkbox' value='$($data.Options[$i])' id='$($data.ID)_option$($i)' name='$($data.Name)' pode-option-id='$($i)' $($disabled) $($checked) $($required)>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
-                            $(if ($data.Options[$i] -ine 'true') { $data.Options[$i] })
+                            $(if ($data.Options[$i] -ine 'true') { $data.DisplayOptions[$i] })
                         </label>
                     </div>"
                 }

--- a/src/Templates/Views/elements/credential.pode
+++ b/src/Templates/Views/elements/credential.pode
@@ -1,5 +1,5 @@
 <div class="form-group row pode-form-creds $($data.CssClasses)">
-    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
+    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.DisplayName)</label>
     <div class="col-sm-10">
         $(
             $describedBy = [string]::Empty
@@ -25,7 +25,7 @@
                         "<label for='$($data.ID)_username'>Username</label>"
                     }
                     else {
-                        $placeholder = "placeholder='Username'"
+                        $placeholder = "placeholder='$($data.Placeholders.Username)'"
                     }
                     "<input type='text' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_username' name='$($data.Name)_Username' $($describedBy) $($readOnly) $($required) $($placeholder)>
                 </div>
@@ -34,7 +34,7 @@
                         "<label for='$($data.ID)_password'>Password</label>"
                     }
                     else {
-                        $placeholder = "placeholder='Password'"
+                        $placeholder = "placeholder='$($data.Placeholders.Password)'"
                     }
                     "<div class='input-group mb-2'>
                         <div class='input-group-prepend'><div class='input-group-text'><span class='mdi mdi-lock'></span></div></div>

--- a/src/Templates/Views/elements/datetime.pode
+++ b/src/Templates/Views/elements/datetime.pode
@@ -1,5 +1,5 @@
 <div class="form-group row pode-form-datetime $($data.CssClasses)">
-    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
+    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.DisplayName)</label>
     <div class="col-sm-10">
         $(
             $describedBy = [string]::Empty

--- a/src/Templates/Views/elements/fileupload.pode
+++ b/src/Templates/Views/elements/fileupload.pode
@@ -1,6 +1,6 @@
 <div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-upload $($data.CssClasses)">
     $(if (!$data.NoForm) {
-        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.DisplayName)</label>"
     })
     <div class="col-sm-10">
         <input type='file' class="form-control-file $(if ($data.NoForm) { 'no-form' })" id="$($data.ID)" name="$($data.Name)" pode-object="$($data.ObjectType)" style="$($data.CssStyles)" $(if ($data.Required) { 'required' })>

--- a/src/Templates/Views/elements/minmax.pode
+++ b/src/Templates/Views/elements/minmax.pode
@@ -1,5 +1,5 @@
 <div class="form-group row pode-form-minmax $($data.CssClasses)">
-    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.Name)</label>
+    <label for="$($data.ID)" class="col-sm-2 col-form-label">$($data.DisplayName)</label>
     <div class="col-sm-10">
         $(
             $describedBy = [string]::Empty

--- a/src/Templates/Views/elements/radio.pode
+++ b/src/Templates/Views/elements/radio.pode
@@ -1,7 +1,7 @@
 <fieldset id="$($data.ID)" class="$(if (!$data.NoForm) { 'form-group' } else { 'no-form' }) pode-form-radio $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     $(if (!$data.NoForm) {
         "<div class='row'>
-            <legend class='col-form-label col-sm-2 pt-0'>$($data.Name)</legend>"
+            <legend class='col-form-label col-sm-2 pt-0'>$($data.DisplayName)</legend>"
     })
         <div class="col-sm-10">
             $(
@@ -14,7 +14,7 @@
                     "<div class='form-check $($inline)' style='$($data.CssStyles)'>
                         <input class='form-check-input' type='radio' name='$($data.Name)' id='$($data.ID)_option$($i)' value='$($data.Options[$i])' $(if ($i -eq 0) { 'checked' }) $(if ($data.Disabled) { 'disabled' }) $(if ($data.Required) { 'required' })>
                         <label class='form-check-label' for='$($data.ID)_option$($i)'>
-                            $($data.Options[$i])
+                            $($data.DisplayOptions[$i])
                         </label>
                     </div>"
                 }

--- a/src/Templates/Views/elements/range.pode
+++ b/src/Templates/Views/elements/range.pode
@@ -1,6 +1,6 @@
 <div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-range $($data.CssClasses)">
     $(if (!$data.NoForm) {
-        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.DisplayName)</label>"
     })
     <div class="col-sm-10">
         $(

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -1,6 +1,6 @@
 <div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-select $($data.CssClasses)">
     $(if (!$data.NoForm) {
-        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.DisplayName)</label>"
     })
     <div class="col-sm-10">
         $(
@@ -21,16 +21,16 @@
                 $(ConvertTo-PodeWebEvents -Events $data.Events)
             >"
 
-            foreach ($option in $data.Options) {
-                if ([string]::IsNullOrWhiteSpace($option)) {
+            for ($i = 0; $i -lt $data.Options.Length; $i++) {
+                if ([string]::IsNullOrWhiteSpace($data.Options[$i])) {
                     continue
                 }
 
                 if ([string]::IsNullOrWhiteSpace($data.SelectedValue)) {
-                    "<option value='$($option)'>$($option)</option>"
+                    "<option value='$($data.Options[$i])'>$($data.DisplayOptions[$i])</option>"
                 }
                 else {
-                    "<option value='$($option)' $(if ($data.SelectedValue -ieq $option) { 'selected' })>$($option)</option>"
+                    "<option value='$($data.Options[$i])' $(if ($data.SelectedValue -ieq $data.Options[$i]) { 'selected' })>$($data.DisplayOptions[$i])</option>"
                 }
             }
 

--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -1,6 +1,6 @@
 <div class="$(if (!$data.NoForm) { 'form-group row' } else { 'no-form' }) pode-form-textbox $($data.CssClasses)">
     $(if (!$data.NoForm) {
-        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.Name)</label>"
+        "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.DisplayName)</label>"
     })
     <div class="col-sm-10">
         $(


### PR DESCRIPTION
### Description of the Change
Adds the new `-DisplayName` parameter to each Form element: textbox, checkbox, radio, select, file-upload, select, range, credentials, datetime, and minmax.

Also adds the new `-DisplayOptions` parameter to each of: checkbox, radio, and select.

These override the values displayed on the frontend, instead of using `-Name` and `-Options`. They purely visual, and the original values are still returned back to the server on form submission.

### Related Issue
Resolves #161 

### Examples
```powershell
New-PodeWebForm -Name 'New User' -ScriptBlock {
    $name = $WebEvent.Data.Name
    $role = $WebEvent.Data.Role
} -Content @(
    New-PodeWebTextbox -Name 'Name' -DisplayName 'Nom'
    New-PodeWebSelect `
        -Name 'Role' `
        -DisplayName 'Rôle' `
        -Options @('Developer', 'Admin', 'Operations') `
        -DisplayOptions @('Développeur', 'Administrateur', 'Opérations')
)
```