### PR TITLE
FixDecoding

### DIFF
--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1577,7 +1577,7 @@ function bindFormSubmits() {
         // show the spinner
         showSpinner(form);
         $('.alert').remove();
-    
+
         // remove validation errors
         removeValidationErrors(form);
     });
@@ -2863,7 +2863,7 @@ function updateButton(action) {
             setTitle(btn, action.DisplayName);
         }
         else {
-            btn.find('span.pode-text').text(action.DisplayName);
+            btn.find('span.pode-text').text(decodeHTML(action.DisplayName));
         }
     }
 
@@ -3019,7 +3019,7 @@ function actionValidation(action, sender) {
     }
 
     var validationId = `div#${$(input).attr('id')}_validation`;
-    $(validationId).text(action.Message);
+    $(validationId).text(decodeHTML(action.Message));
 
     setValidationError(input);
 }

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -182,7 +182,7 @@
                                             <a class='nav-link $($activePage)' name='$($page.Name)' pode-page-group='$($pageGroup.Name)' pode-page-type='$($page.ObjectType)' pode-dynamic='$($page.IsDynamic)' $($href)>
                                                 <div>
                                                     <span class='mdi mdi-$($page.Icon.ToLowerInvariant()) mdi-size-22 mRight02'></span>
-                                                    $([System.Net.WebUtility]::HtmlEncode($page.DisplayName))
+                                                    $($page.DisplayName)
                                                 </div>
                                             </a>
                                         </li>"


### PR DESCRIPTION
Resolve https://github.com/Badgerati/Pode.Web/issues/384

1. Pages display name where encoded in "Pages.ps1" and again in "index.pode". I remove the "index.pode"
2. Buttons and validation display name are encoded in "Elements.ps1" and "default.js". I added a `decodeHTML` between the encodings as in the other elements there.