### PR TITLE
Allow for cell width to also be a percentage

### DIFF
--- a/docs/Tutorials/Layouts/Grid.md
+++ b/docs/Tutorials/Layouts/Grid.md
@@ -137,3 +137,25 @@ New-PodeWebGrid -Width 3 -Cells @(
     )
 )
 ```
+
+## Cell Width
+
+You can optionally specify the width of a cell within a grid, by using the `-Width` parameter on [`New-PodeWebCell`](../../../Functions/Layouts/New-PodeWebCell). A grid is split up into 12 segments, and the `-Width` parameter lets you specify a value between 1 and 12. A value of 12 means the cells takes up the full width of the grid, where as 6 would be half the width.
+
+You can also supply the value as a percentage as well; 50% being 6 segments, etc.
+
+```powershell
+New-PodeWebGrid -Cells @(
+    New-PodeWebCell -Width 6 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+    New-PodeWebCell -Width '25%' -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+    New-PodeWebCell -Width 3 -Content @(
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
+    )
+)
+```
+
+The above example would display a grid, with 1 cell occupying 50% of the width, and the last 2 just 25% each.

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -844,6 +844,54 @@ function ConvertTo-PodeWebStyles
     return $styles
 }
 
+function Protect-PodeWebRange
+{
+    param(
+        [Parameter()]
+        [string]
+        $Value,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Min,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Max
+    )
+
+    # null for no value
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $null
+    }
+
+    $pattern = Get-PodeWebNumberRegex
+
+    # if it's a percentage, calculate value
+    if ($Value.EndsWith('%')) {
+        $_val = [double]$Value.TrimEnd('%')
+        $Value = $Max * $_val * 0.01
+    }
+
+    # if value is number, check range
+    if ($Value -match $pattern) {
+        $_val = [int]$Value
+
+        if ($_val -lt $Min) {
+            return $Min
+        }
+
+        if ($_val -gt $Max) {
+            return $Max
+        }
+
+        return $_val
+    }
+
+    # invalid value
+    throw "Invalid value supplied for range: $($Value). Expected a value between $($Min)-$($Max), or a percentage."
+}
+
 function ConvertTo-PodeWebSize
 {
     param(
@@ -861,7 +909,7 @@ function ConvertTo-PodeWebSize
         $Type
     )
 
-    $pattern = '^\-?\d+(\.\d+){0,1}$'
+    $pattern = Get-PodeWebNumberRegex
     $defIsNumber = ($Default -match $pattern)
 
     if ([string]::IsNullOrWhiteSpace($Value)) {
@@ -891,6 +939,11 @@ function ConvertTo-PodeWebSize
     }
 
     return $Value
+}
+
+function Get-PodeWebNumberRegex
+{
+    return '^\-?\d+(\.\d+){0,1}$'
 }
 
 function Set-PodeWebSecurity

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -58,8 +58,7 @@ function New-PodeWebCell
         $Content,
 
         [Parameter()]
-        [ValidateRange(1, 12)]
-        [int]
+        [string]
         $Width,
 
         [Parameter()]
@@ -84,7 +83,7 @@ function New-PodeWebCell
         ComponentType = 'Layout'
         ObjectType = 'Cell'
         Content = $Content
-        Width = $Width
+        Width = (Protect-PodeWebRange -Value $Width -Min 1 -Max 12)
         ID = (Get-PodeWebElementId -Tag Cell -Id $Id -RandomToken)
         Alignment = $Alignment.ToLowerInvariant()
         CssClasses = ($CssClass -join ' ')


### PR DESCRIPTION
### Description of the Change
Allows the `-Width` on `New-PodeWebCell` to optionally also be supplied as a percentage. Also documents why the numbers are 1-12.

### Related Issue
Resolves #284 

### Examples
```powershell
New-PodeWebGrid -Cells @(
    New-PodeWebCell -Width 6 -Content @(
        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
    )
    New-PodeWebCell -Width '25%' -Content @(
        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
    )
    New-PodeWebCell -Width 3 -Content @(
        New-PodeWebImage -Source '/pode.web/images/icon.png' -Alignment Center
    )
)
```
