### PR TITLE
ConvertTo-PodeWebPage - add grouping parameters

### DIFF
--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -682,7 +682,7 @@ function Add-PodeWebPageLink
 
 function ConvertTo-PodeWebPage
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'NoGrouping')]
     param(
         [Parameter(ValueFromPipeline=$true)]
         [string[]]
@@ -692,8 +692,17 @@ function ConvertTo-PodeWebPage
         [string]
         $Module,
 
+        [Parameter(ParameterSetName = 'GroupByCustomKey')]
+        [string]
+        $Group,
+
+        [Parameter(ParameterSetName = 'GroupByVerbs')]
         [switch]
         $GroupVerbs,
+
+        [Parameter(ParameterSetName = 'GroupByModuleName')]
+        [switch]
+        $GroupModule,
 
         [Parameter()]
         [Alias('NoAuth')]
@@ -854,11 +863,33 @@ function ConvertTo-PodeWebPage
             New-PodeWebTab -Name $name -Layouts $form
         })
 
-        $group = [string]::Empty
-        if ($GroupVerbs) {
-            $group = $cmdInfo.Verb
-            if ([string]::IsNullOrWhiteSpace($group)) {
-                $group = '_'
+        switch ($PSCmdlet.ParameterSetName) {
+            'NoGrouping' {
+                $group = [string]::Empty
+                break
+            }
+
+            'GroupByVerbs' {
+                $group = [string]::Empty
+                $group = $cmdInfo.Verb
+                if ([string]::IsNullOrWhiteSpace($group)) {
+                    $group = '_'
+                }
+                break
+            }
+
+            'GroupByCustomKey' {
+                $group = $Group -replace "\.",""
+                break
+            }
+
+            'GroupByModuleName' {
+                $group = $cmdInfo.ModuleName -replace "\.",""
+                break
+            }
+
+            default {
+                throw 'Unknown parameter set.'
             }
         }
 


### PR DESCRIPTION
### Description of the Change

* add parameter 'Group' to 'ConvertTo-PodeWebPage' (as it defined in 'Add-PodeWebPage'), allow to group generated pages by passed key.
* add parameter 'GroupModule' to 'ConvertTo-PodeWebPage', allow to group pages by module name.

### Related Issue
no, its enhancement

### Examples
ConvertTo-PodeWebPage -Module 'Custom.ADHelpers' -Group 'AD Tools'
ConvertTo-PodeWebPage -Module 'DBUtils' -GroupModule

### Additional Context
In general, I want to add missing parameter ("group") to 'ConvertTo-PodeWebPage' cmdlet.
