### PR TITLE
Fix update-text to work with code blocks

### DIFF
--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -58,6 +58,7 @@ Start-PodeServer -StatusPageExceptions Show {
         $rand = Get-Random -Minimum 0 -Maximum 3
         $colour = (@('Green', 'Yellow', 'Cyan'))[$rand]
         Update-PodeWebBadge -Id 'bdg_test' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')) -Colour $colour
+        Update-PodeWebText -Id 'code_test' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss'))
     }
 
     # set the home page controls (just a simple paragraph) [note: homepage does not require auth in this example]
@@ -80,6 +81,9 @@ Start-PodeServer -StatusPageExceptions Show {
                 Register-PodeWebEvent -Type Click -NoAuth -ScriptBlock {
                     Show-PodeWebToast -Message 'Badge was clicked!'
                 }
+        )
+        New-PodeWebParagraph -Elements @(
+            New-PodeWebCode -Id 'code_test' -Value "some code :o"
         )
         $timer1
         New-PodeWebImage -Source '/pode.web/images/icon.png' -Height 70 -Alignment Right

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2377,7 +2377,8 @@ function actionText(action) {
     }
 
     if (!text.hasClass('pode-text')) {
-        text = text.find('.pode-text') ?? text;
+        var subText = text.find('.pode-text');
+        text = subText.length == 0 ? text : subText;
     }
 
     text.text(decodeHTML(action.Value));

--- a/src/Templates/Views/elements/code.pode
+++ b/src/Templates/Views/elements/code.pode
@@ -1,1 +1,1 @@
-<code id="$($data.ID)" class="$($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">$($data.Value)</code>
+<code id="$($data.ID)" class="pode-text $($data.CssClasses)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">$($data.Value)</code>

--- a/src/Templates/Views/elements/codeblock.pode
+++ b/src/Templates/Views/elements/codeblock.pode
@@ -10,7 +10,7 @@ $(
         <span class='mdi mdi-clipboard-text-multiple-outline mdi-size-20 mRight02'></span>
     </button>
 
-    <code id="$($data.ID)" class="$($data.Language)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
+    <code id="$($data.ID)" class="pode-text $($data.Language)" style="$($data.CssStyles)" pode-object="$($data.ObjectType)">
         $($data.Value)
     </code>
 </pre>


### PR DESCRIPTION
### Description of the Change
Fixes a bug with `Update-PodeWebText` where it wouldn't update code/block elements.

### Related Issue
Resolves #233 
