### PR TITLE
Bump pode to 2.8.0 in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.7.2
+FROM badgerati/pode:2.8.0
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.7.2-alpine
+FROM badgerati/pode:2.8.0-alpine
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.7.2-arm32
+FROM badgerati/pode:2.8.0-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -34,7 +34,7 @@ Install-Module -Name Pode.Web
 [![Docker](https://img.shields.io/docker/stars/badgerati/pode.web.svg?label=Stars)](https://hub.docker.com/r/badgerati/pode.web/)
 [![Docker](https://img.shields.io/docker/pulls/badgerati/pode.web.svg?label=Pulls)](https://hub.docker.com/r/badgerati/pode.web/)
 
-Like Pode, Pode.Web also has Docker images available. The images use Pode v2.7.2 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
+Like Pode, Pode.Web also has Docker images available. The images use Pode v2.8.0 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
 
 * To pull down the latest Pode.Web image you can do:
 

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -2,7 +2,7 @@
 
 Pode.Web has a Docker image that you can use to host your server, for instructions on pulling these images you can [look here](../../Getting-Started/Installation).
 
-The images use Pode v2.7.2 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
+The images use Pode v2.8.0 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
 
 ## Images
 
@@ -11,7 +11,7 @@ The images use Pode v2.7.2 on either an Ubuntu Focal (default), Alpine, or ARM32
 
 ### Default
 
-The default Pode.Web image is an Ubuntu Focal image with Pode v2.7.2 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
+The default Pode.Web image is an Ubuntu Focal image with Pode v2.8.0 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image


### PR DESCRIPTION
### Description of the Change
Bump Pode to v2.8.0 in the Dockerfiles.

### Related Issue
Resolves #418 