### PR TITLE
Add -NoSidebar switch for pages, to hide sidebar per page

### DIFF
--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -195,12 +195,22 @@ If you do this and you add all elements/layouts dynamically (via `-ScriptBlock`)
 
 If however you're added the elements/layouts using the `-Layouts` parameter, then certain elements/layouts will also need their `-NoAuth` switches to be supplied (such as charts, for example), otherwise data/actions will fail with a 401 response.
 
-### Hide
+### Sidebar
 
-When you add a page Pode.Web by default will show the page in the sidebar. You can stop pages/links from appearing in the sidebar by using the `-Hide` switch:
+When you add a page by default it will show in the sidebar. You can stop pages/links from appearing in the sidebar by using the `-Hide` switch:
 
 ```powershell
 Add-PodeWebPage -Name Charts -Hide -Layouts @(
+    New-PodeWebCard -Content @(
+        New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time'
+    )
+)
+```
+
+Alternatively, you can also hide the sidebar on a page by using the `-NoSidebar` switch; useful for dashboard pages:
+
+```powershell
+Add-PodeWebPage -Name Charts -NoSidebar -Layouts @(
     New-PodeWebCard -Content @(
         New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time'
     )

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -217,7 +217,7 @@ Start-PodeServer -StatusPageExceptions Show {
         )
     )
 
-    Add-PodeWebPage -Name Charts -Icon 'chart-bar' -Layouts $tabs1 -Title 'Cycling Tabs' -PassThru |
+    Add-PodeWebPage -Name Charts -Icon 'chart-bar' -Layouts $tabs1 -Title 'Cycling Tabs' -NoSidebar -PassThru |
         Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -ScriptBlock {
             Show-PodeWebToast -Message "Page $($EventType)!"
         }

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -353,6 +353,9 @@ function Add-PodeWebPage
         $Hide,
 
         [switch]
+        $NoSidebar,
+
+        [switch]
         $PassThru
     )
 
@@ -391,6 +394,7 @@ function Add-PodeWebPage
         Group = $Group
         Url = (Get-PodeWebPagePath -Name $Name -Group $Group)
         Hide = $Hide.IsPresent
+        NoSidebar = $NoSidebar.IsPresent
         Navigation = $Navigation
         ScriptBlock = $ScriptBlock
         HelpScriptBlock = $HelpScriptBlock

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -79,7 +79,7 @@
             <div class="row">
                 $(
                     $hideSidebar = [string]::Empty
-                    if (Get-PodeWebState -Name 'hide-sidebar') {
+                    if ($data.Page.NoSidebar -or (Get-PodeWebState -Name 'hide-sidebar')) {
                         $hideSidebar = 'hide-on-start'
                     }
 


### PR DESCRIPTION
### Description of the Change
Add a new `-NoSidebar` switch to `Add-PodeWebPage`, which will hide the sidebar on the page - useful for dashboards.

### Examples
```powershell
Add-PodeWebPage -Name Charts -NoSidebar -Layouts @(
    New-PodeWebCard -Content @(
        New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time'
    )
)
```
