### PR TITLE
Add Submit-WebPodeForm output action

### DIFF
--- a/docs/Tutorials/Outputs/Form.md
+++ b/docs/Tutorials/Outputs/Form.md
@@ -22,3 +22,24 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+## Submit
+
+You can adhoc submit a form by using [`Submit-PodeWebForm`](../../../Functions/Outputs/Submit-PodeWebForm):
+
+```powershell
+New-PodeWebCard -Content @(
+    New-PodeWebForm -Name 'Example' -ScriptBlock {} -Content @(
+        New-PodeWebTextbox -Name 'Name'
+        New-PodeWebTextbox -Name 'Password' -Type Password -PrependIcon Lock
+        New-PodeWebCheckbox -Name 'Checkboxes' -Options @('Terms', 'Privacy') -AsSwitch
+        New-PodeWebSelect -Name 'Role' -Options @('User', 'Admin', 'Operations') -Multiple
+    )
+)
+
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebButton -Name 'Submit Form' -ScriptBlock {
+        Submit-PodeWebForm -Name 'Example'
+    }
+)
+```

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -657,6 +657,27 @@ function Reset-PodeWebForm
     }
 }
 
+function Submit-PodeWebForm
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id
+    )
+
+    return @{
+        Operation = 'Submit'
+        ObjectType = 'Form'
+        ID = $Id
+        Name = $Name
+    }
+}
+
 function Update-PodeWebText
 {
     [CmdletBinding()]

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2293,12 +2293,15 @@ function testTagName(element, tagName) {
 }
 
 function actionForm(action) {
-    var form = getElementByNameOrId(action, 'form');
-    if (!form) {
-        return;
-    }
+    switch (action.Operation.toLowerCase()) {
+        case 'reset':
+            resetForm(getElementByNameOrId(action, 'form'));
+            break;
 
-    resetForm(form);
+        case 'submit':
+            submitForm(getElementByNameOrId(action, 'form'));
+            break;
+    }
 }
 
 function resetForm(form, isInner = false) {
@@ -2314,6 +2317,22 @@ function resetForm(form, isInner = false) {
     }
     else {
         resetForm(form.find('form'), true);
+    }
+}
+
+function submitForm(form, isInner = false) {
+    if (!form) {
+        return;
+    }
+
+    if (testTagName(form, 'form')) {
+        $(form[0]).find('[type="submit"]').trigger('click');
+    }
+    else if (isInner) {
+        return;
+    }
+    else {
+        submitForm(form.find('form'), true);
     }
 }
 


### PR DESCRIPTION
### Description of the Change
Adds a new `Submit-PodeWebForm` output action, so that forms can be submitted dynamically; such as from another button, or via an event (like page load, etc.).

### Related Issue
Resolves #273 

### Examples
```powershell
New-PodeWebCard -Content @(
    New-PodeWebForm -Name 'Example' -ScriptBlock {} -Content @(
        New-PodeWebTextbox -Name 'Name'
        New-PodeWebTextbox -Name 'Password' -Type Password -PrependIcon Lock
        New-PodeWebCheckbox -Name 'Checkboxes' -Options @('Terms', 'Privacy') -AsSwitch
        New-PodeWebSelect -Name 'Role' -Options @('User', 'Admin', 'Operations') -Multiple
    )
)
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebButton -Name 'Submit Form' -ScriptBlock {
        Submit-PodeWebForm -Name 'Example'
    }
)
```
