### PR TITLE
Add Submit/ResetText parameters for Form buttons

### DIFF
--- a/examples/basic.ps1
+++ b/examples/basic.ps1
@@ -21,7 +21,7 @@ Start-PodeServer {
     Set-PodeWebHomePage -Layouts $section -Title 'Awesome Homepage'
 
     # add a page to search process (output as json in an appended textbox)
-    $form = New-PodeWebForm -Name 'Search' -AsCard -ScriptBlock {
+    $form = New-PodeWebForm -Name 'Search' -ShowReset -SubmitText 'Search' -ResetText 'Clear' -AsCard -ScriptBlock {
         Get-Process -Name $WebEvent.Data.Name -ErrorAction Ignore | Select-Object Name, ID, WorkingSet, CPU | Out-PodeWebTextbox -Multiline -Preformat -AsJson
     } -Content @(
         New-PodeWebTextbox -Name 'Name'

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2635,6 +2635,16 @@ function New-PodeWebForm
         $Action,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $SubmitText = 'Submit',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ResetText = 'Reset',
+
+        [Parameter()]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication,
@@ -2671,6 +2681,8 @@ function New-PodeWebForm
         NoEvents = $true
         NoAuthentication = $NoAuthentication.IsPresent
         ShowReset = $ShowReset.IsPresent
+        ResetText = [System.Net.WebUtility]::HtmlEncode($ResetText)
+        SubmitText = [System.Net.WebUtility]::HtmlEncode($SubmitText)
     }
 
     if (!(Test-PodeWebRoute -Path $routePath)) {

--- a/src/Templates/Views/elements/form.pode
+++ b/src/Templates/Views/elements/form.pode
@@ -6,12 +6,12 @@ $(if (![string]::IsNullOrWhiteSpace($data.Message)) {
     $(Use-PodeWebPartialView -Path 'shared/_load' -Data @{ Content = $data.Content })
     <button class="btn btn-inbuilt-theme" type="submit">
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none"></span>
-        Submit
+        $($data.SubmitText)
     </button>
 
     $(if ($data.ShowReset) {
         "<button class='btn btn-secondary form-reset' for='$($data.ID)' type='button'>
-            Reset
+            $($data.ResetText)
         </button>"
     })
 </form>


### PR DESCRIPTION
### Description of the Change
Adds two new `-SubmitText` and `-ResetText` parameters on `New-PodeWebForm`, so their values can be customised.

### Related Issue
Resolves #274 

### Examples
```powershell
New-PodeWebForm -Name 'Search' -ShowReset -SubmitText 'Search' -ResetText 'Clear' -AsCard -ScriptBlock {
    Get-Process -Name $WebEvent.Data.Name -ErrorAction Ignore | Select-Object Name, ID, WorkingSet, CPU | Out-PodeWebTextbox -Multiline -Preformat -AsJson
} -Content @(
    New-PodeWebTextbox -Name 'Name'
)
```
