### PR TITLE
Add update/clear output actions for code-editors

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -198,13 +198,19 @@ task MoveLibs {
 
     # monaco
     New-Item -Path "$($libs_path)/monaco" -ItemType Directory -Force | Out-Null
+    New-Item -Path "$($libs_path)/vs" -ItemType Directory -Force | Out-Null
+
     New-Item -Path "$($libs_path)/monaco/editor" -ItemType Directory -Force | Out-Null
     New-Item -Path "$($libs_path)/monaco/basic-languages" -ItemType Directory -Force | Out-Null
-    New-Item -Path "$($libs_path)/monaco/base/worker" -ItemType Directory -Force | Out-Null
 
     Copy-Item -Path "$($src_path)/monaco-editor/min/vs/loader.js" -Destination "$($libs_path)/monaco/" -Force
     Copy-Item -Path "$($src_path)/monaco-editor/min/vs/editor/*.*" -Destination "$($libs_path)/monaco/editor/" -Force
+
+    New-Item -Path "$($libs_path)/monaco/base/worker" -ItemType Directory -Force | Out-Null
     Copy-Item -Path "$($src_path)/monaco-editor/min/vs/base/worker/*.*" -Destination "$($libs_path)/monaco/base/worker/" -Force
+
+    New-Item -Path "$($libs_path)/monaco/base/browser/ui/codicons/codicon" -ItemType Directory -Force | Out-Null
+    Copy-Item -Path "$($src_path)/monaco-editor/min/vs/base/browser/ui/codicons/codicon/*.*" -Destination "$($libs_path)/monaco/base/browser/ui/codicons/codicon/" -Force
 
     $langs = @(
         'bat',
@@ -234,6 +240,17 @@ task MoveLibs {
             New-Item -Path "$($libs_path)/monaco/basic-languages/$($_)/" -ItemType Directory -Force | Out-Null
             Copy-Item -Path "$($src_path)/monaco-editor/min/vs/basic-languages/$($_)/*.*" -Destination "$($libs_path)/monaco/basic-languages/$($_)/" -Force
         }
+    }
+
+    New-Item -Path "$($libs_path)/monaco/language" -ItemType Directory -Force | Out-Null
+    New-Item -Path "$($libs_path)/vs/language" -ItemType Directory -Force | Out-Null
+
+    (Get-ChildItem -Path "$($src_path)/monaco-editor/min/vs/language" -Directory).Name | ForEach-Object {
+        New-Item -Path "$($libs_path)/monaco/language/$($_)/" -ItemType Directory -Force | Out-Null
+        Copy-Item -Path "$($src_path)/monaco-editor/min/vs/language/$($_)/*.*" -Destination "$($libs_path)/monaco/language/$($_)/" -Force
+
+        New-Item -Path "$($libs_path)/vs/language/$($_)/" -ItemType Directory -Force | Out-Null
+        Copy-Item -Path "$($src_path)/monaco-editor/min/vs/language/$($_)/*.*" -Destination "$($libs_path)/vs/language/$($_)/" -Force
     }
 
     $vs_maps_path = "$($dest_path)/min-maps/vs"

--- a/docs/Tutorials/Outputs/CodeEditor.md
+++ b/docs/Tutorials/Outputs/CodeEditor.md
@@ -1,0 +1,31 @@
+# Code Editor
+
+This page details the available output actions available to Code Editors.
+
+## Clear
+
+To clear the value of a Code Editor, you can use [`Clear-PodeWebCodeEditor`](../../../Functions/Outputs/Clear-PodeWebCodeEditor):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor' -Value "Write-Host 'hi!'"
+
+    New-PodeWebButton -Name 'Clear Editor' -ScriptBlock {
+        Clear-PodeWebCodeEditor -Name 'Code Editor'
+    }
+)
+```
+
+## Update
+
+To update the value/language of a Code Editor, you can use [`Update-PodeWebCodeEditor`](../../../Functions/Outputs/Update-PodeWebCodeEditor):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor'
+
+    New-PodeWebButton -Name 'Update Editor' -ScriptBlock {
+        Update-PodeWebCodeEditor -Name 'Code Editor' -Value '<optional-value>' -Language '<optional-language>'
+    }
+)
+```

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1704,3 +1704,55 @@ function Update-PodeWebVideo
         Thumbnail = $Thumbnail
     }
 }
+
+function Update-PodeWebCodeEditor
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Value,
+
+        [Parameter()]
+        [string]
+        $Language
+    )
+
+    return @{
+        Operation = 'Update'
+        ObjectType = 'Code-Editor'
+        ID = $Id
+        Name = $Name
+        Value = $Value
+        Language = $Language
+    }
+}
+
+function Clear-PodeWebCodeEditor
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Operation = 'Clear'
+        ObjectType = 'Code-Editor'
+        ID = $Id
+        Name = $Name
+    }
+}

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1424,6 +1424,10 @@ function invokeActions(actions, sender) {
                 actionVideo(action);
                 break;
 
+            case 'code-editor':
+                actionCodeEditor(action);
+                break;
+
             default:
                 break;
         }
@@ -2985,6 +2989,54 @@ function actionFileStream(action) {
             clearFileStream(action);
             break;
     }
+}
+
+function actionCodeEditor(action) {
+    switch(action.Operation.toLowerCase()) {
+        case 'update':
+            updateCodeEditor(action);
+            break;
+
+        case 'clear':
+            clearCodeEditor(action);
+            break;
+    }
+}
+
+function updateCodeEditor(action) {
+    var editor = getElementByNameOrId(action, 'div');
+    if (!editor) {
+        return;
+    }
+
+    editor = _editors[editor.attr('id')];
+    if (!editor) {
+        return;
+    }
+
+    // set value
+    if (action.Value) {
+        editor.setValue(action.Value);
+    }
+
+    // set language
+    if (action.Language) {
+        monaco.editor.setModelLanguage(editor.getModel(), action.Language);
+    }
+}
+
+function clearCodeEditor(action) {
+    var editor = getElementByNameOrId(action, 'div');
+    if (!editor) {
+        return;
+    }
+
+    editor = _editors[editor.attr('id')];
+    if (!editor) {
+        return;
+    }
+
+    editor.setValue('');
 }
 
 function updateFileStream(action) {

--- a/src/Templates/Views/elements/code-editor.pode
+++ b/src/Templates/Views/elements/code-editor.pode
@@ -1,4 +1,4 @@
-<div id="$($data.ID)" class="pode-code-editor $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
+<div id="$($data.ID)" name="$($data.Name)" class="pode-code-editor $($data.CssClasses)" pode-object="$($data.ObjectType)" $(ConvertTo-PodeWebEvents -Events $data.Events)>
     $(if ($data.Uploadable) {
         "<button class='btn btn-inbuilt-theme pode-upload mBottom1' type='button' title='Upload' data-toggle='tooltip' for='$($data.ID)'>
             <span class='mdi mdi-upload mRight02'></span>


### PR DESCRIPTION
### Description of the Change
Adds `Update-PodeWebCodeEditor` to enable updating the value and/or language of a code-editor. Also adds `Clear-PodeWebCodeEditor` to clear the value of a code-editor.

### Related Issue
Resolves #210 

### Examples
```powershell
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor' -Value "Write-Host 'hi!'"
    New-PodeWebButton -Name 'Clear Editor' -ScriptBlock {
        Clear-PodeWebCodeEditor -Name 'Code Editor'
    }
)
```
and
```powershell
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor'
    New-PodeWebButton -Name 'Update Editor' -ScriptBlock {
        Update-PodeWebCodeEditor -Name 'Code Editor' -Value '<optional-value>' -Language '<optional-language>'
    }
)
```
