### PR TITLE
Choose latest module version when multiple are imported

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1,6 +1,6 @@
 function Get-PodeWebTemplatePath
 {
-    $path = Split-Path -Parent -Path ((Get-Module -Name 'Pode.Web').Path)
+    $path = Split-Path -Parent -Path ((Get-Module -Name 'Pode.Web' | Sort-Object -Property Version -Descending | Select-Object -First 1).Path)
     return (Join-PodeWebPath $path 'Templates')
 }
 


### PR DESCRIPTION
### Description of the Change
Fix for choosing the module path to use, when multiple versions of Pode.Web happen to be imported at the same time. The latest version available will be chosen - matching similar logic in Pode.

### Related Issue
Resolves #299 
