### PR TITLE
Escapes special characters in group/page names

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -336,7 +336,7 @@ function Protect-PodeWebName
     return ($Name -ireplace '[^a-z0-9_]', '').Trim()
 }
 
-function Protect-PodeWebSpaces
+function Protect-PodeWebSpecialCharacters
 {
     param(
         [Parameter()]
@@ -344,7 +344,8 @@ function Protect-PodeWebSpaces
         $Value
     )
 
-    return ($Value -replace '\s', '_')
+    return ($Value -replace "[!`"#\$%&'\(\)*+,\./:;<=>?@\[\\\]^``{\|}~]", '_')
+    # return ($Value -replace '[\s]', '_')
 }
 
 function Protect-PodeWebValue
@@ -804,8 +805,8 @@ function Get-PodeWebPagePath
         $Group = $Page.Group
     }
 
-    $Name = Protect-PodeWebSpaces -Value $Name
-    $Group = Protect-PodeWebSpaces -Value $Group
+    $Name = Protect-PodeWebSpecialCharacters -Value $Name
+    $Group = Protect-PodeWebSpecialCharacters -Value $Group
 
     if (![string]::IsNullOrWhiteSpace($Group)) {
         $path += "/groups/$($Group)"

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -344,8 +344,7 @@ function Protect-PodeWebSpecialCharacters
         $Value
     )
 
-    return ($Value -replace "[!`"#\$%&'\(\)*+,\./:;<=>?@\[\\\]^``{\|}~]", '_')
-    # return ($Value -replace '[\s]', '_')
+    return ($Value -replace "[\s!`"#\$%&'\(\)*+,\./:;<=>?@\[\\\]^``{\|}~]", '_')
 }
 
 function Protect-PodeWebValue

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -143,7 +143,7 @@
                                     if (![string]::IsNullOrWhiteSpace($pageGroup.Name)) {
                                         $chevron = 'right'
                                         $show = [string]::Empty
-                                        $safeGrpName = Protect-PodeWebSpaces -Value $pageGroup.Name
+                                        $safeGrpName = Protect-PodeWebSpecialCharacters -Value $pageGroup.Name
 
                                         if ($data.Page.Group -ieq $pageGroup.Name) {
                                             $chevron = 'down'


### PR DESCRIPTION
### Description of the Change
Allows special characters to be used in group/page names, without breaking JS selectors.

Characters:
```
!"#$%&'()*+,./:;<=>?@[\]^`{|}~
```

### Related Issue
Resolves #369 
