### PR TITLE
Clean up table paging control, show spinner when reloading, and add paging size control

### DIFF
--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -150,6 +150,14 @@ main[role="main"].fullscreen {
 
 nav[role="pagination"] {
     float: right;
+    display: inline-flex;
+}
+
+nav[role="pagination"] input.page-size {
+    width: 4.5em;
+    font-size: 1em;
+    margin-right: 1em;
+    display: flex;
 }
 
 .breadcrumb {

--- a/src/Templates/Views/elements/table.pode
+++ b/src/Templates/Views/elements/table.pode
@@ -67,7 +67,7 @@ $(if ($data.Filter.Enabled) {
         </div>
 
         $(if ($data.Paging.Enabled) {
-            "<nav role='pagination' aria-label='$($data.Name) Pages' for='$($data.ID)' pode-page-size='$($data.Paging.Size)'>
+            "<nav role='pagination' aria-label='$($data.Name) Pages' for='$($data.ID)' pode-page-size='$($data.Paging.Size)' pode-current-page='1'>
                 <ul class='pagination justify-content-end'>
                 </ul>
             </nav>"


### PR DESCRIPTION
### Description of the Change
This cleans up the table pagination controls, so they're a little easier to look at and use. The "..." has gone, and the first/last numbers have been replaced with first/last chevron buttons instead.

When you click for another page, the table now clears and show a spinner to show that it's actually doing something.

There's now a textbox next to the paging control, which allows altering the number of items that show in the table! 🚀 
