### PR TITLE
Adds support for Hiding a table column

### DIFF
--- a/docs/Tutorials/Elements/Table.md
+++ b/docs/Tutorials/Elements/Table.md
@@ -225,6 +225,8 @@ which renders a table that looks like below:
 
 ![table_columns](../../../images/table_columns.png)
 
+You can also use the `-Hide` switch so a particular column isn't displayed on the page.
+
 ### Width
 
 The `-Width` of a table column has the default unit of `%`. If `0` is specified then `auto` is used instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.

--- a/docs/Tutorials/Outputs/Table.md
+++ b/docs/Tutorials/Outputs/Table.md
@@ -38,7 +38,9 @@ New-PodeWebContainer -NoBackground -Content @(
 )
 ```
 
-Or, to update a single row in the table you can use [`Update-PodeWebTableRow`](../../../Functions/Outputs/Update-PodeWebTableRow). You need to supply the table's ID/Name, and then either the index of the row, or the value of that row's `-DataColumn`. The `-Data` is a HashTable/PSCustomObject containing the properties/columns that you want to update:
+## Update Row
+
+To update a single row in the table you can use [`Update-PodeWebTableRow`](../../../Functions/Outputs/Update-PodeWebTableRow). You need to supply the table's ID/Name, and then either the index of the row, or the value of that row's `-DataColumn`. The `-Data` is a HashTable/PSCustomObject containing the properties/columns that you want to update:
 
 ```powershell
 New-PodeWebContainer -NoBackground -Content @(
@@ -100,5 +102,71 @@ New-PodeWebContainer -NoBackground -Content @(
             Sort-Object -Property CPU -Descending |
             Select-Object -First 15 -Property Name, ID, WorkingSet, CPU
     }
+)
+```
+
+## Hide Column
+
+To hide a column within a table, you can use [`Hide-PodeWebTableColumn`](../../../Functions/Outputs/Hide-PodeWebTableColumn). You'll need to supply the table's ID/Name and then the Key of column, specified via [`Initialize-PodeWebTableColumn`](../../../Functions/Elements/Initialize-PodeWebTableColumn) (or the Key used in a PSCustomObject or Hashtable used to build the table):
+
+```powershell
+New-PodeWebCard -Content @(
+    New-PodeWebButton -Name 'HideCPU' -ScriptBlock {
+        Hide-PodeWebColumn -Name 'Processes' -Key 'CPU'
+    }
+
+    New-PodeWebTable `
+        -Name 'Processes' `
+        -Paginate `
+        -Compact `
+        -ScriptBlock {
+            $processes = Get-Process | Select-Object -Property Name, ID, WorkingSet, CPU
+
+            $totalCount = $processes.Length
+            $pageIndex = [int]$WebEvent.Data.PageIndex
+            $pageSize = [int]$WebEvent.Data.PageSize
+            $processes = $processes[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
+
+            $processes | Update-PodeWebTable -Name $ElementData.Name -PageIndex $pageIndex -TotalItemCount $totalCount
+        } `
+        -Columns @(
+            Initialize-PodeWebTableColumn -Key 'Name'
+            Initialize-PodeWebTableColumn -Key 'ID'
+            Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory' -Alignment Center -Width 10
+            Initialize-PodeWebTableColumn -Key 'CPU'
+        )
+)
+```
+
+## Show Column
+
+To show a column within a table, you can use [`Show-PodeWebTableColumn`](../../../Functions/Outputs/Show-PodeWebTableColumn). You'll need to supply the table's ID/Name and then the Key of column, specified via [`Initialize-PodeWebTableColumn`](../../../Functions/Elements/Initialize-PodeWebTableColumn) (or the Key used in a PSCustomObject or Hashtable used to build the table):
+
+```powershell
+New-PodeWebCard -Content @(
+    New-PodeWebButton -Name 'ShowCPU' -ScriptBlock {
+        Show-PodeWebColumn -Name 'Processes' -Key 'CPU'
+    }
+
+    New-PodeWebTable `
+        -Name 'Processes' `
+        -Paginate `
+        -Compact `
+        -ScriptBlock {
+            $processes = Get-Process | Select-Object -Property Name, ID, WorkingSet, CPU
+
+            $totalCount = $processes.Length
+            $pageIndex = [int]$WebEvent.Data.PageIndex
+            $pageSize = [int]$WebEvent.Data.PageSize
+            $processes = $processes[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
+
+            $processes | Update-PodeWebTable -Name $ElementData.Name -PageIndex $pageIndex -TotalItemCount $totalCount
+        } `
+        -Columns @(
+            Initialize-PodeWebTableColumn -Key 'Name'
+            Initialize-PodeWebTableColumn -Key 'ID'
+            Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory' -Alignment Center -Width 10
+            Initialize-PodeWebTableColumn -Key 'CPU' -Hide
+        )
 )
 ```

--- a/examples/tables.ps1
+++ b/examples/tables.ps1
@@ -21,27 +21,36 @@ Start-PodeServer -Threads 2 {
             Initialize-PodeWebTableColumn -Key 'CPU'
         )
 
-    $processes = New-PodeWebTable `
-        -Name 'Processes' `
-        -Paginate `
-        -Compact `
-        -AsCard `
-        -ScriptBlock {
-            $processes = Get-Process | Select-Object -Property Name, ID, WorkingSet, CPU
+    $card2 = New-PodeWebCard -Name 'Processes' -Content @(
+        New-PodeWebButton -Name 'HideCPU' -ScriptBlock {
+            Hide-PodeWebTableColumn -Name 'Processes' -Key 'CPU'
+        }
 
-            $totalCount = $processes.Length
-            $pageIndex = [int]$WebEvent.Data.PageIndex
-            $pageSize = [int]$WebEvent.Data.PageSize
-            $processes = $processes[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
+        New-PodeWebButton -Name 'ShowCPU' -ScriptBlock {
+            Show-PodeWebTableColumn -Name 'Processes' -Key 'CPU'
+        }
 
-            $processes | Update-PodeWebTable -Name $ElementData.Name -PageIndex $pageIndex -TotalItemCount $totalCount
-        } `
-        -Columns @(
-            Initialize-PodeWebTableColumn -Key 'Name'
-            Initialize-PodeWebTableColumn -Key 'ID'
-            Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory' -Alignment Center -Width 10
-            Initialize-PodeWebTableColumn -Key 'CPU'
-        )
+        New-PodeWebTable `
+            -Name 'Processes' `
+            -Paginate `
+            -Compact `
+            -ScriptBlock {
+                $processes = Get-Process | Select-Object -Property Name, ID, WorkingSet, CPU
 
-    Set-PodeWebHomePage -Layouts $card1, $processes -Title 'Tables'
+                $totalCount = $processes.Length
+                $pageIndex = [int]$WebEvent.Data.PageIndex
+                $pageSize = [int]$WebEvent.Data.PageSize
+                $processes = $processes[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
+
+                $processes | Update-PodeWebTable -Name $ElementData.Name -PageIndex $pageIndex -TotalItemCount $totalCount
+            } `
+            -Columns @(
+                Initialize-PodeWebTableColumn -Key 'Name'
+                Initialize-PodeWebTableColumn -Key 'ID'
+                Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory' -Alignment Center -Width 10
+                Initialize-PodeWebTableColumn -Key 'CPU' -Hide
+            )
+    )
+
+    Set-PodeWebHomePage -Layouts $card1, $card2 -Title 'Tables'
 }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2381,7 +2381,10 @@ function Initialize-PodeWebTableColumn
 
         [Parameter()]
         [string]
-        $Default
+        $Default,
+
+        [switch]
+        $Hide
     )
 
     if ([string]::IsNullOrWhiteSpace($Name)) {
@@ -2395,6 +2398,7 @@ function Initialize-PodeWebTableColumn
         Name = $Name
         Icon = $Icon
         Default = $Default
+        Hide = $Hide.IsPresent
     }
 }
 

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -213,6 +213,58 @@ function Clear-PodeWebTable
     }
 }
 
+function Hide-PodeWebTableColumn
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Key
+    )
+
+    return @{
+        Operation = 'Hide'
+        ObjectType = 'TableColumn'
+        ID = $Id
+        Name = $Name
+        Key = $Key
+    }
+}
+
+function Show-PodeWebTableColumn
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Key
+    )
+
+    return @{
+        Operation = 'Show'
+        ObjectType = 'TableColumn'
+        ID = $Id
+        Name = $Name
+        Key = $Key
+    }
+}
+
 function Update-PodeWebTableRow
 {
     [CmdletBinding(DefaultParameterSetName='Name_and_DataValue')]

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1933,7 +1933,6 @@ function updateTableRow(action) {
 }
 
 function actionTableColumn(action) {
-    //TODO:
     switch (action.Operation.toLowerCase()) {
         case 'hide':
             hideTableColumn(action);

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1324,6 +1324,10 @@ function invokeActions(actions, sender) {
                 actionTableRow(action, sender);
                 break;
 
+            case 'tablecolumn':
+                actionTableColumn(action);
+                break;
+
             case 'chart':
                 actionChart(action, sender);
                 break;
@@ -1928,6 +1932,39 @@ function updateTableRow(action) {
     bindTableClickableRows(tableId);
 }
 
+function actionTableColumn(action) {
+    //TODO:
+    switch (action.Operation.toLowerCase()) {
+        case 'hide':
+            hideTableColumn(action);
+            break;
+
+        case 'show':
+            showTableColumn(action);
+            break;
+    }
+}
+
+function hideTableColumn(action) {
+    var table = getElementByNameOrId(action, 'table');
+    if (!table) {
+        return;
+    }
+
+    addClass(table.find(`thead th[name="${action.Key}"]`), 'd-none');
+    addClass(table.find(`tbody td[pode-column="${action.Key}"]`), 'd-none');
+}
+
+function showTableColumn(action) {
+    var table = getElementByNameOrId(action, 'table');
+    if (!table) {
+        return;
+    }
+
+    removeClass(table.find(`thead th[name="${action.Key}"]`), 'd-none', true);
+    removeClass(table.find(`tbody td[pode-column="${action.Key}"]`), 'd-none', true);
+}
+
 function getQueryStringValue(name) {
     if (!window.location.search) {
         return null;
@@ -2035,7 +2072,8 @@ function updateTable(action, sender) {
 
     // render initial columns?
     var _value = '';
-    var _direction = 'none'
+    var _direction = 'none';
+    var _columnHidden = false;
 
     var columnKeys = Object.keys(columns);
 
@@ -2084,14 +2122,16 @@ function updateTable(action, sender) {
         _oldHeader = tableHead.find(`th[name='${key}']`);
         if (_oldHeader.length > 0) {
             _direction = _oldHeader.attr('sort-direction');
+            _columnHidden = _oldHeader.hasClass('d-none');
         }
         else {
             _direction = 'none';
+            _columnHidden = false;
         }
 
         // add the table header
         if (key in columns) {
-            _value += buildTableHeader(columns[key], _direction);
+            _value += buildTableHeader(columns[key], _direction, _columnHidden);
         }
         else {
             if (_oldHeader.length > 0) {
@@ -2122,7 +2162,13 @@ function updateTable(action, sender) {
                     _value += `text-align:${_header.css('text-align')};`;
                 }
 
-                _value += `'>`;
+                _value += "'";
+
+                if (_header.hasClass('d-none')) {
+                    _value += ` class='d-none'`;
+                }
+
+                _value += ">";
             }
             else {
                 _value += `<td pode-column='${key}'>`;
@@ -2226,7 +2272,7 @@ function updateTable(action, sender) {
     bindTableClickableRows(tableId);
 }
 
-function buildTableHeader(column, direction) {
+function buildTableHeader(column, direction, hidden) {
     var value = `<th sort-direction='${direction}' name='${column.Key}' default-value='${column.Default}' style='`;
 
     if (column.Width) {
@@ -2237,7 +2283,13 @@ function buildTableHeader(column, direction) {
         value += `text-align:${column.Alignment};`;
     }
 
-    value += `'>`;
+    value += "'";
+
+    if (hidden || (hidden == null && column.Hide)) {
+        value += ` class='d-none'`;
+    }
+
+    value += ">";
 
     if (column.Icon) {
         value += `<span class='mdi mdi-${column.Icon.toLowerCase()} mRight04'></span>`;


### PR DESCRIPTION
### Description of the Change
Adds a new `-Hide` switch onto `Initialize-PodeWebTableColumn`, and also adds two new output actions for controlling table columns:

* `Hide-PodeWebTableColumn`
* `Show-PodeWebTableColumn`

### Related Issue
Resolves #275 

### Examples
```powershell
New-PodeWebCard -Content @(
    New-PodeWebButton -Name 'HideCPU' -ScriptBlock {
        Hide-PodeWebColumn -Name 'Processes' -Key 'CPU'
    }

    New-PodeWebButton -Name 'ShowCPU' -ScriptBlock {
        Show-PodeWebColumn -Name 'Processes' -Key 'CPU'
    }

    New-PodeWebTable `
        -Name 'Processes' `
        -Paginate `
        -Compact `
        -ScriptBlock {
            $processes = Get-Process | Select-Object -Property Name, ID, WorkingSet, CPU
            $totalCount = $processes.Length
            $pageIndex = [int]$WebEvent.Data.PageIndex
            $pageSize = [int]$WebEvent.Data.PageSize
            $processes = $processes[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
            $processes | Update-PodeWebTable -Name $ElementData.Name -PageIndex $pageIndex -TotalItemCount $totalCount
        } `
        -Columns @(
            Initialize-PodeWebTableColumn -Key 'Name'
            Initialize-PodeWebTableColumn -Key 'ID'
            Initialize-PodeWebTableColumn -Key 'WorkingSet' -Name 'Memory' -Alignment Center -Width 10
            Initialize-PodeWebTableColumn -Key 'CPU'
        )
)
```
