### PR TITLE
Add Set-PodeWebAuth for login methods like IIS

### DIFF
--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -1,13 +1,16 @@
 # Pages
 
-There are 3 different kinds of pages in Pode.Web, which are defined below. Besides the Login page, the Home and normal Webpages can be populated with Layout/Element components. When you add pages to your site, they appear on sidebar for navigation.
+There are 3 different kinds of pages in Pode.Web, which are defined below. Other than the Login page, the Home and normal Webpages can be populated with custom Layout/Element components. When you add pages to your site, they appear on the sidebar for navigation - unless they are specified to be hidden from the sidebar.
 
 ## Login
 
 To enable the use of a login page, and lock your site behind authentication is simple! First, just setup sessions and define the authentication method you want via the usual `Enable-PodeSessionMiddleware`, `New-PodeAuthScheme` and `Add-PodeAuth` in Pode. Then, pass the authentication name into [`Set-PodeWebLoginPage`](../../Functions/Pages/Set-PodeWebLoginPage) - and that's it!
 
+!!! note
+    Since the login page uses a form to logging a user in, the best scheme to use is Forms: `New-PodeAuthScheme -Form`. OAuth also works, as the login page will automatically trigger the relevant redirects.
+
 ```powershell
-Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+Enable-PodeSessionMiddleware -Duration 120 -Extend
 
 New-PodeAuthScheme -Form | Add-PodeAuth -Name Example -ScriptBlock {
     param($username, $password)
@@ -25,6 +28,16 @@ Set-PodeWebLoginPage -Authentication Example
 ```
 
 By default the Pode icon is displayed as the logo, but you can change this by using the `-Logo` parameter; this takes a literal or relative URL to an image file.
+
+### IIS
+
+If you're hosting the site using IIS, and want to use Windows Authentication within IIS, then you can setup authentication in Pode.Web via [`Set-PodeWebAuth`](../../Functions/Utilities/Set-PodeWebAuth). This works similar to `Set-PodeWebLoginPage`, and sets up authentication on the pages, but it doesn't cause a login page or the sign-in/out buttons to appear. Instead, Pode.Web gets the session from IIS, and then displays the logged in user at the top - similar to how the login page would after a successful login.
+
+```powershell
+Enable-PodeSessionMiddleware -Duration 120 -Extend
+Add-PodeAuthIIS -Name Example
+Set-PodeWebAuth -Authentication Example
+```
 
 ## Home
 

--- a/examples/full_iis.ps1
+++ b/examples/full_iis.ps1
@@ -1,0 +1,350 @@
+#Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\..\Pode\src\Pode.psm1 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer -StatusPageExceptions Show {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+
+    # enable sessions and authentication
+    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
+    Add-PodeAuthIIS -Name Example
+
+    # set the use of templates
+    Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web/images/icon.png' -Theme Dark
+
+    # set auth to iis
+    Set-PodeWebAuth -Authentication Example
+
+    $link1 = New-PodeWebNavLink -Name 'Home' -Url '/' -Icon Home
+    $link2 = New-PodeWebNavLink -Name 'Dynamic' -Icon Cogs -ScriptBlock {
+        Show-PodeWebToast -Message "I'm from a nav link!"
+    }
+    $div1 = New-PodeWebNavDivider
+    $link3 = New-PodeWebNavLink -Name 'Disabled' -Url '/' -Disabled
+    $dd1 = New-PodeWebNavDropdown -Name 'Dropdown' -Icon Expand -Items @(
+        New-PodeWebNavLink -Name 'Twitter' -Url 'https://twitter.com'
+        New-PodeWebNavLink -Name 'Facebook' -Url 'https://facebook.com' -Disabled
+        New-PodeWebNavDivider
+        New-PodeWebNavLink -Name 'YouTube' -Url 'https://youtube.com' -Icon YouTube
+        New-PodeWebNavDropdown -Name 'InnerDrop' -Items @(
+            New-PodeWebNavLink -Name 'Twitch' -Url 'https://twitch.tv'
+            New-PodeWebNavLink -Name 'Pode' -Url 'https://github.com/Badgerati/Pode'
+        )
+    )
+
+    Set-PodeWebNavDefault -Items $link1, $link2, $div1, $link3, $dd1
+
+
+    $timer1 = New-PodeWebTimer -Name 'Timer1' -Interval 10 -ScriptBlock {
+        $rand = Get-Random -Minimum 0 -Maximum 3
+        $colour = (@('Green', 'Yellow', 'Cyan'))[$rand]
+        Update-PodeWebBadge -Id 'bdg_test' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')) -Colour $colour
+        Update-PodeWebText -Id 'code_test' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss'))
+    }
+
+    # set the home page controls (just a simple paragraph) [note: homepage does not require auth in this example]
+    $section = New-PodeWebCard -Name 'Welcome' -NoTitle -Content @(
+        New-PodeWebParagraph -Value 'This is an example homepage, with some example text'
+        New-PodeWebParagraph -Elements @(
+            New-PodeWebText -Value 'Using some '
+            New-PodeWebText -Value 'example' -Style Italics
+            New-PodeWebText -Value ' paragraphs' -Style Bold
+        )
+        New-PodeWebParagraph -Elements @(
+            New-PodeWebText -Value 'Pronuncation example: '
+            New-PodeWebText -Value '漢' -Pronunciation 'ㄏㄢˋ'
+        )
+        New-PodeWebParagraph -Elements @(
+            New-PodeWebText -Value "Look, here's a "
+            New-PodeWebLink -Source 'https://github.com/badgerati/pode' -Value 'link' -NewTab
+            New-PodeWebText -Value "! "
+            New-PodeWebBadge -Id 'bdg_test' -Value 'Sweet!' -Colour Cyan |
+                Register-PodeWebEvent -Type Click -ScriptBlock {
+                    Show-PodeWebToast -Message 'Badge was clicked!'
+                }
+        )
+        New-PodeWebParagraph -Elements @(
+            New-PodeWebCode -Id 'code_test' -Value "some code :o"
+        )
+        $timer1
+        New-PodeWebImage -Source '/pode.web/images/icon.png' -Height 70 -Alignment Right
+        New-PodeWebQuote -Value 'Pode is awesome!' -Source 'Badgerati'
+        New-PodeWebButton -Name 'Click Me' -DataValue 'PowerShell Rules!' -Icon 'console-line' -Colour Green -ScriptBlock {
+            Show-PodeWebToast -Message "Message of the day: $($WebEvent.Data.Value)"
+            Show-PodeWebNotification -Title 'Hello, there' -Body 'General Kenobi' -Icon '/pode.web/images/icon.png'
+        }
+        New-PodeWebButton -Name 'Click Me Outlined' -DataValue 'PowerShell Rules!' -Icon 'console-line' -Colour Green -Outline -ScriptBlock {
+            Show-PodeWebToast -Message "Message of the day: $($WebEvent.Data.Value)"
+            Show-PodeWebNotification -Title 'Hello, there' -Body 'General Kenobi' -Icon '/pode.web/images/icon.png'
+        }
+        New-PodeWebContainer -Content @(
+            New-PodeWebButton -Name 'Dark Theme' -Icon 'moon-new' -Colour Dark -ScriptBlock { Update-PodeWebTheme -Name Dark }
+            New-PodeWebButton -Name 'Light Theme' -Icon 'weather-sunny' -Colour Light -ScriptBlock { Update-PodeWebTheme -Name Light }
+            New-PodeWebButton -Name 'Reset Theme' -Icon 'refresh' -ScriptBlock { Reset-PodeWebTheme }
+        )
+        New-PodeWebAlert -Type Note -Value 'Hello, world'
+    )
+
+    $section2 = New-PodeWebCard -Name 'Code' -NoTitle -Content @(
+        New-PodeWebCodeBlock -Value "Write-Host 'hello, world!'" -NoHighlight
+        New-PodeWebCodeBlock -Value "
+            function Write-SomeStuff
+            {
+                param(
+                    [Parameter()]
+                    [string]
+                    `$Message
+                )
+
+                Write-Host `$Message
+            }
+
+            Write-SomeStuff -Message 'Hello, there'
+        " -Language PowerShell
+    )
+
+    $section3 = New-PodeWebCard -Name 'Comments' -Icon 'comment' -Content @(
+        New-PodeWebComment -Icon '/pode.web/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
+        New-PodeWebComment -Icon '/pode.web/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
+    )
+
+    $codeEditor = New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor' -AsCard
+
+    $chartData = {
+        $count = 1
+        if ($WebEvent.Data.FirstLoad -eq '1') {
+            $count = 4
+        }
+
+        return (1..$count | ForEach-Object {
+            @{
+                Key = $_
+                Values = @(
+                    @{
+                        Key = 'Example1'
+                        Value = (Get-Random -Maximum 10)
+                    },
+                    @{
+                        Key = 'Example2'
+                        Value = (Get-Random -Maximum 10)
+                    }
+                )
+            }
+        })
+    }
+
+    $processData = {
+        Get-Process |
+            Sort-Object -Property CPU -Descending |
+            Select-Object -First 10 |
+            ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU, Handles
+    }
+
+    $grid1 = New-PodeWebGrid -Cells @(
+        New-PodeWebCell -Content @(
+            New-PodeWebChart -Name 'Line Example 1' -Type Line -ScriptBlock $chartData -Append -TimeLabels -MaxItems 15 -AutoRefresh -AsCard
+        )
+        New-PodeWebCell -Content @(
+            New-PodeWebChart -Name 'Top Processes' -Type Bar -ScriptBlock $processData -AutoRefresh -RefreshInterval 10 -AsCard
+        )
+        New-PodeWebCell -Content @(
+            New-PodeWebCounterChart -Counter '\Processor(_Total)\% Processor Time' -MinY 0 -MaxY 100 -AsCard
+        )
+    )
+
+    $hero = New-PodeWebHero -Title 'Welcome!' -Message 'This is the home page for the full.ps1 example' -Content @(
+        New-PodeWebText -Value 'Here you will see examples for close to everything Pode.Web can do.' -InParagraph -Alignment Center
+        New-PodeWebParagraph -Alignment Center -Elements @(
+            New-PodeWebButton -Name 'Repository' -Icon Link -Url 'https://github.com/Badgerati/Pode.Web' -NewTab
+        )
+    )
+
+    $carousel = New-PodeWebCarousel -Slides @(
+        New-PodeWebSlide -Title 'First Slide' -Message 'First slide message' -Content @(
+            New-PodeWebContainer -Nobackground -Content @(
+                New-PodeWebText -Value 'Slide 1' -Alignment Center
+            )
+        )
+        New-PodeWebSlide -Title 'Second Slide' -Message 'Second slide message' -Content @(
+            New-PodeWebContainer -Nobackground -Content @(
+                New-PodeWebText -Value 'Slide 2' -Alignment Center
+            )
+        )
+        New-PodeWebSlide -Title 'Third Slide' -Message 'Third slide message' -Content @(
+            New-PodeWebContainer -Nobackground -Content @(
+                New-PodeWebText -Value 'Slide 3' -Alignment Center
+            )
+        )
+    )
+
+    Set-PodeWebHomePage -Layouts $hero, $grid1, $section, $carousel, $section2, $section3, $codeEditor -NoTitle -PassThru |
+        Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -ScriptBlock {
+            Show-PodeWebToast -Message "Home page $($EventType)!"
+        }
+
+
+    # tabs and charts
+    $tabs1 = New-PodeWebTabs -Cycle -Tabs @(
+        New-PodeWebTab -Name 'Line' -Icon 'chart-line' -Layouts @(
+            New-PodeWebChart -Name 'Line Example 2' -Type Line -ScriptBlock $chartData -Append -TimeLabels -MaxItems 30 -AutoRefresh -Height 250 -AsCard
+        )
+        New-PodeWebTab -Name 'Bar' -Icon 'chart-bar' -Layouts @(
+            New-PodeWebChart -Name 'Bar Example 2' -Type Bar -ScriptBlock $chartData -AsCard
+        )
+        New-PodeWebTab -Name 'Doughnut' -Icon 'chart-donut' -Layouts @(
+            New-PodeWebChart -Name 'Doughnut Example 1' -Type Doughnut -ScriptBlock $chartData -AsCard
+        )
+    )
+
+    Add-PodeWebPage -Name Charts -Icon 'chart-bar' -Layouts $tabs1 -Title 'Cycling Tabs' -NoSidebar -PassThru |
+        Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -ScriptBlock {
+            Show-PodeWebToast -Message "Page $($EventType)!"
+        }
+
+
+    # add a page to search and filter services (output in a new table element) [note: requires auth]
+    $editModal = New-PodeWebModal -Name 'Edit Service' -Icon 'square-edit-outline' -Id 'modal_edit_svc' -AsForm -Content @(
+        New-PodeWebAlert -Type Info -Value 'This does nothing, it is just an example'
+        New-PodeWebCheckbox -Name Running -Id 'chk_svc_running' -AsSwitch
+    ) -ScriptBlock {
+        $WebEvent.Data | Out-Default
+        Hide-PodeWebModal
+    }
+
+    $helpModal = New-PodeWebModal -Name 'Help' -Icon 'help' -Content @(
+        New-PodeWebText -Value 'HELP!'
+    )
+
+    $table = New-PodeWebTable -Name 'Static' -DataColumn Name -AsCard -Filter -SimpleSort -Click -Paginate -ScriptBlock {
+        $stopBtn = New-PodeWebButton -Name 'Stop' -Icon 'stop-circle-outline' -IconOnly -ScriptBlock {
+            Stop-Service -Name $WebEvent.Data.Value -Force | Out-Null
+            Show-PodeWebToast -Message "$($WebEvent.Data.Value) stopped"
+            Sync-PodeWebTable -Id $ElementData.Parent.ID
+        }
+
+        $startBtn = New-PodeWebButton -Name 'Start' -Icon 'play-circle-outline' -IconOnly -ScriptBlock {
+            Start-Service -Name $WebEvent.Data.Value | Out-Null
+            Show-PodeWebToast -Message "$($WebEvent.Data.Value) started"
+            Sync-PodeWebTable -Id $ElementData.Parent.ID
+        }
+
+        $editBtn = New-PodeWebButton -Name 'Edit' -Icon 'square-edit-outline' -IconOnly -ScriptBlock {
+            $svc = Get-Service -Name $WebEvent.Data.Value
+            $checked = ($svc.Status -ieq 'running')
+
+            Show-PodeWebModal -Id 'modal_edit_svc' -DataValue $WebEvent.Data.Value -Actions @(
+                Update-PodeWebCheckbox -Id 'chk_svc_running' -Checked:$checked
+            )
+        }
+
+        $filter = "*$($WebEvent.Data.Filter)*"
+
+        foreach ($svc in (Get-Service)) {
+            if ($svc.Name -inotlike $filter) {
+                continue
+            }
+
+            $btns = @($editBtn)
+            if ($svc.Status -ieq 'running') {
+                $btns += $stopBtn
+            }
+            else {
+                $btns += $startBtn
+            }
+
+            [ordered]@{
+                Name = $svc.Name
+                Status = "$($svc.Status)"
+                Actions = $btns
+            }
+        }
+    }
+
+    Add-PodeStaticRoute -Path '/download' -Source '.\storage' -DownloadOnly
+
+    $table | Add-PodeWebTableButton -Name 'Excel' -Icon 'chart-bar' -ScriptBlock {
+        $path = Join-Path (Get-PodeServerPath) '.\storage\test.csv'
+        $WebEvent.Data | Export-Csv -Path $path -NoTypeInformation
+        Set-PodeResponseAttachment -Path '/download/test.csv'
+    }
+
+    $homeLink1 = New-PodeWebNavLink -Name 'Home' -Url '/'
+
+    Add-PodeWebPage -Name Services -Icon 'cogs' -Group Tools -Layouts $editModal, $helpModal, $table -Navigation $homeLink1 -ScriptBlock {
+        $name = $WebEvent.Query['value']
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            return
+        }
+
+        $svc = Get-Service -Name $name | Out-String
+
+        New-PodeWebCard -Name "$($name) Details" -Content @(
+            New-PodeWebCodeBlock -Value $svc -NoHighlight
+        )
+    } `
+    -HelpScriptBlock {
+        Show-PodeWebModal -Name 'Help'
+    }
+
+
+    # add a page to search process (output as json in an appended textbox) [note: requires auth]
+    $form = New-PodeWebForm -Name 'Search' -AsCard -ScriptBlock {
+        if ($WebEvent.Data.Name.Length -le 3) {
+            Out-PodeWebValidation -Name 'Name' -Message 'Name must be greater than 3 characters'
+            return
+        }
+
+        Get-Process -Name $WebEvent.Data.Name -ErrorAction Ignore | Select-Object Name, ID, WorkingSet, CPU | Out-PodeWebTextbox -Multiline -Preformat -ReadOnly
+    } -Content @(
+        New-PodeWebTextbox -Name 'Name'
+    )
+
+    Add-PodeWebPage -Name Processes -Icon 'chart-box-outline' -Group Tools -AccessGroups Developer -Layouts $form
+
+
+    # page with table showing csv data
+    $table2 = New-PodeWebTable -Name 'Users' -DataColumn UserId -Filter -SimpleSort -Paginate -CsvFilePath './misc/data.csv' -AsCard
+    Add-PodeWebPage -Name CSV -Icon Database -Group Tools -Layouts $table2
+
+
+    # page with table show dynamic paging, filter, and sorting via a csv
+    $table3 = New-PodeWebTable -Name 'Dynamic Users' -DataColumn UserId -Filter -Sort -Paginate -AsCard -ScriptBlock {
+        # load the file
+        $filePath = Join-Path (Get-PodeServerPath) 'misc/data.csv'
+        $data = Import-Csv -Path $filePath
+
+        # apply filter if present
+        $filter = $WebEvent.Data.Filter
+        if (![string]::IsNullOrWhiteSpace($filter)) {
+            $filter = "*$($filter)*"
+            $data = @($data | Where-Object { ($_.psobject.properties.value -ilike $filter).length -gt 0 })
+        }
+
+        # apply sorting
+        $sortColumn = $WebEvent.Data.SortColumn
+        if (![string]::IsNullOrWhiteSpace($sortColumn)) {
+            $descending = ($WebEvent.Data.SortDirection -ieq 'desc')
+            $data = @($data | Sort-Object -Property { $_.$sortColumn } -Descending:$descending)
+        }
+
+        # apply paging
+        $totalCount = $data.Length
+        $pageIndex = [int]$WebEvent.Data.PageIndex
+        $pageSize = [int]$WebEvent.Data.PageSize
+        $data = $data[(($pageIndex - 1) * $pageSize) .. (($pageIndex * $pageSize) - 1)]
+
+        # update table
+        $data | Update-PodeWebTable -Name 'Dynamic Users' -PageIndex $pageIndex -TotalItemCount $totalCount
+    }
+
+    Add-PodeWebPage -Name 'Dynamic Paging' -Icon Database -Group Tools -Layouts $table3
+
+
+    # open twitter
+    Add-PodeWebPageLink -Name Twitter -Icon Twitter -Group Social -ScriptBlock {
+        Move-PodeWebUrl -Url 'https://twitter.com' -NewTab
+    }
+}

--- a/examples/web.config
+++ b/examples/web.config
@@ -14,7 +14,7 @@
         <remove name="WebDAVModule" />
       </modules>
 
-      <aspNetCore processPath="pwsh.exe" arguments=".\full.ps1" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="OutOfProcess"/>
+      <aspNetCore processPath="pwsh.exe" arguments=".\full_iis.ps1" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="OutOfProcess" />
 
       <security>
         <authorization>
@@ -24,4 +24,7 @@
       </security>
     </system.webServer>
   </location>
+    <system.web>
+        <authentication mode="Windows" />
+    </system.web>
 </configuration>

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -50,6 +50,7 @@ function Set-PodeWebLoginPage
         Group = $GroupProperty
         Avatar = $AvatarProperty
         Theme = $ThemeProperty
+        Logout = $true
     }
 
     # set a default logo/url
@@ -153,7 +154,7 @@ function Set-PodeWebLoginPage
             Navigation = $navigation
             Auth = @{
                 Enabled = $true
-                Logout = $true
+                Logout = (Get-PodeWebState -Name 'auth-props').Logout
                 Authenticated = $authData.IsAuthenticated
                 Username = $username
                 Groups = $groups
@@ -265,6 +266,7 @@ function Set-PodeWebHomePage
             Layouts = $comps
             Auth = @{
                 Enabled = ![string]::IsNullOrWhiteSpace((Get-PodeWebState -Name 'auth'))
+                Logout = (Get-PodeWebState -Name 'auth-props').Logout
                 Authenticated = $authData.IsAuthenticated
                 Username = $username
                 Groups = $groups
@@ -444,6 +446,7 @@ function Add-PodeWebPage
 
         $authMeta = @{
             Enabled = ![string]::IsNullOrWhiteSpace((Get-PodeWebState -Name 'auth'))
+            Logout = (Get-PodeWebState -Name 'auth-props').Logout
             Authenticated = $authData.IsAuthenticated
             Username = $username
             Groups = $groups

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -153,6 +153,7 @@ function Set-PodeWebLoginPage
             Navigation = $navigation
             Auth = @{
                 Enabled = $true
+                Logout = $true
                 Authenticated = $authData.IsAuthenticated
                 Username = $username
                 Groups = $groups

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -285,3 +285,84 @@ function Join-PodeWebPath
 
     return $result
 }
+
+function Set-PodeWebAuth
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Authentication,
+
+        [Parameter()]
+        [string]
+        $UsernameProperty,
+
+        [Parameter()]
+        [string]
+        $GroupProperty,
+
+        [Parameter()]
+        [string]
+        $AvatarProperty,
+
+        [Parameter()]
+        [string]
+        $ThemeProperty
+    )
+
+    Set-PodeWebState -Name 'auth' -Value $Authentication
+    Set-PodeWebState -Name 'auth-props' -Value @{
+        Username = $UsernameProperty
+        Group = $GroupProperty
+        Avatar = $AvatarProperty
+        Theme = $ThemeProperty
+    }
+
+    # set default failure/success urls
+    $auth = Get-PodeAuth -Name $Authentication
+    $auth.Failure.Url = (Add-PodeWebAppPath -Url '/')
+    $auth.Success.Url = (Add-PodeWebAppPath -Url '/')
+
+    # get the endpoints to bind
+    $endpointNames = Get-PodeWebState -Name 'endpoint-name'
+
+    # add an authenticated home route
+    Remove-PodeWebRoute -Method Get -Path '/' -EndpointName $endpointNames
+
+    Add-PodeRoute -Method Get -Path '/' -Authentication $Authentication -EndpointName $endpointNames -ScriptBlock {
+        $page = Get-PodeWebFirstPublicPage
+        if ($null -ne $page) {
+            Move-PodeResponseUrl -Url (Get-PodeWebPagePath -Page $page)
+        }
+
+        $authData = Get-PodeWebAuthData
+        $username = Get-PodeWebAuthUsername -AuthData $authData
+        $groups = Get-PodeWebAuthGroups -AuthData $authData
+        $avatar = Get-PodeWebAuthAvatarUrl -AuthData $authData
+        $theme = Get-PodeWebTheme
+        $navigation = Get-PodeWebNavDefault
+
+        Write-PodeWebViewResponse -Path 'index' -Data @{
+            Page = @{
+                Name = 'Home'
+                Path = '/'
+                IsSystem = $true
+            }
+            Theme = $theme
+            Navigation = $navigation
+            Auth = @{
+                Enabled = $true
+                Logout = $false
+                Authenticated = $authData.IsAuthenticated
+                Username = $username
+                Groups = $groups
+                Avatar = $avatar
+            }
+        }
+    }
+
+    if ($PassThru) {
+        return $pageMeta
+    }
+}

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -317,6 +317,7 @@ function Set-PodeWebAuth
         Group = $GroupProperty
         Avatar = $AvatarProperty
         Theme = $ThemeProperty
+        Logout = $false
     }
 
     # set default failure/success urls
@@ -353,7 +354,7 @@ function Set-PodeWebAuth
             Navigation = $navigation
             Auth = @{
                 Enabled = $true
-                Logout = $false
+                Logout = (Get-PodeWebState -Name 'auth-props').Logout
                 Authenticated = $authData.IsAuthenticated
                 Username = $username
                 Groups = $groups

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -60,12 +60,14 @@
                                 "<span id='avatar' class='mdi mdi-account'></span>"
                             }
                             "Hello, $([System.Net.WebUtility]::HtmlEncode($data.Auth.Username))
-                        </span>
-                        <button class='btn btn-danger my-2 my-sm-0 mBottom-06 mRight05' type='submit'>
-                            <span class='mdi mdi-logout mRight02'></span>
-                            Sign out
-                        </button>
-                    </form>"
+                        </span>"
+                        if ($data.Auth.Logout) {
+                            "<button class='btn btn-danger my-2 my-sm-0 mBottom-06 mRight05' type='submit'>
+                                <span class='mdi mdi-logout mRight02'></span>
+                                Sign out
+                            </button>"
+                        }
+                    "</form>"
                 }
                 else {
                     "<form class='form-inline' action='$($data.AppPath)/login' method='GET' style='margin-bottom: 0'>


### PR DESCRIPTION
### Description of the Change
Adds a new `Set-PodeWebAuth` function so authentication methods that don't need a login page can be set - such as IIS, Basic, Digest, etc.

For the case of each, Pode.Web checks if theirs a session available and authenticated, and this is used to display the current user.

Similar to `Set-PodeWebLoginPage`, this function also wires up the authentication on all pages as well. The logout button is hidden, as there's no need since authentication is dealt with elsewhere.

### Related Issue
Resolves #129 

### Examples
The below will configure Pode.Web pages to use IIS authentication.
```powershell
Enable-PodeSessionMiddleware -Duration 120 -Extend
Add-PodeAuthIIS -Name Example
Set-PodeWebAuth -Authentication Example
```