### PR TITLE
Add page events for Load, Unload and BeforeUnload

### DIFF
--- a/docs/Tutorials/Events.md
+++ b/docs/Tutorials/Events.md
@@ -6,20 +6,24 @@ For now only Element components support registering events, and not all elements
 
 The following general events are supported:
 
-* Change
-* Focus
-* FocusOut
-* Click
-* MouseOver
-* MouseOut
-* KeyDown
-* KeyUp
+| Name | Description |
+| ---- | ----------- |
+| Change | Fires when the value of the component changes |
+| Focus | Fires when the component gains focus |
+| FocusOut | Fires when the component loses focus |
+| Click | Fires when the component is clicked |
+| MouseOver | Fires when the mouse moves over the component |
+| MouseOut | Fires when the mouse moves out of the component |
+| KeyDown | Fires when a key is pressed down on the component |
+| KeyUp | Fires when a key is lifted up on a component |
 
 Similar to say a Button's click scriptblock, these events can run whatever logic you like, including returning output actions for Pode.Web to action against on the frontend.
 
+You can binding the same action to multiple event types by supplying mutliple types to [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent)'s `-Type` parameter. The current event that has triggered the logic can be sourced via `$EventType` within the `-ScriptBlock`.
+
 ## Example
 
-Let's say you want to have a Select element, but not in a form. When the Select's current value is changed, you want to run a script to show a message:
+Let's say you want to have a Select element, but not in a form. When the Select's current value is changed, you want to run a script to show a message; to achieve this you can pipe the object returned by [`New-PodeWebSelect`](../../Functions/Elements/New-PodeWebSelect) into [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent):
 
 ```powershell
 New-PodeWebSelect -Name 'Role' -Options @('Choose...', 'User', 'Admin', 'Operations') |
@@ -32,7 +36,7 @@ If the element the event triggers for is a form input element, the value will be
 
 ## Element Specific
 
-The events listed here are general events supported by almost every component. However some elements, like Audio, have their own specific events, and these can be found on the element's document page.
+The events listed above are general events supported by almost every component. However some elements, like Audio, have their own specific events, and these can be found on the element's document page.
 
 For example, the Audio element has a `play` event which can be registered as follows:
 
@@ -40,7 +44,11 @@ For example, the Audio element has a `play` event which can be registered as fol
 New-PodeWebAudio -Name 'example' -Source @(
     New-PodeWebAudioSource -Id 'sample' -Url 'https://samplelib.com/lib/preview/mp3/sample-6s.mp3'
 ) |
-Register-PodeWebMediaEvent -Type Play -ScriptBlock {
-    Show-PodeWebToast -Title 'Action' -Message $EventType
-}
+    Register-PodeWebMediaEvent -Type Play -ScriptBlock {
+        Show-PodeWebToast -Title 'Action' -Message $EventType
+    }
 ```
+
+## Page Events
+
+Pages also support events, and documentation can be [found here](../Pages#events).

--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -227,3 +227,37 @@ Start-PodeServer {
     ConvertTo-PodeWebPage -Module Pester -GroupVerbs
 }
 ```
+
+## Events
+
+The Login, Home and Webpages support registering the following events, and they can be registered via [`Register-PodeWebPageEvent`](../../Functions/Events/Register-PodeWebPageEvent):
+
+| Name | Description |
+| ---- | ----------- |
+| Load | Fires when the page has fully loaded, including js/css/etc. |
+| Unload | Fires when the has fully unloaded/closed |
+| BeforeUnload | Fires just before the page is about to unload/close |
+
+To register an event for each page type:
+
+* `Login`: you'll need to use `-PassThru` on [`Set-PodeWebLoginPage`](../../Functions/Pages/Set-PodeWebLoginPage) and pipe the result in [`Register-PodeWebPageEvent`](../../Functions/Events/Register-PodeWebPageEvent).
+* `Home`: you'll need to use `-PassThru` on [`Set-PodeWebHomePage`](../../Functions/Pages/Set-PodeWebHomePage) and pipe the result in [`Register-PodeWebPageEvent`](../../Functions/Events/Register-PodeWebPageEvent).
+* `Webpage`: you'll need to use `-PassThru` on [`Add-PodeWebPage`](../../Functions/Pages/Add-PodeWebPage) and pipe the result in [`Register-PodeWebPageEvent`](../../Functions/Events/Register-PodeWebPageEvent).
+
+For example, if you want to show a message on a Webpage just before it closes:
+
+```powershell
+Add-PodeWebPage -Name Example -Layouts $some_layouts -PassThru |
+    Register-PodeWebPageEvent -Type BeforeUnload -ScriptBlock {
+        Show-PodeWebToast -Message "Bye!"
+    }
+```
+
+Or on the Login page, after it's finished loading (note: you will need to use the `-NoAuth` switch):
+
+```powershell
+Set-PodeWebLoginPage -Authentication Example -PassThru |
+    Register-PodeWebPageEvent -Type Load -NoAuth -ScriptBlock {
+        Show-PodeWebToast -Message "Hi!"
+    }
+```

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -35,7 +35,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
     # set login page 
     # -BackgroundImage '/images/galaxy.jpg'
-    Set-PodeWebLoginPage -Authentication Example  -PassThru |
+    Set-PodeWebLoginPage -Authentication Example -PassThru |
         Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -NoAuth -ScriptBlock {
             Show-PodeWebToast -Message "Login page $($EventType)!"
         }

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -30,9 +30,15 @@ Start-PodeServer -StatusPageExceptions Show {
     }
 
 
-    # set the use of templates, and set a login page
+    # set the use of templates
     Use-PodeWebTemplates -Title Test -Logo '/pode.web/images/icon.png' -Theme Dark
-    Set-PodeWebLoginPage -Authentication Example #-BackgroundImage '/images/galaxy.jpg'
+
+    # set login page 
+    # -BackgroundImage '/images/galaxy.jpg'
+    Set-PodeWebLoginPage -Authentication Example  -PassThru |
+        Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -NoAuth -ScriptBlock {
+            Show-PodeWebToast -Message "Login page $($EventType)!"
+        }
 
     $link1 = New-PodeWebNavLink -Name 'Home' -Url '/' -Icon Home
     $link2 = New-PodeWebNavLink -Name 'Dynamic' -Icon Cogs -NoAuth -ScriptBlock {
@@ -192,7 +198,10 @@ Start-PodeServer -StatusPageExceptions Show {
         )
     )
 
-    Set-PodeWebHomePage -NoAuth -Layouts $hero, $grid1, $section, $carousel, $section2, $section3, $codeEditor -NoTitle
+    Set-PodeWebHomePage -NoAuth -Layouts $hero, $grid1, $section, $carousel, $section2, $section3, $codeEditor -NoTitle -PassThru |
+        Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -NoAuth -ScriptBlock {
+            Show-PodeWebToast -Message "Home page $($EventType)!"
+        }
 
 
     # tabs and charts

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -208,7 +208,10 @@ Start-PodeServer -StatusPageExceptions Show {
         )
     )
 
-    Add-PodeWebPage -Name Charts -Icon 'chart-bar' -Layouts $tabs1 -Title 'Cycling Tabs'
+    Add-PodeWebPage -Name Charts -Icon 'chart-bar' -Layouts $tabs1 -Title 'Cycling Tabs' -PassThru |
+        Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -ScriptBlock {
+            Show-PodeWebToast -Message "Page $($EventType)!"
+        }
 
 
     # add a page to search and filter services (output in a new table element) [note: requires auth]

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -1,4 +1,4 @@
-function Register-PodeWebEventInternal
+function Register-PodeWebComponentEventInternal
 {
     [CmdletBinding()]
     param(
@@ -68,7 +68,76 @@ function Register-PodeWebEventInternal
             $global:ComponentData = $null
         }
     }
+}
 
-    # return the component back
-    return $Component
+function Register-PodeWebPageEventInternal
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNull()]
+        [hashtable]
+        $Page,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true)]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList,
+
+        [Parameter()]
+        [Alias('NoAuth')]
+        [switch]
+        $NoAuthentication
+    )
+
+    # does page support events?
+    if ($Page.NoEvents -or ($Page.ComponentType -ine 'page')) {
+        throw "$($Page.ObjectType) '$($Page.Name) [Group: $($Page.Group)]' does not support events"
+    }
+
+    # add events map if not present
+    if ($null -eq $Page.Events) {
+        $Page.Events = @()
+    }
+
+    # ensure not already defined
+    if ($Page.Events -icontains $Type) {
+        throw "$($Page.ObjectType) '$($Page.Name) [Group: $($Page.Group)]' already has the $($Type) event defined"
+    }
+
+    # add event type
+    $Page.Events += $Type.ToLowerInvariant()
+
+    # setup the route
+    $routePath = "$($Page.Path)/events/$($Type.ToLowerInvariant())"
+    if (!(Test-PodeWebRoute -Path $routePath)) {
+        $auth = $null
+        if (!$NoAuthentication -and !$Page.NoAuthentication) {
+            $auth = (Get-PodeWebState -Name 'auth')
+        }
+
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $Page.EndpointName -ScriptBlock {
+            param($Data)
+            $global:PageData = $using:Page
+            $global:EventType = $using:Type
+
+            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ScriptBlock -Arguments $Data.Data -Splat -Return
+            if ($null -eq $result) {
+                $result = @()
+            }
+
+            if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
+                Write-PodeJsonResponse -Value $result
+            }
+
+            $global:PageData = $null
+        }
+    }
 }

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -116,7 +116,13 @@ function Register-PodeWebPageEventInternal
     $Page.Events += $Type.ToLowerInvariant()
 
     # setup the route
-    $routePath = "$($Page.Path)/events/$($Type.ToLowerInvariant())"
+    $pagePath = $Page.Path
+    if ($pagePath -eq '/') {
+        $pagePath = '/home'
+    }
+
+    $routePath = "$($pagePath)/events/$($Type.ToLowerInvariant())"
+
     if (!(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication -and !$Page.NoAuthentication) {

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -686,12 +686,13 @@ function Test-PodeWebOutputWrapped
 
 function Get-PodeWebFirstPublicPage
 {
-    $pages = @(Get-PodeWebState -Name 'pages')
-    if (Test-PodeWebArrayEmpty -Array $pages) {
+    $pages = Get-PodeWebState -Name 'pages'
+    if (($null -eq $pages) -or ($pages.Count -eq 0)) {
         return $null
     }
 
-    foreach ($page in ($pages | Sort-Object -Property { $_.Name })) {
+    #TODO: what happens if we have a page in a group starting with A?
+    foreach ($page in ($pages.Values | Sort-Object -Property { $_.Name })) {
         if ((Test-PodeWebArrayEmpty -Array $page.Access.Groups) -and (Test-PodeWebArrayEmpty -Array $page.Access.Users)) {
             return $page
         }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -691,8 +691,7 @@ function Get-PodeWebFirstPublicPage
         return $null
     }
 
-    #TODO: what happens if we have a page in a group starting with A?
-    foreach ($page in ($pages.Values | Sort-Object -Property { $_.Name })) {
+    foreach ($page in ($pages.Values | Sort-Object -Property { $_.Group }, { $_.Name })) {
         if ((Test-PodeWebArrayEmpty -Array $page.Access.Groups) -and (Test-PodeWebArrayEmpty -Array $page.Access.Users)) {
             return $page
         }

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -27,7 +27,12 @@ function Register-PodeWebEvent
     )
 
     foreach ($t in $Type) {
-        Register-PodeWebEventInternal -Component $Component -Type $t -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -NoAuthentication:$NoAuthentication | Out-Null
+        Register-PodeWebComponentEventInternal `
+            -Component $Component `
+            -Type $t `
+            -ScriptBlock $ScriptBlock `
+            -ArgumentList $ArgumentList `
+            -NoAuthentication:$NoAuthentication | Out-Null
     }
 
     return $Component
@@ -68,8 +73,64 @@ function Register-PodeWebMediaEvent
 
     # register event
     foreach ($t in $Type) {
-        Register-PodeWebEventInternal -Component $Component -Type $t -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -NoAuthentication:$NoAuthentication | Out-Null
+        Register-PodeWebComponentEventInternal `
+            -Component $Component `
+            -Type $t `
+            -ScriptBlock $ScriptBlock `
+            -ArgumentList $ArgumentList `
+            -NoAuthentication:$NoAuthentication | Out-Null
     }
 
     return $Component
+}
+
+function Register-PodeWebPageEvent
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNull()]
+        [hashtable]
+        $Page,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Load', 'Unload', 'BeforeUnload')]
+        [string[]]
+        $Type,
+
+        [Parameter(Mandatory=$true)]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList,
+
+        [Parameter()]
+        [Alias('NoAuth')]
+        [switch]
+        $NoAuthentication,
+
+        [switch]
+        $PassThru
+    )
+
+    # ensure page is a page
+    if (!(Test-PodeWebContent -Content $Page -ComponentType Page)) {
+        throw 'Page events can only be registered onto pages'
+    }
+
+    # register event
+    foreach ($t in $Type) {
+        Register-PodeWebPageEventInternal `
+            -Page $Page `
+            -Type $t `
+            -ScriptBlock $ScriptBlock `
+            -ArgumentList $ArgumentList `
+            -NoAuthentication:$NoAuthentication | Out-Null
+    }
+
+    if ($PassThru) {
+        return $Page
+    }
 }

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -121,6 +121,7 @@ function Set-PodeWebLoginPage
         Write-PodeWebViewResponse -Path 'index' -Data @{
             Page = @{
                 Name = 'Home'
+                Path = '/'
             }
             Theme = $theme
             Navigation = $navigation
@@ -182,6 +183,7 @@ function Set-PodeWebHomePage
     # setup page meta
     $pageMeta = @{
         Name = 'Home'
+        Path = '/'
         Title = $Title
         NoTitle = $NoTitle.IsPresent
     }
@@ -296,7 +298,10 @@ function Add-PodeWebPage
         $NewTab,
 
         [switch]
-        $Hide
+        $Hide,
+
+        [switch]
+        $PassThru
     )
 
     # ensure layouts are correct
@@ -314,9 +319,14 @@ function Add-PodeWebPage
         $Title = $Name
     }
 
+    # build the route path
+    $routePath = (Get-PodeWebPagePath -Name $Name -Group $Group -NoAppPath)
+
     # setup page meta
     $pageMeta = @{
-        PageType = 'Page'
+        ComponentType = 'Page'
+        ObjectType = 'Page'
+        Path = $routePath
         Name = $Name
         Title = $Title
         NoTitle = $NoTitle.IsPresent
@@ -329,6 +339,10 @@ function Add-PodeWebPage
         Group = $Group
         Url = (Get-PodeWebPagePath -Name $Name -Group $Group)
         Hide = $Hide.IsPresent
+        Navigation = $Navigation
+        ScriptBlock = $ScriptBlock
+        HelpScriptBlock = $HelpScriptBlock
+        Layouts = $Layouts
         NoAuthentication = $NoAuthentication.IsPresent
         Access = @{
             Groups = @($AccessGroups)
@@ -336,7 +350,9 @@ function Add-PodeWebPage
         }
     }
 
-    Set-PodeWebState -Name 'pages' -Value  (@(Get-PodeWebState -Name 'pages') + $pageMeta)
+    # add page meta to state
+    $pages = Get-PodeWebState -Name 'pages'
+    $pages[$routePath] = $pageMeta
 
     # does the page need auth?
     $auth = $null
@@ -350,10 +366,9 @@ function Add-PodeWebPage
     }
 
     # add the page route
-    $routePath = (Get-PodeWebPagePath -Name $Name -Group $Group -NoAppPath)
-    Add-PodeRoute -Method Get -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
+    Add-PodeRoute -Method Get -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList; Path = $routePath } -EndpointName $EndpointName -ScriptBlock {
         param($Data)
-        $global:PageData = $using:pageMeta
+        $global:PageData = (Get-PodeWebState -Name 'pages')[$Data.Path]
 
         if (!$global:PageData.NoBackArrow) {
             $global:PageData.ShowBack = (($null -ne $WebEvent.Query) -and ($WebEvent.Query.Count -gt 0))
@@ -368,7 +383,7 @@ function Add-PodeWebPage
         $groups = Get-PodeWebAuthGroups -AuthData $authData
         $avatar = Get-PodeWebAuthAvatarUrl -AuthData $authData
         $theme = Get-PodeWebTheme
-        $navigation = Get-PodeWebNavDefault -Items $using:Navigation
+        $navigation = Get-PodeWebNavDefault -Items $global:PageData.Navigation
 
         $authMeta = @{
             Enabled = ![string]::IsNullOrWhiteSpace((Get-PodeWebState -Name 'auth'))
@@ -386,12 +401,12 @@ function Add-PodeWebPage
         else {
             # if we have a scriptblock, invoke that to get dynamic components
             $layouts =$null
-            if ($null -ne $using:ScriptBlock) {
-                $layouts = Invoke-PodeScriptBlock -ScriptBlock $using:ScriptBlock -Arguments $Data.Data -Splat -Return
+            if ($null -ne $global:PageData.ScriptBlock) {
+                $layouts = Invoke-PodeScriptBlock -ScriptBlock $global:PageData.ScriptBlock -Arguments $Data.Data -Splat -Return
             }
 
             if (($null -eq $layouts) -or ($layouts.Length -eq 0)) {
-                $layouts = $using:Layouts
+                $layouts = $global:PageData.Layouts
             }
 
             $breadcrumb = $null
@@ -412,7 +427,7 @@ function Add-PodeWebPage
 
             Write-PodeWebViewResponse -Path 'index' -Data @{
                 Page = $global:PageData
-                Title = $using:Title
+                Title = $global:PageData.Title
                 Theme = $theme
                 Navigation = $navigation
                 Breadcrumb = $breadcrumb
@@ -427,9 +442,9 @@ function Add-PodeWebPage
     # add the page help route
     $helpPath = "$($routePath)/help"
     if (($null -ne $HelpScriptBlock) -and !(Test-PodeWebRoute -Path $helpPath)) {
-        Add-PodeRoute -Method Post -Path $helpPath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
+        Add-PodeRoute -Method Post -Path $helpPath -Authentication $auth -ArgumentList @{ Data = $ArgumentList; Path = $routePath } -EndpointName $EndpointName -ScriptBlock {
             param($Data)
-            $global:PageData = $using:pageMeta
+            $global:PageData = (Get-PodeWebState -Name 'pages')[$Data.Path]
 
             # get auth details of a user
             $authData = Get-PodeWebAuthData
@@ -448,7 +463,7 @@ function Add-PodeWebPage
                 Set-PodeResponseStatus -Code 403
             }
             else {
-                $result = Invoke-PodeScriptBlock -ScriptBlock $using:HelpScriptBlock -Arguments $Data.Data -Splat -Return
+                $result = Invoke-PodeScriptBlock -ScriptBlock $global:PageData.HelpScriptBlock -Arguments $Data.Data -Splat -Return
                 if ($null -eq $result) {
                     $result = @()
                 }
@@ -460,6 +475,10 @@ function Add-PodeWebPage
 
             $global:PageData = $null
         }
+    }
+
+    if ($PassThru) {
+        return $pageMeta
     }
 }
 
@@ -524,7 +543,8 @@ function Add-PodeWebPageLink
 
     # setup page meta
     $pageMeta = @{
-        PageType = 'Link'
+        ComponentType = 'Page'
+        ObjectType = 'Link'
         Name = $Name
         NewTab = $NewTab.IsPresent
         Icon = $Icon
@@ -532,15 +552,22 @@ function Add-PodeWebPageLink
         Url = (Add-PodeWebAppPath -Url $Url)
         Hide = $Hide.IsPresent
         IsDynamic = ($null -ne $ScriptBlock)
+        ScriptBlock = $ScriptBlock
         Access = @{
             Groups = @($AccessGroups)
             Users = @($AccessUsers)
         }
+        NoEvents = $true
     }
 
-    Set-PodeWebState -Name 'pages' -Value  (@(Get-PodeWebState -Name 'pages') + $pageMeta)
-
+    # build the route path
     $routePath = (Get-PodeWebPagePath -Name $Name -Group $Group -NoAppPath)
+
+    # add page meta to state
+    $pages = Get-PodeWebState -Name 'pages'
+    $pages[$routePath] = $pageMeta
+
+    # add page link
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
         $auth = $null
         if (!$NoAuthentication) {
@@ -551,10 +578,11 @@ function Add-PodeWebPageLink
             $EndpointName = Get-PodeWebState -Name 'endpoint-name'
         }
 
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList; Path = $routePath } -EndpointName $EndpointName -ScriptBlock {
             param($Data)
+            $pageData = (Get-PodeWebState -Name 'pages')[$Data.Path]
 
-            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ScriptBlock -Arguments $Data.Data -Splat -Return
+            $result = Invoke-PodeScriptBlock -ScriptBlock $pageData.ScriptBlock -Arguments $Data.Data -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }
@@ -799,6 +827,11 @@ function Get-PodeWebPage
 
     # get all pages
     $pages = Get-PodeWebState -Name 'pages'
+    if (($null -eq $pages) -or ($pages.Count -eq 0)) {
+        return $null
+    }
+
+    $pages = $pages.Values
 
     # filter by group
     if ($NoGroup -and [string]::IsNullOrWhiteSpace($Group)) {

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -80,6 +80,7 @@ function Use-PodeWebTemplates
             Page = @{
                 Name = 'Home'
                 Path = '/'
+                IsSystem = $true
             }
         }
     }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -53,7 +53,7 @@ function Use-PodeWebTemplates
     Set-PodeWebState -Name 'no-page-filter' -Value $NoPageFilter.IsPresent
     Set-PodeWebState -Name 'hide-sidebar' -Value $HideSidebar.IsPresent
     Set-PodeWebState -Name 'social' -Value ([ordered]@{})
-    Set-PodeWebState -Name 'pages' -Value @()
+    Set-PodeWebState -Name 'pages' -Value @{}
     Set-PodeWebState -Name 'default-nav' -Value $null
     Set-PodeWebState -Name 'endpoint-name' -Value $EndpointName
     Set-PodeWebState -Name 'custom-css' -Value @()
@@ -79,6 +79,7 @@ function Use-PodeWebTemplates
         Write-PodeWebViewResponse -Path 'index' -Data @{
             Page = @{
                 Name = 'Home'
+                Path = '/'
             }
         }
     }

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -3806,7 +3806,7 @@ function getComponentUrl(component) {
     }
 
     if (getTagName(component) == null) {
-        return window.location.pathname;
+        return (window.location.pathname == '/' ? '/home' : window.location.pathname);
     }
     else {
         return `/components/${component.attr('pode-object').toLowerCase()}/${component.attr('id')}`;

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -3783,16 +3783,19 @@ function invokeEvent(type, sender) {
     var url = `${getComponentUrl(sender)}/events/${type}`;
 
     var inputs = {};
-    inputs.data = sender.serialize();
 
-    if (!inputs.data) {
-        inputs = serializeInputs(sender);
-    }
+    if (!testTagName(sender, 'body')) {
+        inputs.data = sender.serialize();
 
-    if (!inputs.opts) {
-        inputs.opts = {};
+        if (!inputs.data) {
+            inputs = serializeInputs(sender);
+        }
+
+        if (!inputs.opts) {
+            inputs.opts = {};
+        }
+        inputs.opts.keepFocus = true;
     }
-    inputs.opts.keepFocus = true;
 
     sendAjaxReq(url, inputs.data, sender, true, null, inputs.opts);
 }
@@ -3802,7 +3805,12 @@ function getComponentUrl(component) {
         component = $(`#${component}`);
     }
 
-    return `/components/${component.attr('pode-object').toLowerCase()}/${component.attr('id')}`;
+    if (getTagName(component) == null) {
+        return window.location.pathname;
+    }
+    else {
+        return `/components/${component.attr('pode-object').toLowerCase()}/${component.attr('id')}`;
+    }
 }
 
 function buildEvents(events) {

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -3784,7 +3784,7 @@ function invokeEvent(type, sender) {
 
     var inputs = {};
 
-    if (!testTagName(sender, 'body')) {
+    if (getTagName(sender) != null) {
         inputs.data = sender.serialize();
 
         if (!inputs.data) {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -124,7 +124,7 @@
 
                                 foreach ($pageGroup in $pageGroups) {
                                     $pages = @(foreach ($page in $pageGroup.Group) {
-                                        if ($page.Hide -or !(Test-PodeWebPageAccess -PageAccess $page.Access -Auth $data.Auth)) {
+                                        if ($page.Hide -or $page.IsSystem -or !(Test-PodeWebPageAccess -PageAccess $page.Access -Auth $data.Auth)) {
                                             continue
                                         }
 

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -5,7 +5,7 @@
         AppPath = $data.AppPath
     })
 
-    <body id="normal-page" pode-theme="$($data.Theme)" pode-app-path="$($data.AppPath)">
+    <body id="normal-page" pode-theme="$($data.Theme)" pode-app-path="$($data.AppPath)" $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
         <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow navbar-expand-lg">
             <button type='button' class='btn btn-icon-only' id='menu-toggle'>
                 <span class='mdi mdi-menu-open'></span>
@@ -120,7 +120,7 @@
                             </li>
 
                             $(
-                                $pageGroups = (Get-PodeWebState -Name 'pages' | Group-Object -Property { $_.Group } | Sort-Object -Property Name)
+                                $pageGroups = ((Get-PodeWebState -Name 'pages').Values | Group-Object -Property { $_.Group } | Sort-Object -Property Name)
 
                                 foreach ($pageGroup in $pageGroups) {
                                     $pages = @(foreach ($page in $pageGroup.Group) {
@@ -173,7 +173,7 @@
                                         }
 
                                         "<li class='nav-item nav-page-item'>
-                                            <a class='nav-link $($activePage)' name='$($page.Name)' pode-page-group='$($pageGroup.Name)' pode-page-type='$($page.PageType)' pode-dynamic='$($page.IsDynamic)' $($href)>
+                                            <a class='nav-link $($activePage)' name='$($page.Name)' pode-page-group='$($pageGroup.Name)' pode-page-type='$($page.ObjectType)' pode-dynamic='$($page.IsDynamic)' $($href)>
                                                 <div>
                                                     <span class='mdi mdi-$($page.Icon.ToLowerInvariant()) mdi-size-22 mRight02'></span>
                                                     $($page.Name)

--- a/src/Templates/Views/login.pode
+++ b/src/Templates/Views/login.pode
@@ -1,11 +1,16 @@
 <html>
     $(Use-PodeWebPartialView -Path 'shared/head' -Data @{
-        Title = 'Login'
+        Title = $data.Page.Name
         Theme = $data.Theme
         AppPath = $data.AppPath
     })
 
-    <body id="login-page" pode-theme="$($data.Theme)" pode-app-path="$($data.AppPath)" style="background-image: url('$($data.Background.Image)'); background-repeat: no-repeat; background-size: cover">
+    <body id="login-page" pode-theme="$($data.Theme)" pode-app-path="$($data.AppPath)" style="background-image: url('$($data.Background.Image)'); background-repeat: no-repeat; background-size: cover" $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
+        <div aria-live="polite" aria-atomic="true" style="min-height: 200px;" class="sticky">
+            <div id="toast-area">
+            </div>
+        </div>
+
         <form class="form-signin" action="$($data.AppPath)/login" method='POST'>
             <div class='text-center mb-4'>
                 <a href='$($data.LogoUrl)'>


### PR DESCRIPTION
### Description of the Change
Add page events for Load, Unload and BeforeUnload for custom pages (`Add-PodeWebPage`), plus Home/Login pages (`Set-PodeWebHomePage` / `Set-PodeWebLoginPage`).

### Related Issue
Resolves #234 

### Examples
Login:
```powershell
Set-PodeWebLoginPage -Authentication Example  -PassThru |
    Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -NoAuth -ScriptBlock {
        Show-PodeWebToast -Message "Login page $($EventType)!"
    }
```

Home:
```powershell
Set-PodeWebHomePage -PassThru |
    Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -ScriptBlock {
        Show-PodeWebToast -Message "Home page $($EventType)!"
    }
```

Custom:
```powershell
Add-PodeWebPage -Name Charts -PassThru |
    Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -ScriptBlock {
        Show-PodeWebToast -Message "Page $($EventType)!"
    }
```
