### PR TITLE
Add support for multiple pre-selected values

### DIFF
--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -540,7 +540,7 @@ function New-PodeWebSelect
         $ArgumentList,
 
         [Parameter()]
-        [string]
+        [string[]]
         $SelectedValue,
 
         [Parameter()]
@@ -564,6 +564,10 @@ function New-PodeWebSelect
         [switch]
         $Required
     )
+
+    if (!$Multiple.IsPresent -and $SelectedValue.Length -ge 2) {
+        throw 'Multiple selected values require -Multiple switch'
+    }
 
     $Id = Get-PodeWebElementId -Tag Select -Id $Id -Name $Name
 

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -798,7 +798,7 @@ function Update-PodeWebSelect
         $DisplayOptions,
 
         [Parameter()]
-        [string]
+        [string[]]
         $SelectedValue
     )
 
@@ -818,7 +818,7 @@ function Update-PodeWebSelect
             ID = $Id
             Options = $items
             DisplayOptions = @(Protect-PodeWebValues -Value $DisplayOptions -Default $items -EqualCount)
-            SelectedValue = [System.Net.WebUtility]::HtmlEncode($SelectedValue)
+            SelectedValue = @(Protect-PodeWebValues -Value $SelectedValue -Encode)
         }
     }
 }

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -2778,12 +2778,15 @@ function updateSelect(action) {
     }
 
     action.DisplayOptions = convertToArray(action.DisplayOptions);
+    action.SelectedValue = convertToArray(action.SelectedValue);
 
     action.Options.forEach((opt, idx) => {
-        select.append(`<option value="${opt}">${action.DisplayOptions[idx]}</option>`);
+        var optSelected = '';
+        if (action.SelectedValue.includes(opt) == true) {
+            optSelected = ' selected';
+        }
+        select.append(`<option value="${opt}"${optSelected}>${action.DisplayOptions[idx]}</option>`);
     })
-
-    setSelectValue(select, action.SelectedValue);
 }
 
 function clearSelect(action) {

--- a/src/Templates/Views/elements/select.pode
+++ b/src/Templates/Views/elements/select.pode
@@ -9,6 +9,11 @@
                 $multiple = "multiple size='$($data.Size)'"
             }
 
+            $selectedValue = $data.SelectedValue
+            if (!$data.Multiple -and $selectedValue.Length -ge 2) {
+                $selectedValue = $data.SelectedValue[0]
+            }
+
             "<select
                 class='custom-select $(if ($data.NoForm) { 'no-form' })'
                 style='$($data.CssStyles)'
@@ -26,11 +31,11 @@
                     continue
                 }
 
-                if ([string]::IsNullOrWhiteSpace($data.SelectedValue)) {
+                if ([string]::IsNullOrWhiteSpace($selectedValue)) {
                     "<option value='$($data.Options[$i])'>$($data.DisplayOptions[$i])</option>"
                 }
                 else {
-                    "<option value='$($data.Options[$i])' $(if ($data.SelectedValue -ieq $data.Options[$i]) { 'selected' })>$($data.DisplayOptions[$i])</option>"
+                    "<option value='$($data.Options[$i])' $(if ($selectedValue -icontains $data.Options[$i]) { 'selected' })>$($data.DisplayOptions[$i])</option>"
                 }
             }
 


### PR DESCRIPTION
### Description of the Change
This adds support for selecting multiple options of a multi select element during creation/update. Therefore parameter `-SelectedValue` was changed to accept a list of values for:
- `New-PodeWebSelect`
- `Update-PodeWebSelect`

#### Behavior with non-multiple select

Creating a non-multiple select element with multiple selected values will create an exception.
Updating a non-multiple select element with multiple selected values will select only the first one.

### Related Issue
#304 

### Examples

- New select with multiple preselected values:

```powershell
New-PodeWebCard -Content @(
    New-PodeWebForm -Name 'Example Form' -ScriptBlock {
        $WebEvent.Data | Out-Default
    } -Content @(
        New-PodeWebSelect -Name 'Role2' `
                          -Options @('User', 'Admin', 'Operations') `
                          -Multiple `
                          -SelectedValue @('User', 'Operations')
    )
)
```

- Update select with multiple selected values when pressing button:

```powershell
New-PodeWebCard -Content @(
    New-PodeWebButton -Name 'New Selected' -ScriptBlock {
        Update-PodeWebSelect -Name 'DynamicSelectedValue' `
                             -Options (1..10) `
                             -SelectedValue (Get-Random -Minimum 1 -Maximum 10 -Count 3)
    }

    New-PodeWebSelect -Name 'DynamicSelectedValue' -Options (1..10) -Multiple
)
```