### PR TITLE
Add method/action parameters for forms

### DIFF
--- a/docs/Tutorials/Elements/Form.md
+++ b/docs/Tutorials/Elements/Form.md
@@ -52,7 +52,15 @@ The available form elements in Pode.Web are:
 * [DateTime](../DateTime)
 * [FileUpload](../FileUpload)
 * [Hidden](../Hidden)
+* [MinMax](../DateTime)
+* [Range](../Range)
 * [Radio](../Radio)
 * [Range](../Range)
 * [Select](../Select)
 * [Textbox](../Textbox)
+
+## Method/Action
+
+The default method for forms is `Post`, and the action is the internal route created for the form.
+
+You can change these values by using the `-Method` and `-Action` parameters. The method can only be `Get` or `Post`, and the action must be a valid URL.

--- a/docs/Tutorials/Layouts/Modal.md
+++ b/docs/Tutorials/Layouts/Modal.md
@@ -95,6 +95,12 @@ Which would look like below:
 
 ![modal_form](../../../images/modal_form.png)
 
+#### Method/Action
+
+The default method for forms is `Post`, and the action is the internal route created for the form.
+
+You can change these values by using the `-Method` and `-Action` parameters. The method can only be `Get` or `Post`, and the action must be a valid URL.
+
 ### Arguments
 
 You can pass values to the scriptblock by using the `-ArgumentList` parameter. This accepts an array of values/objects, and they are supplied as parameters to the scriptblock:

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2533,6 +2533,15 @@ function New-PodeWebForm
         $EndpointName,
 
         [Parameter()]
+        [ValidateSet('Get', 'Post')]
+        [string]
+        $Method = 'Post',
+
+        [Parameter()]
+        [string]
+        $Action,
+
+        [Parameter()]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication,
@@ -2548,6 +2557,7 @@ function New-PodeWebForm
 
     # generate ID
     $Id = Get-PodeWebElementId -Tag Form -Id $Id -Name $Name
+    $routePath = "/components/form/$($Id)"
 
     $element = @{
         ComponentType = 'Element'
@@ -2560,11 +2570,12 @@ function New-PodeWebForm
         NoHeader = $NoHeader.IsPresent
         CssClasses = ($CssClass -join ' ')
         CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
+        Method = $Method
+        Action = (Protect-PodeWebValue -Value $Action -Default $routePath)
         NoEvents = $true
         NoAuthentication = $NoAuthentication.IsPresent
     }
 
-    $routePath = "/components/form/$($Id)"
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -338,6 +338,15 @@ function New-PodeWebModal
         [string[]]
         $EndpointName,
 
+        [Parameter()]
+        [ValidateSet('Get', 'Post')]
+        [string]
+        $Method = 'Post',
+
+        [Parameter()]
+        [string]
+        $Action,
+
         [switch]
         $AsForm,
 
@@ -391,6 +400,8 @@ function New-PodeWebModal
         ShowSubmit = ($null -ne $ScriptBlock)
         CssClasses = ($CssClass -join ' ')
         CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
+        Method = $Method
+        Action = (Protect-PodeWebValue -Value $Action -Default $routePath)
     }
 }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -559,11 +559,12 @@ function sendAjaxReq(url, data, sender, useActions, successCallback, opts) {
     opts = (opts ?? {});
     opts.contentType = (opts.contentType == null ? 'application/x-www-form-urlencoded; charset=UTF-8' : opts.contentType);
     opts.processData = (opts.processData == null ? true : opts.processData);
+    opts.method = (opts.method == null ? 'post' : opts.method);
 
     // make the call
     $.ajax({
         url: url,
-        method: 'post',
+        method: opts.method,
         data: data,
         dataType: 'binary',
         processData: opts.processData,
@@ -1533,9 +1534,21 @@ function bindModalSubmits() {
         // find a form
         var inputs = {};
         var form = null;
+        var method = 'post';
 
         if (button.attr('pode-modal-form') == 'True') {
             form = modal.find('div.modal-body form');
+
+            var action = form.attr('action');
+            if (action) {
+                url = action;
+            }
+
+            var _method = form.attr('method');
+            if (_method) {
+                method = _method;
+            }
+
             inputs = serializeInputs(form);
             removeValidationErrors(form);
         }
@@ -1547,6 +1560,13 @@ function bindModalSubmits() {
         if (dataValue) {
             inputs.data = addFormDataValue(inputs.data, 'Value', dataValue);
         }
+
+        // add method
+        if (!inputs.opts) {
+            inputs.opts = {};
+        }
+
+        inputs.opts.method = method;
 
         // invoke url
         sendAjaxReq(url, inputs.data, (form ?? button), true, null, inputs.opts);

--- a/src/Templates/Views/elements/form.pode
+++ b/src/Templates/Views/elements/form.pode
@@ -2,7 +2,7 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
     "<p class='card-text'>$($data.Message)</p>"
 })
 
-<form id="$($data.ID)" name="$($data.Name)" class="pode-form $($data.CssClasses)" style="$($data.CssStyles)" method="POST" action="/components/form/$($data.ID)" pode-object="$($data.ObjectType)">
+<form id="$($data.ID)" name="$($data.Name)" class="pode-form $($data.CssClasses)" style="$($data.CssStyles)" method="$($data.Method)" action="$($data.Action)" pode-object="$($data.ObjectType)">
     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })
     <button class="btn btn-inbuilt-theme" type="submit">
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none"></span>

--- a/src/Templates/Views/layouts/modal.pode
+++ b/src/Templates/Views/layouts/modal.pode
@@ -17,7 +17,7 @@
             <div class="modal-body">
                 $(
                     if ($data.AsForm) {
-                        "<form class='pode-form'>"
+                        "<form class='pode-form' method='$($data.Method)' action='$($data.Action)'>"
                     }
 
                     Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content }
@@ -32,7 +32,7 @@
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">$($data.CloseText)</button>
 
                 $(if ($data.ShowSubmit) {
-                    "<button type='button' class='btn btn-inbuilt-theme pode-modal-submit' pode-url='/components/modal/$($data.ID)' pode-modal-form='$($data.AsForm)'>$($data.SubmitText)</button>"
+                    "<button type='button' class='btn btn-inbuilt-theme pode-modal-submit' pode-url='$($data.Action)' pode-modal-form='$($data.AsForm)'>$($data.SubmitText)</button>"
                 })
             </div>
 


### PR DESCRIPTION
### Description of the Change
Adds two new `-Method` and `-Action` parameters onto `New-PodeWebForm` and `New-PodeWebModal`. This allows the overriding of the default method/action properties for forms.

### Related Issue
Resolves #214

### Examples
```powershell
New-PodeWebForm -Name 'Example' -Method Get -Action 'https://example.com/some/url' -ScriptBlock {} -Content @()
```
