### PR TITLE
Add Update-PodeWebIFrame output action

### DIFF
--- a/docs/Tutorials/Outputs/IFrame.md
+++ b/docs/Tutorials/Outputs/IFrame.md
@@ -1,0 +1,35 @@
+# IFrame
+
+This page details the available output actions available to IFrames.
+
+## Update
+
+To update an iframe's URL you can use [`Update-PodeWebIFrame`](../../../Functions/Outputs/Update-PodeWebIFrame):
+
+```powershell
+# set toggle buttons for different pages
+$con1 = New-PodeWebContainer -Content @(
+    1..3 |  ForEach-Object {
+        New-PodeWebButton -Name "Page$_" -ScriptBlock {
+            Update-PodeWebIFrame -Name 'IFrame' -Url "/pages/$($ElementData.Name)"
+        }
+    }
+)
+
+# create iframe
+$con2 = New-PodeWebContainer -Content @(
+    New-PodeWebIFrame -Name 'IFrame' -Url '/pages/Page1'
+)
+
+# add page with buttons/iframe
+Add-PodeWebPage -Name 'Example' -Layouts $con1, $con2
+
+# add 3 hidden pages for the iframe to toggle between
+1..3 |  ForEach-Object {
+    Add-PodeWebPage -Name "Page$_" -Hide -Layouts @(
+        New-PodeWebContainer -Content @(
+            New-PodeWebText -Value "Page$_!"
+        )
+    )
+}
+```

--- a/examples/iframe.ps1
+++ b/examples/iframe.ps1
@@ -1,0 +1,33 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'IFrame Example' -Theme Dark
+
+    $con1 = New-PodeWebContainer -Content @(
+        1..3 |  ForEach-Object {
+            New-PodeWebButton -Name "Page$_" -ScriptBlock {
+                Update-PodeWebIFrame -Name 'IFrame' -Url "/pages/$($ElementData.Name)"
+            }
+        }
+    )
+
+    $con2 = New-PodeWebContainer -Content @(
+        New-PodeWebIFrame -Name 'IFrame' -Url '/pages/Page1'
+    )
+
+    Add-PodeWebPage -Name 'Example' -Layouts $con1, $con2
+
+    1..3 |  ForEach-Object {
+        Add-PodeWebPage -Name "Page$_" -Hide -Layouts @(
+            New-PodeWebContainer -Content @(
+                New-PodeWebText -Value "Page$_!"
+            )
+        )
+    }
+}

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -1814,3 +1814,34 @@ function Clear-PodeWebCodeEditor
         Name = $Name
     }
 }
+
+function Update-PodeWebIFrame
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Url,
+
+        [Parameter()]
+        [string]
+        $Title
+    )
+
+    return @{
+        Operation = 'Update'
+        ObjectType = 'IFrame'
+        ID = $Id
+        Name = $Name
+        Url = $Url
+        Title = $Title
+    }
+}

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1428,6 +1428,10 @@ function invokeActions(actions, sender) {
                 actionCodeEditor(action);
                 break;
 
+            case 'iframe':
+                actionIFrame(action);
+                break;
+
             default:
                 break;
         }
@@ -3028,6 +3032,31 @@ function actionFileStream(action) {
         case 'clear':
             clearFileStream(action);
             break;
+    }
+}
+
+function actionIFrame(action) {
+    switch(action.Operation.toLowerCase()) {
+        case 'update':
+            updateIFrame(action);
+            break;
+    }
+}
+
+function updateIFrame(action) {
+    var iframe = getElementByNameOrId(action, 'iframe');
+    if (!iframe) {
+        return;
+    }
+
+    // set url
+    if (action.Url) {
+        iframe.attr('src', action.Url);
+    }
+
+    // set title
+    if (action.Title) {
+        iframe.attr('title', action.Title);
     }
 }
 


### PR DESCRIPTION
### Description of the Change
Adds a new `Update-PodeWebIFrame` output action, to update an IFrame's URL and/or Title

### Examples

```powershell
# set toggle buttons for different pages
$con1 = New-PodeWebContainer -Content @(
    1..3 |  ForEach-Object {
        New-PodeWebButton -Name "Page$_" -ScriptBlock {
            Update-PodeWebIFrame -Name 'IFrame' -Url "/pages/$($ElementData.Name)"
        }
    }
)
# create iframe
$con2 = New-PodeWebContainer -Content @(
    New-PodeWebIFrame -Name 'IFrame' -Url '/pages/Page1'
)
# add page with buttons/iframe
Add-PodeWebPage -Name 'Example' -Layouts $con1, $con2
# add 3 hidden pages for the iframe to toggle between
1..3 |  ForEach-Object {
    Add-PodeWebPage -Name "Page$_" -Hide -Layouts @(
        New-PodeWebContainer -Content @(
            New-PodeWebText -Value "Page$_!"
        )
    )
}
```
