### PR TITLE
Use RequiredModules instead to make sure Pode is loaded

### DIFF
--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -1,5 +1,5 @@
 Import-Module Pode -MaximumVersion 2.99.99 -Force
-Import-Module ..\src\Pode.Web.psm1 -Force
+Import-Module ..\src\Pode.Web.psd1 -Force
 
 Start-PodeServer -StatusPageExceptions Show {
     # add a simple endpoint

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -1,5 +1,5 @@
 Import-Module Pode -MaximumVersion 2.99.99 -Force
-Import-Module ..\src\Pode.Web.psm1 -Force
+Import-Module ..\src\Pode.Web.psd1 -Force
 
 Start-PodeServer {
     # add a simple endpoint

--- a/src/Pode.Web.psd1
+++ b/src/Pode.Web.psd1
@@ -28,6 +28,14 @@
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '5.0'
 
+    RequiredModules = @(
+        @{
+            ModuleName = 'Pode'
+            ModuleVersion = '2.6.0'
+            Guid = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
+        }
+    )
+
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData = @{
         PSData = @{

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -38,11 +38,6 @@ function Use-PodeWebTemplates
         $UseHsts
     )
 
-    $mod = (Get-Module -Name Pode -ErrorAction Ignore | Sort-Object -Property Version -Descending | Select-Object -First 1)
-    if (($null -eq $mod) -or ($mod.Version -lt [version]'2.6.0')) {
-        throw "The Pode module is not loaded. You need at least Pode v2.6.0 to use this version of the Pode.Web module."
-    }
-
     if ([string]::IsNullOrWhiteSpace($FavIcon)) {
         $FavIcon = '/pode.web/images/favicon.ico'
     }


### PR DESCRIPTION
### Description of the Change
Use RequiredModules to make sure Pode is loaded, instead of using custom logic to do the same thing.

### Related Issue
Resolves #333 
