### PR TITLE
TextBoxNoFormWidth

### DIFF
--- a/src/Templates/Views/elements/textbox.pode
+++ b/src/Templates/Views/elements/textbox.pode
@@ -1,10 +1,7 @@
 $(
     $controlDivClass = 'form-group row'
-    if ($data.DynamicLabel) {
+    if ($data.NoForm -or $data.DynamicLabel) {
         $controlDivClass = [string]::Empty
-    }
-    if ($data.NoForm) {
-        $controlDivClass = 'no-form'
     }
 
     "<div class='$($controlDivClass) pode-form-textbox $($data.CssClasses)'>"
@@ -13,7 +10,7 @@ $(
     $(if (!$data.NoForm -and !$data.DynamicLabel) {
         "<label for='$($data.ID)' class='col-sm-2 col-form-label'>$($data.DisplayName)</label>"
     })
-    <div class="$(if (!$data.DynamicLabel) { 'col-sm-10' })">
+    <div class="$(if (!$data.NoForm -and !$data.DynamicLabel) { 'col-sm-10' })">
         $(
             $element = [string]::Empty
 


### PR DESCRIPTION
Fix Output with `New-PodeWebTextbox -NoForm` part of https://github.com/Badgerati/Pode.Web/issues/390
Now it is possible to create wide `New-PodeWebTextbox -NoForm`

Before
![image](https://user-images.githubusercontent.com/6960531/209738255-1325630c-593f-4e99-8748-f0135d07e70a.png)
After
![image](https://user-images.githubusercontent.com/6960531/209738260-68e6d8a4-2ca5-46e5-8560-340678911643.png)

```powershell
    Add-PodeWebPage -Name Services -DisplayName 'Test' -Icon 'cogs' -ScriptBlock {
        New-PodeWebTextbox -Name 'Name1' -Multiline -DynamicLabel
        New-PodeWebTextbox -Name 'Name2' -Multiline -NoForm
        New-PodeWebTextbox -Name 'Name1' -Multiline -DynamicLabel -Width 50
        New-PodeWebTextbox -Name 'Name2' -Multiline -NoForm -Width 50
        New-PodeWebForm -Name 'Search' -Content @(
            New-PodeWebTextbox -Name 'Name'
        ) -ScriptBlock {
            Start-Sleep 3
            Out-PodeWebValidation -Name 'Name' -Message 'Username m"ust be 4+ chars'
        }
        New-PodeWebButton -Name 'Search' -Icon 'magnify' -ScriptBlock {
            Out-PodeWebTextbox -Value ''
        }
    }
```