### PR TITLE
Fix Update-PodeWebTextbox to work with date types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/[Ff]unctions/
 examples/state.json
 examples/docs.ps1
 examples/issue-*
+examples/issues/
 pkg/
 yarn.lock
 min-maps/

--- a/src/Public/Outputs.ps1
+++ b/src/Public/Outputs.ps1
@@ -530,7 +530,7 @@ function Out-PodeWebTextbox
 
     end {
         if (!$AsJson) {
-            $items = ($items | Out-String)
+            $items = ($items | Out-String -NoNewline)
         }
 
         if ($Size -le 0) {
@@ -585,7 +585,7 @@ function Update-PodeWebTextbox
 
     end {
         if (!$AsJson) {
-            $items = ($items | Out-String)
+            $items = ($items | Out-String -NoNewline)
         }
 
         return @{


### PR DESCRIPTION
### Description of the Change
Fixes a new-line issue prevents `Update-PodeWebTextbox` from working with Date input types.

### Related Issue
Resolves #413 

### Examples
```powershell
Update-PodeWebTextbox -Name 'Date1' -Value '2023-02-08'
```
