### PR TITLE
Temp fix for showing the back button

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,7 @@
 * #392: Fixes `New-PodeWebTextbox` with `-NoForm` to we can create wider textboxes (thanks @ili101!)
 * #413: Fixes `Update-PodeWebTextbox` to work with Date types
 * #423: Fixes line charts back to being curved lines and filled areas
+* #430: Temporary fix for showing the back button pages when there is no query string
 
 ### Packaging
 * #378: Bumps highlightjs to 11.7.0

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -477,6 +477,9 @@ function Add-PodeWebPage
 
         if (!$global:PageData.NoBackArrow) {
             $global:PageData.ShowBack = (($null -ne $WebEvent.Query) -and ($WebEvent.Query.Count -gt 0))
+            if ($global:PageData.ShowBack -and ($WebEvent.Query.Count -eq 1) -and ($WebEvent.Query.ContainsKey(''))) {
+                $global:PageData.ShowBack = $false
+            }
         }
         else {
             $global:PageData.ShowBack = $false


### PR DESCRIPTION
### Description of the Change
Temporary fix for the back button on pages, to not show when there is no query string

### Related Issue
Resolves #430 
