### PR TITLE
Allow empty string for hidden value

### DIFF
--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1163,6 +1163,7 @@ function New-PodeWebHidden
         $Id,
 
         [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
         [string]
         $Value,
 


### PR DESCRIPTION
### Description of the Change
Add allow empty string attribute to the Value parameter.

### Related Issue
#335 

### Examples
![image](https://user-images.githubusercontent.com/19328074/186253221-2d81913d-2d84-43ec-a1d9-12e712b741f9.png)


### Additional Context
As we can see, page loads happily, HTML looks happy as well, and this prevents unexpected when incoming value is in fact an empty string.