### PR TITLE
Allow textbox, chart, image, table-cols to use CSS sizes

### DIFF
--- a/docs/Tutorials/Elements/Audio.md
+++ b/docs/Tutorials/Elements/Audio.md
@@ -35,6 +35,10 @@ New-PodeWebCard -Content @(
 )
 ```
 
+## Size
+
+The `-Width` of an audio element has the default unit of `%`. If `0` is specified then `20%` is used instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.
+
 ## Events
 
 The following specific events are supported by the Audio element, and can be registered via [`Register-PodeWebMediaEvent`](../../../Functions/Events/Register-PodeWebMediaEvent):

--- a/docs/Tutorials/Elements/Charts.md
+++ b/docs/Tutorials/Elements/Charts.md
@@ -141,3 +141,7 @@ New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time' -AsCard
 which renders a chart that looks like below:
 
 ![chart_line_counter](../../../images/chart_line_counter.png)
+
+## Size
+
+The `-Height` of a chart has the default unit of `px`. If `0` is specified then `auto` is used instead. Any custom value such as `10%` can be used, but if a plain number is used then `px` is appended.

--- a/docs/Tutorials/Elements/Image.md
+++ b/docs/Tutorials/Elements/Image.md
@@ -15,3 +15,7 @@ New-PodeWebCard -Content @(
 Which looks like below:
 
 ![image](../../../images/image.png)
+
+## Size
+
+The `-Width` and `-Height` of an image have the default unit of `px`. If `0` is specified then `auto` is used instead. Any custom value such as `10%` can be used, but if a plain number is used then `px` is appended.

--- a/docs/Tutorials/Elements/Table.md
+++ b/docs/Tutorials/Elements/Table.md
@@ -221,6 +221,10 @@ which renders a table that looks like below:
 
 ![table_columns](../../../images/table_columns.png)
 
+### Size
+
+The `-Width` of a table column has the default unit of `%`. If `0` is specified then `auto` is used instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.
+
 ## Buttons
 
 At the bottom of a table, there are usually two buttons on the left: Refresh and Export. You can add more buttons to a table by piping a new table into [`Add-PodeWebTableButton`](../../../Functions/Elements/Add-PodeWebTableButton):

--- a/docs/Tutorials/Elements/Textbox.md
+++ b/docs/Tutorials/Elements/Textbox.md
@@ -79,3 +79,9 @@ You can render this element inline with other non-form elements by using the `-N
 ## Display Name
 
 By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.
+
+## Size
+
+The `-Width` of a textbox has the default unit of `%`. If `0` is specified then `auto` is used instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.
+
+The `-Height` of the textbox is how many lines are displayed when the textbox is multilined.

--- a/docs/Tutorials/Elements/Video.md
+++ b/docs/Tutorials/Elements/Video.md
@@ -35,6 +35,10 @@ New-PodeWebCard -Content @(
 )
 ```
 
+## Size
+
+The `-Width` and `-Height` of a video have the default unit of `%`. If `0` is specified then `20%` is used for the width, and `15%` for the height instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.
+
 ## Events
 
 The following specific events are supported by the Video element, and can be registered via [`Register-PodeWebMediaEvent`](../../../Functions/Events/Register-PodeWebMediaEvent):

--- a/docs/Tutorials/Sizes.md
+++ b/docs/Tutorials/Sizes.md
@@ -1,0 +1,17 @@
+# Sizes
+
+Some `-Width`, `-Height`, and `-Size` parameters for components accept either plain number or a pure CSS value.
+
+When a plain number is supplied these parameters will append a default unit, such as `px` or `%`, and use that for the CSS width/height. In some cases, if `0` is supplied then the default value will be `auto`. For components that support this, they will have a relevant "Size" section in their docs page.
+
+For example, an [Image](../Elements/Image) element has a default unit of `px` for its width/height. If you wanted to add a image of 100px by 100px you could do:
+
+```powershell
+New-PodeWebImage -Source '/url/to/image.png' -Width 100 -Height 100
+```
+
+and Pode.Web will append the default `px` unit. If instead you wanted a image at 25% and 10em:
+
+```powershell
+New-PodeWebImage -Source '/url/to/image.png' -Width '25%' -Height '10em'
+```

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -765,7 +765,7 @@ function ConvertTo-PodeWebSize
         $Value,
 
         [Parameter()]
-        [double]
+        [string]
         $Default = 0,
 
         [Parameter(Mandatory=$true)]
@@ -774,14 +774,27 @@ function ConvertTo-PodeWebSize
         $Type
     )
 
+    $pattern = '^\-?\d+(\.\d+){0,1}$'
+    $defIsNumber = ($Default -match $pattern)
+
     if ([string]::IsNullOrWhiteSpace($Value)) {
-        return "$($Default)$($Type)"
+        if ($defIsNumber) {
+            return "$($Default)$($Type)"
+        }
+        else {
+            return $Default
+        }
     }
 
-    if ($Value -match '^\-?\d+(\.\d+){0,1}$') {
+    if ($Value -match $pattern) {
         $_val = [double]$Value
         if ($_val -le 0) {
-            $Value = $Default
+            if ($defIsNumber) {
+                $Value = $Default
+            }
+            else {
+                return $Default
+            }
         }
         elseif (($Type -eq '%') -and ($_val -gt 100)) {
             $Value = 100

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -29,7 +29,7 @@ function New-PodeWebTextbox
         $Size = 4,
 
         [Parameter()]
-        [int]
+        [string]
         $Width = 100,
 
         [Parameter()]
@@ -101,14 +101,6 @@ function New-PodeWebTextbox
         $Size = 4
     }
 
-    # constrain width
-    if ($Width -lt 0) {
-        $Width = 0
-    }
-    if ($Width -gt 100) {
-        $Width = 100
-    }
-
     # build element
     $element = @{
         ComponentType = 'Element'
@@ -121,7 +113,7 @@ function New-PodeWebTextbox
         Multiline = $Multiline.IsPresent
         Placeholder = $Placeholder
         Size = $Size
-        Width = $Width
+        Width = (ConvertTo-PodeWebSize -Value $Width -Default 'auto' -Type '%')
         Preformat = $Preformat.IsPresent
         HelpText = $HelpText
         ReadOnly = $ReadOnly.IsPresent
@@ -538,6 +530,7 @@ function New-PodeWebSelect
         [string]
         $SelectedValue,
 
+        [Parameter()]
         [int]
         $Size = 4,
 
@@ -802,11 +795,11 @@ function New-PodeWebImage
         $Alignment = 'Left',
 
         [Parameter()]
-        [int]
+        [string]
         $Height = 0,
 
         [Parameter()]
-        [int]
+        [string]
         $Width = 0,
 
         [Parameter()]
@@ -820,14 +813,6 @@ function New-PodeWebImage
 
     $Id = Get-PodeWebElementId -Tag Img -Id $Id -RandomToken
 
-    if ($Height -lt 0) {
-        $Height = 0
-    }
-
-    if ($Width -lt 0) {
-        $Width = 0
-    }
-
     return @{
         ComponentType = 'Element'
         ObjectType = 'Image'
@@ -836,8 +821,8 @@ function New-PodeWebImage
         Source = $Source
         Title = $Title
         Alignment = $Alignment.ToLowerInvariant()
-        Height = $Height
-        Width = $Width
+        Height = (ConvertTo-PodeWebSize -Value $Height -Default 'auto' -Type 'px')
+        Width = (ConvertTo-PodeWebSize -Value $Width -Default 'auto' -Type 'px')
         CssClasses = ($CssClass -join ' ')
         CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
@@ -1821,7 +1806,7 @@ function New-PodeWebChart
         $MaxItems = 0,
 
         [Parameter()]
-        [int]
+        [string]
         $Height = 0,
 
         [Parameter()]
@@ -1917,7 +1902,7 @@ function New-PodeWebChart
         IsDynamic = ($null -ne $ScriptBlock)
         Append = $Append.IsPresent
         MaxItems = $MaxItems
-        Height = $Height
+        Height = (ConvertTo-PodeWebSize -Value $Height -Default 'auto' -Type 'px')
         TimeLabels = $TimeLabels.IsPresent
         AutoRefresh = $AutoRefresh.IsPresent
         RefreshInterval = ($RefreshInterval * 1000)
@@ -2295,7 +2280,7 @@ function Initialize-PodeWebTableColumn
         $Key,
 
         [Parameter()]
-        [int]
+        [string]
         $Width = 0,
 
         [Parameter()]
@@ -2318,7 +2303,7 @@ function Initialize-PodeWebTableColumn
 
     return @{
         Key = $Key
-        Width = $Width
+        Width = (ConvertTo-PodeWebSize -Value $Width -Default 'auto' -Type '%')
         Alignment = $Alignment.ToLowerInvariant()
         Name = $Name
         Icon = $Icon

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2165,8 +2165,8 @@ function updateTable(action, sender) {
 function buildTableHeader(column, direction) {
     var value = `<th sort-direction='${direction}' name='${column.ID}' style='`;
 
-    if (column.Width > 0) {
-        value += `width:${column.Width}%;`;
+    if (column.Width) {
+        value += `width:${column.Width};`;
     }
 
     if (column.Alignment) {

--- a/src/Templates/Views/elements/chart.pode
+++ b/src/Templates/Views/elements/chart.pode
@@ -17,7 +17,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
         class="my-4 w-100"
         id="$($data.ID)"
         name="$($data.Name)"
-        style="$(if ($data.Height -gt 0) { "height:$($data.Height)px;" }) $($data.CssStyles)"
+        style="$(if ($data.Height -ine 'auto') { "height:$($data.Height);" }) $($data.CssStyles)"
         pode-object="$($data.ObjectType)"
         pode-chart-type="$($data.ChartType)"
         pode-dynamic="$($data.IsDynamic)"

--- a/src/Templates/Views/elements/image.pode
+++ b/src/Templates/Views/elements/image.pode
@@ -14,21 +14,10 @@ $(
         }
     }
 
-    $dim = [string]::Empty
-    $fluid = [string]::Empty
+    $dim = "height:$($data.Height);width:$($data.Width);"
 
-    if ($data.Height -gt 0 -and $data.Width -gt 0) {
-        $dim = "height:$($data.Height)px;width:$($data.Width)px;"
-    }
-    elseif ($data.Height -gt 0) {
-        $dim = "height:$($data.Height)px;"
-        $fluid = 'img-fluid'
-    }
-    elseif ($data.Width -gt 0) {
-        $dim = "width:$($data.Width)px;"
-        $fluid = 'img-fluid'
-    }
-    else {
+    $fluid = [string]::Empty
+    if (($data.Height -ieq 'auto') -or ($data.Width -ieq 'auto')) {
         $fluid = 'img-fluid'
     }
 

--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -26,10 +26,7 @@
                 $value = "value='$($data.Value)'"
             }
 
-            $width = "width: auto;"
-            if ($data.Width -gt 0) {
-                $width = "width: $($data.Width)%;"
-            }
+            $width = "width: $($data.Width);"
 
             $events = ConvertTo-PodeWebEvents -Events $data.Events
 


### PR DESCRIPTION
### Description of the Change
Enable the new raw CSS size logic to work for Textboxes, Charts, Images, and Table Columns.

### Examples
If you wanted to add a image of 100px by 100px you could do:

```powershell
New-PodeWebImage -Source '/url/to/image.png' -Width 100 -Height 100
```

and Pode.Web will append the default `px` unit. If instead you wanted a image at 25% and 10em:

```powershell
New-PodeWebImage -Source '/url/to/image.png' -Width '25%' -Height '10em'
```
