### PR TITLE
Bump dockerfiles to use Pode v2.7.2

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -1,3 +1,7 @@
+param (
+    [string]
+    $Version = ''
+)
 
 $dest_path = './src/Templates/Public'
 $src_path = './pode_modules'
@@ -264,6 +268,35 @@ task MoveLibs {
     Copy-Item -Path "$($src_path)/monaco-editor/min-maps/vs/loader.js.map" -Destination $vs_maps_path -Force
     Copy-Item -Path "$($src_path)/monaco-editor/min-maps/vs/editor/*.*" -Destination "$($vs_maps_path)/editor/" -Force
     Copy-Item -Path "$($src_path)/monaco-editor/min-maps/vs/base/worker/*.*" -Destination "$($vs_maps_path)/base/worker/" -Force
+}
+
+
+<#
+# Pack
+#>
+
+# Synopsis: Package up the Module
+task Pack -If (Test-PodeBuildIsWindows) Build, {
+    if (!$Version) {
+        $Version = (Import-PowerShellDataFile -Path './src/Pode.Web.psd1').ModuleVersion
+    }
+}, DockerPack
+
+# Synopsis: Create docker tags
+task DockerPack {
+    docker build -t badgerati/pode.web:$Version -f ./Dockerfile .
+    docker build -t badgerati/pode.web:latest -f ./Dockerfile .
+    docker build -t badgerati/pode.web:$Version-alpine -f ./alpine.dockerfile .
+    docker build -t badgerati/pode.web:latest-alpine -f ./alpine.dockerfile .
+    docker build -t badgerati/pode.web:$Version-arm32 -f ./arm32.dockerfile .
+    docker build -t badgerati/pode.web:latest-arm32 -f ./arm32.dockerfile .
+
+    docker tag badgerati/pode.web:latest docker.pkg.github.com/badgerati/pode.web/pode.web:latest
+    docker tag badgerati/pode.web:$Version docker.pkg.github.com/badgerati/pode.web/pode.web:$Version
+    docker tag badgerati/pode.web:latest-alpine docker.pkg.github.com/badgerati/pode.web/pode.web:latest-alpine
+    docker tag badgerati/pode.web:$Version-alpine docker.pkg.github.com/badgerati/pode.web/pode.web:$Version-alpine
+    docker tag badgerati/pode.web:latest-arm32 docker.pkg.github.com/badgerati/pode.web/pode.web:latest-arm32
+    docker tag badgerati/pode.web:$Version-arm32 docker.pkg.github.com/badgerati/pode.web/pode.web:$Version-arm32
 }
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,9 @@ jobs:
       run: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         Invoke-Build Build
+
+    - name: Test docker builds
+      shell: pwsh
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-Build DockerPack -Version '0.0.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       shell: pwsh
       run: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Invoke-Build DockerPack -Version '0.0.0'
+        Invoke-Build DockerPack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.6.2
+FROM badgerati/pode:2.7.2
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.6.2-alpine
+FROM badgerati/pode:2.7.2-alpine
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.6.2-arm32
+FROM badgerati/pode:2.7.2-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -34,7 +34,7 @@ Install-Module -Name Pode.Web
 [![Docker](https://img.shields.io/docker/stars/badgerati/pode.web.svg?label=Stars)](https://hub.docker.com/r/badgerati/pode.web/)
 [![Docker](https://img.shields.io/docker/pulls/badgerati/pode.web.svg?label=Pulls)](https://hub.docker.com/r/badgerati/pode.web/)
 
-Like Pode, Pode.Web also has Docker images available. The images use Pode v2.6.2 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
+Like Pode, Pode.Web also has Docker images available. The images use Pode v2.7.2 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
 
 * To pull down the latest Pode.Web image you can do:
 

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -2,7 +2,7 @@
 
 Pode.Web has a Docker image that you can use to host your server, for instructions on pulling these images you can [look here](../../Getting-Started/Installation).
 
-The images use Pode v2.6.2 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
+The images use Pode v2.7.2 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
 
 ## Images
 
@@ -11,7 +11,7 @@ The images use Pode v2.6.2 on either an Ubuntu Focal (default), Alpine, or ARM32
 
 ### Default
 
-The default Pode.Web image is an Ubuntu Focal image with Pode v2.6.2 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
+The default Pode.Web image is an Ubuntu Focal image with Pode v2.7.2 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image


### PR DESCRIPTION
### Description of the Change
Bumps the dockerfiles to use Pode v2.7.2.

### Related Issue
Resolves #350 
