### PR TITLE
Add optional reset button for forms

### DIFF
--- a/docs/Tutorials/Elements/Form.md
+++ b/docs/Tutorials/Elements/Form.md
@@ -64,3 +64,7 @@ The available form elements in Pode.Web are:
 The default method for forms is `Post`, and the action is the internal route created for the form.
 
 You can change these values by using the `-Method` and `-Action` parameters. The method can only be `Get` or `Post`, and the action must be a valid URL.
+
+## Reset
+
+You can reset all form inputs by either using the [`Reset-PodeWebForm`](../../../Functions/Outputs/Reset-PodeWebForm) output action, or by using `-ShowReset` switch on [`New-PodeWebForm`](../../../Functions/Elements/New-PodeWebForm) to display an optional reset button.

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -10,7 +10,7 @@ Start-PodeServer {
     Use-PodeWebTemplates -Title 'Inputs' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
-    $form = New-PodeWebForm -Name 'Test' -AsCard -ScriptBlock {
+    $form = New-PodeWebForm -Name 'Test' -ShowReset -AsCard -ScriptBlock {
         $WebEvent.Data | Out-PodeWebTextbox -Multiline -Preformat -AsJson
     } -Content @(
         New-PodeWebTextbox -Name 'Name' -AppendIcon Account -AutoComplete {

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2547,7 +2547,10 @@ function New-PodeWebForm
         $NoAuthentication,
 
         [switch]
-        $AsCard
+        $AsCard,
+
+        [switch]
+        $ShowReset
     )
 
     # ensure content are correct
@@ -2574,6 +2577,7 @@ function New-PodeWebForm
         Action = (Protect-PodeWebValue -Value $Action -Default $routePath)
         NoEvents = $true
         NoAuthentication = $NoAuthentication.IsPresent
+        ShowReset = $ShowReset.IsPresent
     }
 
     if (!(Test-PodeWebRoute -Path $routePath)) {

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -60,6 +60,7 @@ $(() => {
     bindRangeValue();
     bindProgressValue();
     bindModalSubmits();
+    bindFormResets();
 
     bindTileRefresh();
     bindTileClick();
@@ -1494,6 +1495,20 @@ function bindFormSubmits() {
     
         // remove validation errors
         removeValidationErrors(form);
+    });
+}
+
+function bindFormResets() {
+    $('button.form-reset').off('click').on('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // get the button
+        var button = getButton(e);
+
+        // reset
+        resetForm($(`#${button.attr('for')}`));
+        unfocus(button);
     });
 }
 

--- a/src/Templates/Views/elements/form.pode
+++ b/src/Templates/Views/elements/form.pode
@@ -8,4 +8,10 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none"></span>
         Submit
     </button>
+
+    $(if ($data.ShowReset) {
+        "<button class='btn btn-secondary form-reset' for='$($data.ID)' type='button'>
+            Reset
+        </button>"
+    })
 </form>


### PR DESCRIPTION
### Description of the Change
Adds a `-ShowReset` switch onto `New-PodeWebForm`, and if supplied an optional reset button will be rendered for the form. Clicking it will reset all form inputs to their defaults.

### Related Issue
Resolves #211 
