### PR TITLE
Fix pressing enter key in textarea in modal

### DIFF
--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1599,7 +1599,7 @@ function bindFormResets() {
 
 function bindModalSubmits() {
     $("div.modal-content form.pode-form").off('keypress').on('keypress', function(e) {
-        if (!isEnterKey(e)) {
+        if (!isEnterKey(e) || testTagName(e.target, 'textarea')) {
             return;
         }
 


### PR DESCRIPTION
### Description of the Change
Fixes an issue where pressing the enter key in a multline text input, in a modal, submitted the modal.

### Related Issue
Resolves #380 
