### PR TITLE
Add enable/disable checkbox output actions

### DIFF
--- a/docs/Tutorials/Outputs/Checkbox.md
+++ b/docs/Tutorials/Outputs/Checkbox.md
@@ -2,9 +2,37 @@
 
 This page details the available output actions available to Checkboxes.
 
+## Disable
+
+To enable a checkbox you can use [`Disable-PodeWebCheckbox`](../../../Functions/Outputs/Disable-PodeWebCheckbox):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebCheckbox -Name 'Enable' -AsSwitch
+
+    New-PodeWebButton -Name 'Disable Checkbox' -ScriptBlock {
+        Disable-PodeWebCheckbox -Name 'Enable'
+    }
+)
+```
+
+## Enable
+
+To enable a checkbox you can use [`Enable-PodeWebCheckbox`](../../../Functions/Outputs/Enable-PodeWebCheckbox):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebCheckbox -Name 'Disabled' -AsSwitch -Disabled
+
+    New-PodeWebButton -Name 'Enable Checkbox' -ScriptBlock {
+        Enable-PodeWebCheckbox -Name 'Disabled'
+    }
+)
+```
+
 ## Update
 
-To update a checkbox to be checked/unchecked, you can use [`Update-PodeWebCheckbox`](../../../Functions/Outputs/Update-PodeWebCheckbox):
+To update a checkbox to be checked/unchecked, or to enable/disable, you can use [`Update-PodeWebCheckbox`](../../../Functions/Outputs/Update-PodeWebCheckbox):
 
 ```powershell
 New-PodeWebContainer -NoBackground -Content @(
@@ -13,6 +41,12 @@ New-PodeWebContainer -NoBackground -Content @(
     New-PodeWebButton -Name 'Update Checkbox' -ScriptBlock {
         $checked = [bool](Get-Random -Minimum 0 -Maximum 2)
         Update-PodeWebCheckbox -Name 'Enabled' -Checked:$checked
+    }
+    New-PodeWebButton -Name 'Enable Checkbox' -ScriptBlock {
+        Update-PodeWebCheckbox -Name 'Enabled' -Checked:$false -State Enabled
+    }
+    New-PodeWebButton -Name 'Disable Checkbox' -ScriptBlock {
+        Update-PodeWebCheckbox -Name 'Enabled' -Checked:$false -State Disabled
     }
 )
 ```

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -839,6 +839,11 @@ function Update-PodeWebCheckbox
         $OptionId = 0,
 
         [Parameter()]
+        [ValidateSet('Unchanged', 'Disabled', 'Enabled')]
+        [string]
+        $State = 'Unchanged',
+
+        [Parameter()]
         [switch]
         $Checked
     )
@@ -849,7 +854,60 @@ function Update-PodeWebCheckbox
         ID = $Id
         Name = $Name
         OptionId = $OptionId
+        State = $State.ToLowerInvariant()
         Checked = $Checked.IsPresent
+    }
+}
+
+function Enable-PodeWebCheckbox
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [int]
+        $OptionId = 0
+    )
+
+    return @{
+        Operation = 'Enable'
+        ObjectType = 'Checkbox'
+        ID = $Id
+        Name = $Name
+        OptionId = $OptionId
+    }
+}
+
+function Disable-PodeWebCheckbox
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [int]
+        $OptionId = 0
+    )
+
+    return @{
+        Operation = 'Disable'
+        ObjectType = 'Checkbox'
+        ID = $Id
+        Name = $Name
+        OptionId = $OptionId
     }
 }
 

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2650,6 +2650,19 @@ function decodeHTML(value) {
 }
 
 function actionCheckbox(action) {
+    switch (action.Operation.toLowerCase()) {
+        case 'update':
+            updateCheckbox(action);
+            break;
+
+        case 'enable':
+        case 'disable':
+            toggleCheckboxState(action, action.Operation.toLowerCase());
+            break;
+    }
+}
+
+function updateCheckbox(action) {
     if (action.ID) {
         action.ID = `${action.ID}_option${action.OptionId}`;
     }
@@ -2659,7 +2672,34 @@ function actionCheckbox(action) {
         return;
     }
 
+    // check/uncheck
     checkbox.attr('checked', action.Checked);
+
+    // enable/disable
+    if (action.State == 'enabled') {
+        enable(checkbox);
+    }
+    else if (action.State == 'disabled') {
+        disable(checkbox);
+    }
+}
+
+function toggleCheckboxState(action, toggle) {
+    if (action.ID) {
+        action.ID = `${action.ID}_option${action.OptionId}`;
+    }
+
+    var checkbox = getElementByNameOrId(action, 'input', null, `[pode-option-id="${action.OptionId}"]`);
+    if (!checkbox) {
+        return;
+    }
+
+    if (toggle == 'enable') {
+        enable(checkbox);
+    }
+    else {
+        disable(checkbox);
+    }
 }
 
 function actionToast(action) {
@@ -3728,6 +3768,22 @@ function show(element) {
     }
 
     element.show();
+}
+
+function enable(element) {
+    if (!element) {
+        return;
+    }
+
+    element.prop('disabled', false);
+}
+
+function disable(element) {
+    if (!element) {
+        return;
+    }
+
+    element.prop('disabled', true);
 }
 
 function actionTab(action) {


### PR DESCRIPTION
### Description of the Change
Adds `Enable-PodeWebCheckbox` and `Disable-PodeWebCheckbox` output actions. Also adds a `-State` parameter onto `Update-PodeWebCheckbox` to toggle disabled/enabled (the default is "unchanged").

### Examples
* Disable
```powershell
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebCheckbox -Name 'Enable' -AsSwitch
    New-PodeWebButton -Name 'Disable Checkbox' -ScriptBlock {
        Disable-PodeWebCheckbox -Name 'Enable'
    }
)
```

* Enable
```powershell
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebCheckbox -Name 'Disabled' -AsSwitch -Disabled
    New-PodeWebButton -Name 'Enable Checkbox' -ScriptBlock {
        Enable-PodeWebCheckbox -Name 'Disabled'
    }
)
```
