### PR TITLE
Add DisplayName for tables/charts, and use the Title in the sidebar for pages

### DIFF
--- a/examples/language.ps1
+++ b/examples/language.ps1
@@ -1,0 +1,137 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psd1 -Force
+
+Start-PodeServer -StatusPageExceptions Show {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+
+    # set the use of templates
+    Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web/images/icon.png' -Theme Dark
+
+    $chartData = {
+        $count = 1
+        if ($WebEvent.Data.FirstLoad -eq '1') {
+            $count = 4
+        }
+
+        return (1..$count | ForEach-Object {
+            @{
+                Key = $_
+                Values = @(
+                    @{
+                        Key = 'Example1'
+                        Value = (Get-Random -Maximum 10)
+                    },
+                    @{
+                        Key = 'Example2'
+                        Value = (Get-Random -Maximum 10)
+                    }
+                )
+            }
+        })
+    }
+
+    $processData = {
+        Get-Process |
+            Sort-Object -Property CPU -Descending |
+            Select-Object -First 10 |
+            ConvertTo-PodeWebChartData -LabelProperty ProcessName -DatasetProperty CPU, Handles
+    }
+
+    $grid1 = New-PodeWebGrid -Cells @(
+        New-PodeWebCell -Content @(
+            New-PodeWebChart -Name 'Line Example 1' -DisplayName '行の例' -Type Line -ScriptBlock $chartData -Append -TimeLabels -MaxItems 15 -AutoRefresh -AsCard
+        )
+        New-PodeWebCell -Content @(
+            New-PodeWebChart -Name 'Top Processes' -DisplayName 'トッププロセス' -Type Bar -ScriptBlock $processData -AutoRefresh -RefreshInterval 10 -AsCard
+        )
+        New-PodeWebCell -Content @(
+            New-PodeWebCounterChart -DisplayName 'プロセッサ時間' -Counter '\Processor(_Total)\% Processor Time' -MinY 0 -MaxY 100 -AsCard
+        )
+    )
+
+    Set-PodeWebHomePage -Layouts $grid1 -Title '家'
+
+
+    # add a page to search and filter services (output in a new table element) [note: requires auth]
+    $editModal = New-PodeWebModal -Name 'Edit Service' -Icon 'square-edit-outline' -Id 'modal_edit_svc' -AsForm -Content @(
+        New-PodeWebAlert -Type Info -Value 'This does nothing, it is just an example'
+        New-PodeWebCheckbox -Name Running -Id 'chk_svc_running' -AsSwitch
+    ) -ScriptBlock {
+        $WebEvent.Data | Out-Default
+        Hide-PodeWebModal
+    }
+
+    $helpModal = New-PodeWebModal -Name 'Help' -Icon 'help' -Content @(
+        New-PodeWebText -Value 'HELP!'
+    )
+
+    $table = New-PodeWebTable -Name 'Services' -DisplayName 'サービス' -DataColumn Name -AsCard -Filter -SimpleSort -Click -Paginate -ScriptBlock {
+        $stopBtn = New-PodeWebButton -Name 'Stop' -Icon 'stop-circle-outline' -IconOnly -ScriptBlock {
+            Stop-Service -Name $WebEvent.Data.Value -Force | Out-Null
+            Show-PodeWebToast -Message "$($WebEvent.Data.Value) stopped"
+            Sync-PodeWebTable -Id $ElementData.Parent.ID
+        }
+
+        $startBtn = New-PodeWebButton -Name 'Start' -Icon 'play-circle-outline' -IconOnly -ScriptBlock {
+            Start-Service -Name $WebEvent.Data.Value | Out-Null
+            Show-PodeWebToast -Message "$($WebEvent.Data.Value) started"
+            Sync-PodeWebTable -Id $ElementData.Parent.ID
+        }
+
+        $editBtn = New-PodeWebButton -Name 'Edit' -Icon 'square-edit-outline' -IconOnly -ScriptBlock {
+            $svc = Get-Service -Name $WebEvent.Data.Value
+            $checked = ($svc.Status -ieq 'running')
+
+            Show-PodeWebModal -Id 'modal_edit_svc' -DataValue $WebEvent.Data.Value -Actions @(
+                Update-PodeWebCheckbox -Id 'chk_svc_running' -Checked:$checked
+            )
+        }
+
+        $filter = "*$($WebEvent.Data.Filter)*"
+
+        foreach ($svc in (Get-Service)) {
+            if ($svc.Name -inotlike $filter) {
+                continue
+            }
+
+            $btns = @($editBtn)
+            if ($svc.Status -ieq 'running') {
+                $btns += $stopBtn
+            }
+            else {
+                $btns += $startBtn
+            }
+
+            [ordered]@{
+                Name = $svc.Name
+                Status = "$($svc.Status)"
+                Actions = $btns
+            }
+        }
+    }
+
+    Add-PodeWebPage -Name Services -Title 'サービス' -Icon 'cogs' -Group Tools -Layouts $editModal, $helpModal, $table -ScriptBlock {
+        $name = $WebEvent.Query['value']
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            return
+        }
+
+        $svc = Get-Service -Name $name | Out-String
+
+        New-PodeWebCard -Name "$($name) Details" -Content @(
+            New-PodeWebCodeBlock -Value $svc -NoHighlight
+        )
+    } `
+    -HelpScriptBlock {
+        Show-PodeWebModal -Name 'Help'
+    }
+
+
+    # open twitter
+    Add-PodeWebPageLink -Name Twitter -Title 'Tweet' -Icon Twitter -Group Social -ScriptBlock {
+        Move-PodeWebUrl -Url 'https://twitter.com' -NewTab
+    }
+}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -302,6 +302,16 @@ function Get-PodeWebState
     return (Get-PodeState -Name "pode.web.$($Name)")
 }
 
+function Get-PodeWebHomeName
+{
+    $name = (Get-PodeWebState -Name 'pages')['/'].Title
+    if ([string]::IsNullOrWhiteSpace($name)) {
+        return 'Home'
+    }
+
+    return $name
+}
+
 function Get-PodeWebCookie
 {
     param(

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1883,6 +1883,10 @@ function New-PodeWebChart
 
         [Parameter()]
         [string]
+        $DisplayName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter()]
@@ -1993,6 +1997,7 @@ function New-PodeWebChart
         ObjectType = 'Chart'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = $Id
         Message = $Message
         ChartType = $Type
@@ -2050,7 +2055,7 @@ function New-PodeWebChart
     }
 
     if ($AsCard) {
-        $element = New-PodeWebCard -Name $Name -Content $element
+        $element = New-PodeWebCard -Name $Name -DisplayName $DisplayName -Content $element
     }
 
     return $element
@@ -2067,6 +2072,10 @@ function New-PodeWebCounterChart
         [Parameter()]
         [string]
         $Name,
+
+        [Parameter()]
+        [string]
+        $DisplayName,
 
         [Parameter()]
         [string[]]
@@ -2122,6 +2131,7 @@ function New-PodeWebCounterChart
 
     New-PodeWebChart `
         -Name $Name `
+        -DisplayName $DisplayName `
         -Type Line `
         -MaxItems $MaxItems `
         -ArgumentList $Counter `
@@ -2153,6 +2163,10 @@ function New-PodeWebTable
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
+
+        [Parameter()]
+        [string]
+        $DisplayName,
 
         [Parameter()]
         [string]
@@ -2267,6 +2281,7 @@ function New-PodeWebTable
         ObjectType = 'Table'
         Parent = $ElementData
         Name = $Name
+        DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = $Id
         DataColumn = $DataColumn
         Columns = $Columns
@@ -2366,7 +2381,7 @@ function New-PodeWebTable
     }
 
     if ($AsCard) {
-        $element = New-PodeWebCard -Name $Name -Content $element
+        $element = New-PodeWebCard -Name $Name -DisplayName $DisplayName -Content $element
     }
 
     return $element

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -173,6 +173,7 @@ function Set-PodeWebLoginPage
         Write-PodeWebViewResponse -Path 'index' -Data @{
             Page = @{
                 Name = 'Home'
+                Title = 'Home'
                 Path = '/'
                 IsSystem = $true
             }
@@ -578,6 +579,10 @@ function Add-PodeWebPageLink
 
         [Parameter()]
         [string]
+        $Title,
+
+        [Parameter()]
+        [string]
         $Group,
 
         [Parameter()]
@@ -627,11 +632,17 @@ function Add-PodeWebPageLink
         throw "Web page/link already exists: $($Name) [Group: $($Group)]"
     }
 
+    # set page title
+    if ([string]::IsNullOrWhiteSpace($Title)) {
+        $Title = $Name
+    }
+
     # setup page meta
     $pageMeta = @{
         ComponentType = 'Page'
         ObjectType = 'Link'
         Name = $Name
+        Title = [System.Net.WebUtility]::HtmlEncode($Title)
         NewTab = $NewTab.IsPresent
         Icon = $Icon
         Group = $Group

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -83,6 +83,7 @@ function Use-PodeWebTemplates
             Page = @{
                 Name = 'Home'
                 Path = '/'
+                TItle = 'Home'
                 IsSystem = $true
             }
         }

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -1,6 +1,6 @@
 <html>
     $(Use-PodeWebPartialView -Path 'shared/head' -Data @{
-        Title = $data.Page.Name
+        Title = $data.Page.Title
         Theme = $data.Theme
         AppPath = $data.AppPath
     })
@@ -119,7 +119,7 @@
                                 <a class="nav-link $(if ($data.Page.Name -ieq 'home') { 'active' })" href="$($data.AppPath)/">
                                     <div>
                                         <span class="mdi mdi-home mdi-size-22 mRight02"></span>
-                                        Home
+                                        $(Get-PodeWebHomeName)
                                     </div>
                                 </a>
                             </li>
@@ -182,7 +182,7 @@
                                             <a class='nav-link $($activePage)' name='$($page.Name)' pode-page-group='$($pageGroup.Name)' pode-page-type='$($page.ObjectType)' pode-dynamic='$($page.IsDynamic)' $($href)>
                                                 <div>
                                                     <span class='mdi mdi-$($page.Icon.ToLowerInvariant()) mdi-size-22 mRight02'></span>
-                                                    $([System.Net.WebUtility]::HtmlEncode($page.Name))
+                                                    $([System.Net.WebUtility]::HtmlEncode($page.Title))
                                                 </div>
                                             </a>
                                         </li>"


### PR DESCRIPTION
### Description of the Change
Charts and Tables now have an added `-DisplayName` parameter, which will be used when `-AsCard` is also used.

Page names in the sidebar will now display the `-Title` of the page, rather than the `-Name` so different languages can be used. The Home page now also has a `-Title` parameter, as well as PageLinks. Also, the title of tabs in the browser will now use the `-Title`  as well.

### Related Issue
Resolves #361 
