### PR TITLE
Feature/text box max length

### DIFF
--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -99,6 +99,7 @@ function New-PodeWebTextbox
         [switch]
         $DynamicLabel,
 
+        [ValidateRange(0, [int]::MaxValue)]
         [int]
         $MaxLength = 524288
     )

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -124,7 +124,7 @@ function New-PodeWebTextbox
         HelpText = [System.Net.WebUtility]::HtmlEncode($HelpText)
         ReadOnly = $ReadOnly.IsPresent
         IsAutoComplete = ($null -ne $AutoComplete)
-        Value = $Value
+        Value = [System.Net.WebUtility]::HtmlEncode($Value)
         CssClasses = ($CssClass -join ' ')
         CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Prepend = @{

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -97,7 +97,10 @@ function New-PodeWebTextbox
         $AutoFocus,
 
         [switch]
-        $DynamicLabel
+        $DynamicLabel,
+
+        [int]
+        $MaxLength = 524288
     )
 
     $Id = Get-PodeWebElementId -Tag Textbox -Id $Id -Name $Name
@@ -142,6 +145,7 @@ function New-PodeWebTextbox
         Required = $Required.IsPresent
         AutoFocus = $AutoFocus.IsPresent
         DynamicLabel = $DynamicLabel.IsPresent
+        MaxLength = $MaxLength
     }
 
     # create autocomplete route

--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -38,8 +38,15 @@ $(
             }
 
             $value = [string]::Empty
+            $textareavalue = [string]::Empty
             if (![string]::IsNullOrWhiteSpace($data.Value)) {
                 $value = "value='$($data.Value)'"
+                $textareavalue = "$($data.Value)"
+            }
+
+            $maxLength = [string]::Empty
+            if (![string]::IsNullOrWhiteSpace($data.maxLength)) {
+                $maxLength = "maxlength='$($data.maxLength)'"
             }
 
             $width = "width: $($data.Width);"
@@ -51,7 +58,7 @@ $(
             }
 
             if ($data.Multiline) {
-                $element = "<textarea class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width) $($data.CssStyles)' $($describedBy) $($readOnly) $($required) $($autofocus) $($value) $($events)></textarea>"
+                $element = "<textarea class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width) $($data.CssStyles)' $($describedBy) $($readOnly) $($required) $($autofocus) $($events) $($maxLength)>$($textareavalue)</textarea>"
             }
             else {
                 if ($data.Prepend.Enabled -or $data.Append.Enabled) {
@@ -72,7 +79,7 @@ $(
                     $_type = 'datetime-local'
                 }
 
-                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' style='$($width) $($data.CssStyles)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($required) $($autofocus) $($value) $($events)>"
+                $element += "<input type='$($_type.ToLowerInvariant())' class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' style='$($width) $($data.CssStyles)' placeholder='$($data.Placeholder)' pode-autocomplete='$($data.IsAutoComplete)' $($describedBy) $($readOnly) $($required) $($autofocus) $($value) $($events) $($maxLength)>"
 
                 if ($data.Append.Enabled) {
                     if (![string]::IsNullOrWhiteSpace($data.Append.Text)) {

--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -38,10 +38,13 @@ $(
             }
 
             $value = [string]::Empty
-            $textareavalue = [string]::Empty
-            if (![string]::IsNullOrWhiteSpace($data.Value)) {
-                $value = "value='$($data.Value)'"
-                $textareavalue = "$($data.Value)"
+            if (![string]::IsNullOrWhitespace($data.Value)) {
+                if ($data.Multiline) {
+                    $value = $data.Value
+                }
+                else {
+                    $value = "value='$($data.Value)'"
+                }
             }
 
             $maxLength = [string]::Empty
@@ -58,7 +61,7 @@ $(
             }
 
             if ($data.Multiline) {
-                $element = "<textarea class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width) $($data.CssStyles)' $($describedBy) $($readOnly) $($required) $($autofocus) $($events) $($maxLength)>$($textareavalue)</textarea>"
+                $element = "<textarea class='form-control $(if ($data.NoForm) { 'no-form' })' id='$($data.ID)' name='$($data.Name)' pode-object='$($data.ObjectType)' placeholder='$($data.Placeholder)' rows='$($data.Size)' style='$($width) $($data.CssStyles)' $($describedBy) $($readOnly) $($required) $($autofocus) $($events) $($maxLength)>$($value)</textarea>"
             }
             else {
                 if ($data.Prepend.Enabled -or $data.Append.Enabled) {


### PR DESCRIPTION
### Description of the Change
Add parameter MaxLength to the New-PodeWebTextbox function

### Related Issue
#339 

### Examples
This code:
```ps1
Import-Module "C:\dev\Pode.Web\src\Pode.Web.psd1" -Force

Start-PodeServer {
    # add a simple endpoint
    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http

    # set the use of the pode.web templates
    Use-PodeWebTemplates -Title 'Example' -Theme Dark

    # add the page
    Add-PodeWebPage -Name Processes -Icon Activity -Layouts @(
        New-PodeWebContainer -Content @(

            New-PodeWebTextbox -Name "Default - No limit"

            New-PodeWebTextbox -Name "Limit - 20" -MaxLength 20 
            
            New-PodeWebTextbox -Name "Limit - 40" -Multiline -MaxLength 40
        )
    )
}
```

Creates:

![image](https://user-images.githubusercontent.com/19328074/186519429-9ac043af-e76f-4150-b736-d3d6e7f83f03.png)


### Additional Context
The default limit is set as per https://www.w3schools.com/tags/att_input_maxlength.asp
