### PR TITLE
A few minor fixes/enhancements for tables/columns

### DIFF
--- a/docs/Tutorials/Elements/Table.md
+++ b/docs/Tutorials/Elements/Table.md
@@ -100,6 +100,10 @@ New-PodeWebContainer -Content @(
 
 ## Options
 
+### Compact
+
+If you have a lot of data that needs to be displayed, and you need to see more on the screen without scrolling, you can supply the `-Compact` switch to `New-PodeWebTable`. This will remove extra padding space on rows, to help show more data than normal.
+
 ### Click
 
 You can set a table's rows to be clickable by passing `-Click`. This by default will set it so that when a row is clicked the page is reloaded, and the `-DataColumn` value for that row will be set in the query string as `?value=<value>` - available in `$WebEvent.Query.Value`.
@@ -221,7 +225,7 @@ which renders a table that looks like below:
 
 ![table_columns](../../../images/table_columns.png)
 
-### Size
+### Width
 
 The `-Width` of a table column has the default unit of `%`. If `0` is specified then `auto` is used instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.
 

--- a/examples/tables.ps1
+++ b/examples/tables.ps1
@@ -21,5 +21,27 @@ Start-PodeServer -Threads 2 {
             Initialize-PodeWebTableColumn -Key 'CPU'
         )
 
-    Set-PodeWebHomePage -Layouts $card1 -Title 'Tables'
+    $processes = New-PodeWebTable `
+        -Name 'Processes' `
+        -Paginate `
+        -Compact `
+        -AsCard `
+        -ScriptBlock {
+            $processes = Get-Process | Select-Object -Property Name, ID, WorkingSet, CPU
+
+            $totalCount = $processes.Length
+            $pageIndex = [int]$WebEvent.Data.PageIndex
+            $pageSize = [int]$WebEvent.Data.PageSize
+            $processes = $processes[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
+
+            $processes | Update-PodeWebTable -Name $ElementData.Name -PageIndex $pageIndex -TotalItemCount $totalCount
+        } `
+        -Columns @(
+            Initialize-PodeWebTableColumn -Key 'Name'
+            Initialize-PodeWebTableColumn -Key 'ID'
+            Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory' -Alignment Center -Width 10
+            Initialize-PodeWebTableColumn -Key 'CPU'
+        )
+
+    Set-PodeWebHomePage -Layouts $card1, $processes -Title 'Tables'
 }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2138,6 +2138,9 @@ function New-PodeWebTable
         $RefreshInterval = 60,
 
         [switch]
+        $Compact,
+
+        [switch]
         $Filter,
 
         [switch]
@@ -2198,6 +2201,7 @@ function New-PodeWebTable
         Columns = $Columns
         Buttons = @()
         Message = $Message
+        Compact = $Compact.IsPresent
         Filter = @{
             Enabled = ($Filter.IsPresent -or $SimpleFilter.IsPresent)
             Simple = $SimpleFilter.IsPresent
@@ -2320,7 +2324,11 @@ function Initialize-PodeWebTableColumn
 
         [Parameter()]
         [string]
-        $Icon
+        $Icon,
+
+        [Parameter()]
+        [string]
+        $Default
     )
 
     if ([string]::IsNullOrWhiteSpace($Name)) {
@@ -2333,6 +2341,7 @@ function Initialize-PodeWebTableColumn
         Alignment = $Alignment.ToLowerInvariant()
         Name = $Name
         Icon = $Icon
+        Default = $Default
     }
 }
 

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -88,6 +88,10 @@ function Update-PodeWebTable
     end {
         # columns
         $_columns = [ordered]@{}
+        if ((($null -eq $Columns) -or ($Columns.Length -eq 0)) -and ($null -ne $ElementData.Columns) -and ($ElementData.Columns.Length -gt 0)) {
+            $Columns = $ElementData.Columns
+        }
+
         if (($null -ne $Columns) -and ($Columns.Length -gt 0)) {
             foreach ($col in $Columns) {
                 $_columns[$col.Key] = $col

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2061,6 +2061,7 @@ function updateTable(action, sender) {
     // table headers
     _value = '<tr>';
     var _oldHeader = null;
+    var _header = null;
 
     keys.forEach((key) => {
         // table header sort direction
@@ -2077,7 +2078,12 @@ function updateTable(action, sender) {
             _value += buildTableHeader(columns[key], _direction);
         }
         else {
-            _value += `<th sort-direction='${_direction}' name='${key}'>${key}</th>`;
+            if (_oldHeader.length > 0) {
+                _value += _oldHeader[0].outerHTML;
+            }
+            else {
+                _value += `<th sort-direction='${_direction}' name='${key}'>${key}</th>`;
+            }
         }
     });
     _value += '</tr>';
@@ -2089,15 +2095,15 @@ function updateTable(action, sender) {
     tableBody.empty();
 
     action.Data.forEach((item) => {
-        _value = `<tr pode-data-value="${item[dataColumn]}">`;
+        _value = `<tr ${item[dataColumn] != null ? `pode-data-value="${item[dataColumn]}"` : ''}>`;
 
         keys.forEach((key) => {
-            var col = columns[key];
-            if (key in columns) {
+            _header = tableHead.find(`th[name='${key}']`);
+            if (_header.length > 0) {
                 _value += `<td pode-column='${key}' style='`;
 
-                if (col.Alignment) {
-                    _value += `text-align:${col.Alignment};`;
+                if (_header.css('text-align')) {
+                    _value += `text-align:${_header.css('text-align')};`;
                 }
 
                 _value += `'>`;
@@ -2109,8 +2115,11 @@ function updateTable(action, sender) {
             if (Array.isArray(item[key]) || (item[key] && item[key].ObjectType)) {
                 _value += buildElements(item[key]);
             }
-            else if (item[key]) {
+            else if (item[key] != null) {
                 _value += item[key];
+            }
+            else if (!item[key] && _header.length > 0) {
+                _value += _header.attr('default-value');
             }
 
             _value += `</td>`;
@@ -2202,7 +2211,7 @@ function updateTable(action, sender) {
 }
 
 function buildTableHeader(column, direction) {
-    var value = `<th sort-direction='${direction}' name='${column.ID}' style='`;
+    var value = `<th sort-direction='${direction}' name='${column.Key}' default-value='${column.Default}' style='`;
 
     if (column.Width) {
         value += `width:${column.Width};`;

--- a/src/Templates/Views/elements/table.pode
+++ b/src/Templates/Views/elements/table.pode
@@ -21,7 +21,7 @@ $(if ($data.Filter.Enabled) {
                 id='$($data.ID)'
                 name='$($data.Name)'
                 pode-object='$($data.ObjectType)'
-                class='table table-striped table-hover $($click)'
+                class='table table-striped table-hover $(if ($data.Compact) { 'table-sm' }) $($click)'
                 style='$($data.CssStyles)'
                 pode-dynamic='$($data.IsDynamic)'
                 pode-click-dynamic='$($data.ClickIsDynamic)'


### PR DESCRIPTION
### Description of the Change
Applies a few fixes for tables, and also a couple extra enhancements:

* Bug: `Initialize-PodeWebColumn` wasn't being respected on manual calls to `Update-PodeWebTable`
* Bug: If you tried to show "0" or empty values in tables, nothing would be displayed - not even "0"
* New: `-Compact` on `New-PodeWebTable` to remove padding on rows
* New: `-Default` on `Initialize-PodeWebColumn`, this will be used in a column if the row value to be used is null
