### PR TITLE
Fix light theme icon-only colour for buttons

### DIFF
--- a/src/Templates/Public/styles/default-light.css
+++ b/src/Templates/Public/styles/default-light.css
@@ -34,7 +34,11 @@ body, main[role="main"], body#login-page, body#normal-page {
 }
 
 .btn-icon-only {
-    color: #f5f5f5 !important;
+    color: #777 !important;
+}
+
+.btn-icon-only:hover {
+    color: #333 !important;
 }
 
 .card {


### PR DESCRIPTION
### Description of the Change
Fix icon-only button colour on light theme.

### Related Issue
Resolves #254 