### PR TITLE
Fix group names with spaces

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -336,6 +336,17 @@ function Protect-PodeWebName
     return ($Name -ireplace '[^a-z0-9_]', '').Trim()
 }
 
+function Protect-PodeWebSpaces
+{
+    param(
+        [Parameter()]
+        [string]
+        $Value
+    )
+
+    return ($Value -replace '\s', '_')
+}
+
 function Protect-PodeWebValue
 {
     param(
@@ -792,6 +803,9 @@ function Get-PodeWebPagePath
         $Name = $Page.Name
         $Group = $Page.Group
     }
+
+    $Name = Protect-PodeWebSpaces -Value $Name
+    $Group = Protect-PodeWebSpaces -Value $Group
 
     if (![string]::IsNullOrWhiteSpace($Group)) {
         $path += "/groups/$($Group)"

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -143,6 +143,7 @@
                                     if (![string]::IsNullOrWhiteSpace($pageGroup.Name)) {
                                         $chevron = 'right'
                                         $show = [string]::Empty
+                                        $safeGrpName = Protect-PodeWebSpaces -Value $pageGroup.Name
 
                                         if ($data.Page.Group -ieq $pageGroup.Name) {
                                             $chevron = 'down'
@@ -150,7 +151,7 @@
                                         }
 
                                         "<li class='nav-item mTop1 nav-group-title'>
-                                            <a class='nav-link' data-toggle='collapse' href='#nav-$($pageGroup.Name)' aria-expanded='$($data.Page.Group -ieq $pageGroup.Name)' aria-controls='nav-$($pageGroup.Name)'>
+                                            <a class='nav-link' data-toggle='collapse' href='#nav-$($safeGrpName)' aria-expanded='$($data.Page.Group -ieq $pageGroup.Name)' aria-controls='nav-$($safeGrpName)'>
                                                 <div>
                                                     <span class='mdi mdi-chevron-$($chevron) mdi-size-22 mRight02'></span>
                                                     <span class='h6'>$([System.Net.WebUtility]::HtmlEncode($pageGroup.Name))</span>
@@ -159,7 +160,7 @@
                                             </a>
                                         </li>"
 
-                                        "<div class='collapse $($show)' id='nav-$($pageGroup.Name)'>"
+                                        "<div class='collapse $($show)' id='nav-$($safeGrpName)'>"
                                     }
 
                                     foreach ($page in ($pages | Sort-Object -Property { $_.Name })) {


### PR DESCRIPTION
### Description of the Change
Fixes a bug where if the `-Group` value for `Add-PodeWebPage` contained a space, the section wouldn't expand and pages wouldn't load.

This fix keeps the space in place on the page visually, but replaces the space internally with an underscore to preserve HTML `id`'s.

### Related Issue
Resolves #255 
Resolves #323 
