### PR TITLE
Add -Type param to datetime, creds, and minmax

### DIFF
--- a/docs/Tutorials/Elements/Credentials.md
+++ b/docs/Tutorials/Elements/Credentials.md
@@ -21,6 +21,21 @@ Which looks like below:
 
 ![credentials](../../../images/credentials.png)
 
+## Type
+
+By default both the Username and Password fields are displayed, but you can control which ones are displayed by using the `-Type` parameter:
+
+```powershell
+# both (this is the default)
+New-PodeWebCredential -Name 'Example' -Type Username, Password
+
+# just username
+New-PodeWebCredential -Name 'Example' -Type Username
+
+# just password
+New-PodeWebCredential -Name 'Example' -Type Password
+```
+
 ## Display Name
 
 By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Elements/DateTime.md
+++ b/docs/Tutorials/Elements/DateTime.md
@@ -21,6 +21,21 @@ Which looks like below:
 
 ![datetime](../../../images/datetime.png)
 
+## Type
+
+By default both the Date and Time fields are displayed, but you can control which ones are displayed by using the `-Type` parameter:
+
+```powershell
+# both (this is the default)
+New-PodeWebDateTime -Name 'Example' -Type Date, Time
+
+# just date
+New-PodeWebDateTime -Name 'Example' -Type Date
+
+# just time
+New-PodeWebDateTime -Name 'Example' -Type Time
+```
+
 ## Display Name
 
 By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/docs/Tutorials/Elements/MinMax.md
+++ b/docs/Tutorials/Elements/MinMax.md
@@ -21,6 +21,21 @@ Which looks like below:
 
 ![minmax](../../../images/minmax.png)
 
+## Type
+
+By default both the Min and Max fields are displayed, but you can control which ones are displayed by using the `-Type` parameter:
+
+```powershell
+# both (this is the default)
+New-PodeWebMinMax -Name 'Example' -Type Min, Max
+
+# just min
+New-PodeWebMinMax -Name 'Example' -Type Min
+
+# just max
+New-PodeWebMinMax -Name 'Example' -Type Max
+```
+
 ## Display Name
 
 By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1204,6 +1204,12 @@ function New-PodeWebCredential
         [string]
         $PlaceholderPassword,
 
+        [Parameter()]
+        [ValidateSet('Username', 'Password')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        $Type = @('Username', 'Password'),
+
         [switch]
         $ReadOnly,
 
@@ -1232,6 +1238,7 @@ function New-PodeWebCredential
             Username = (Protect-PodeWebValue -Value $PlaceholderUsername -Default 'Username')
             Password = (Protect-PodeWebValue -Value $PlaceholderPassword -Default 'Password')
         }
+        Type = @($Type)
         Required = $Required.IsPresent
     }
 }
@@ -1264,6 +1271,12 @@ function New-PodeWebDateTime
         [hashtable]
         $CssStyle,
 
+        [Parameter()]
+        [ValidateSet('Date', 'Time')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        $Type = @('Date', 'Time'),
+
         [switch]
         $ReadOnly,
 
@@ -1288,6 +1301,7 @@ function New-PodeWebDateTime
         NoLabels = $NoLabels.IsPresent
         CssClasses = ($CssClass -join ' ')
         CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
+        Type = @($Type)
         Required = $Required.IsPresent
     }
 }
@@ -1344,6 +1358,12 @@ function New-PodeWebMinMax
         [hashtable]
         $CssStyle,
 
+        [Parameter()]
+        [ValidateSet('Min', 'Max')]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        $Type = @('Min', 'Max'),
+
         [switch]
         $ReadOnly,
 
@@ -1382,6 +1402,7 @@ function New-PodeWebMinMax
             Text = $AppendText
             Icon = $AppendIcon
         }
+        Type = @($Type)
         Required = $Required.IsPresent
     }
 }

--- a/src/Templates/Views/elements/credential.pode
+++ b/src/Templates/Views/elements/credential.pode
@@ -19,29 +19,34 @@
 
             $placeholder = [string]::Empty
 
-            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>
-                <div class='form-group col-md-6'>"
-                    if (!$data.NoLabels) {
-                        "<label for='$($data.ID)_username'>Username</label>"
-                    }
-                    else {
-                        $placeholder = "placeholder='$($data.Placeholders.Username)'"
-                    }
-                    "<input type='text' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_username' name='$($data.Name)_Username' $($describedBy) $($readOnly) $($required) $($placeholder)>
-                </div>
-                <div class='form-group col-md-6'>"
-                    if (!$data.NoLabels) {
-                        "<label for='$($data.ID)_password'>Password</label>"
-                    }
-                    else {
-                        $placeholder = "placeholder='$($data.Placeholders.Password)'"
-                    }
-                    "<div class='input-group mb-2'>
-                        <div class='input-group-prepend'><div class='input-group-text'><span class='mdi mdi-lock'></span></div></div>
-                        <input type='password' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_password' name='$($data.Name)_Password' $($describedBy) $($readOnly) $($required) $($placeholder)>
-                    </div>
-                </div>
-            </div>"
+            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>"
+                if ($data.Type -icontains 'username') {
+                    "<div class='form-group col-md-6'>"
+                        if (!$data.NoLabels) {
+                            "<label for='$($data.ID)_username'>Username</label>"
+                        }
+                        else {
+                            $placeholder = "placeholder='$($data.Placeholders.Username)'"
+                        }
+                        "<input type='text' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_username' name='$($data.Name)_Username' $($describedBy) $($readOnly) $($required) $($placeholder)>
+                    </div>"
+                }
+
+                if ($data.Type -icontains 'password') {
+                    "<div class='form-group col-md-6'>"
+                        if (!$data.NoLabels) {
+                            "<label for='$($data.ID)_password'>Password</label>"
+                        }
+                        else {
+                            $placeholder = "placeholder='$($data.Placeholders.Password)'"
+                        }
+                        "<div class='input-group mb-2'>
+                            <div class='input-group-prepend'><div class='input-group-text'><span class='mdi mdi-lock'></span></div></div>
+                            <input type='password' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_password' name='$($data.Name)_Password' $($describedBy) $($readOnly) $($required) $($placeholder)>
+                        </div>
+                    </div>"
+                }
+            "</div>"
         )
 
         $(if (![string]::IsNullOrWhiteSpace($data.HelpText)) {

--- a/src/Templates/Views/elements/datetime.pode
+++ b/src/Templates/Views/elements/datetime.pode
@@ -17,20 +17,25 @@
                 $required = "required"
             }
 
-            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>
-                <div class='form-group col-md-6'>"
-                    if (!$data.NoLabels) {
-                        "<label for='$($data.ID)_date'>Date</label>"
-                    }
-                    "<input type='date' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_date' name='$($data.Name)_Date' $($describedBy) $($readOnly) $($required)>
-                </div>
-                <div class='form-group col-md-6'>"
-                    if (!$data.NoLabels) {
-                        "<label for='$($data.ID)_time'>Time</label>"
-                    }
-                    "<input type='time' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_time' name='$($data.Name)_Time' $($describedBy) $($readOnly) $($required)>
-                </div>
-            </div>"
+            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>"
+                if ($data.Type -icontains 'date') {
+                    "<div class='form-group col-md-6'>"
+                        if (!$data.NoLabels) {
+                            "<label for='$($data.ID)_date'>Date</label>"
+                        }
+                        "<input type='date' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_date' name='$($data.Name)_Date' $($describedBy) $($readOnly) $($required)>
+                    </div>"
+                }
+
+                if ($data.Type -icontains 'time') {
+                    "<div class='form-group col-md-6'>"
+                        if (!$data.NoLabels) {
+                            "<label for='$($data.ID)_time'>Time</label>"
+                        }
+                        "<input type='time' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_time' name='$($data.Name)_Time' $($describedBy) $($readOnly) $($required)>
+                    </div>"
+                }
+            "</div>"
         )
 
         $(if (![string]::IsNullOrWhiteSpace($data.HelpText)) {

--- a/src/Templates/Views/elements/minmax.pode
+++ b/src/Templates/Views/elements/minmax.pode
@@ -39,48 +39,53 @@
                 }
             }
 
-            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>
-                <div class='form-group col-md-6'>"
-                    if (!$data.NoLabels) {
-                        "<label for='$($data.ID)_min'>Minimum</label>"
-                    }
+            "<div class='form-row' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' $(ConvertTo-PodeWebEvents -Events $data.Events)>"
+                if ($data.Type -icontains 'min') {
+                    "<div class='form-group col-md-6'>"
+                        if (!$data.NoLabels) {
+                            "<label for='$($data.ID)_min'>Minimum</label>"
+                        }
 
-                    $element = [string]::Empty
-                    if ($wrapped) {
-                        $element += "<div class='input-group mb-2'>"
-                    }
+                        $element = [string]::Empty
+                        if ($wrapped) {
+                            $element += "<div class='input-group mb-2'>"
+                        }
 
-                    $element += $prepend
-                    $element += "<input type='number' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_min' name='$($data.Name)_Min' value='$($data.Values.Min)' $($describedBy) $($readOnly) $($required)>"
-                    $element += $append
+                        $element += $prepend
+                        $element += "<input type='number' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_min' name='$($data.Name)_Min' value='$($data.Values.Min)' $($describedBy) $($readOnly) $($required)>"
+                        $element += $append
 
-                    if ($wrapped) {
-                        $element += "</div>"
-                    }
+                        if ($wrapped) {
+                            $element += "</div>"
+                        }
 
-                    $element
-                "</div>
-                <div class='form-group col-md-6'>"
-                    if (!$data.NoLabels) {
-                        "<label for='$($data.ID)_max'>Maximum</label>"
-                    }
+                        $element
+                    "</div>"
+                }
 
-                    $element = [string]::Empty
-                    if ($wrapped) {
-                        $element += "<div class='input-group mb-2'>"
-                    }
+                if ($data.Type -icontains 'max') {
+                    "<div class='form-group col-md-6'>"
+                        if (!$data.NoLabels) {
+                            "<label for='$($data.ID)_max'>Maximum</label>"
+                        }
 
-                    $element += $prepend
-                    $element += "<input type='number' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_max' name='$($data.Name)_Max' value='$($data.Values.Max)' $($describedBy) $($readOnly) $($required)>"
-                    $element += $append
+                        $element = [string]::Empty
+                        if ($wrapped) {
+                            $element += "<div class='input-group mb-2'>"
+                        }
 
-                    if ($wrapped) {
-                        $element += "</div>"
-                    }
+                        $element += $prepend
+                        $element += "<input type='number' class='form-control' style='$($data.CssStyles)' id='$($data.ID)_max' name='$($data.Name)_Max' value='$($data.Values.Max)' $($describedBy) $($readOnly) $($required)>"
+                        $element += $append
 
-                    $element
-                "</div>
-            </div>"
+                        if ($wrapped) {
+                            $element += "</div>"
+                        }
+
+                        $element
+                    "</div>"
+                }
+            "</div>"
         )
 
         $(if (![string]::IsNullOrWhiteSpace($data.HelpText)) {


### PR DESCRIPTION
### Description of the Change
Adds new `-Type` parameter for DateTime, Credentials and MinMax to allow selecting which fields are displayed.

### Related Issue
Resolves #230 

### Examples
```powershell
New-PodeWebDateTime -Name 'Example' -Type Date, Time
New-PodeWebCredential -Name 'Example' -Type Username, Password
New-PodeWebMinMax -Name 'Example' -Type Min, Max
```
