### PR TITLE
Add Update-PodeWebRaw support

### DIFF
--- a/docs/Tutorials/Actions/Raw.md
+++ b/docs/Tutorials/Actions/Raw.md
@@ -1,0 +1,18 @@
+# Raw
+
+This page details the actions available to Raw elements.
+
+## Update
+
+To update the value of a Raw element, you can use [`Update-PodeWebRaw`](../../../Functions/Actions/Update-PodeWebRaw):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebRaw -Name 'ExampleRaw' -Value '<h1>Initial Value</h1>'
+
+    New-PodeWebTimer -Interval 10 -ScriptBlock {
+        $size = Get-Random -Minimum 1 -Maximum 7
+        Update-PodeWebRaw -Name 'ExampleRaw' -Value "<h$($size)>Random Size</h$($size)>"
+    }
+)
+```

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -65,6 +65,7 @@ Start-PodeServer -StatusPageExceptions Show {
         $colour = (@('Green', 'Yellow', 'Cyan'))[$rand]
         Update-PodeWebBadge -Id 'bdg_test' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')) -Colour $colour
         Update-PodeWebText -Id 'code_test' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss'))
+        Update-PodeWebText -Id 'link_test' -Value "link$(Get-Random -Minimum 1 -Maximum 99)"
     }
 
     # set the home page controls (just a simple paragraph) [note: homepage does not require auth in this example]
@@ -81,7 +82,7 @@ Start-PodeServer -StatusPageExceptions Show {
         )
         New-PodeWebParagraph -Content @(
             New-PodeWebText -Value "Look, here's a "
-            New-PodeWebLink -Source 'https://github.com/badgerati/pode' -Value 'link' -NewTab
+            New-PodeWebLink -Id 'link_test' -Source 'https://github.com/badgerati/pode' -Value 'link' -NewTab
             New-PodeWebText -Value "! "
             New-PodeWebBadge -Id 'bdg_test' -Value 'Sweet!' -Colour Cyan |
                 Register-PodeWebEvent -Type Click -NoAuth -ScriptBlock {

--- a/examples/raw.ps1
+++ b/examples/raw.ps1
@@ -1,0 +1,22 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+Start-PodeServer {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Raw' -Theme Dark
+
+    # set the home page controls (just a simple paragraph)
+    $card = New-PodeWebCard -Content @(
+        New-PodeWebRaw -Name 'ExampleRaw' -Value '<h1>Initial Value</h1>'
+        New-PodeWebTimer -Interval 10 -ScriptBlock {
+            $size = Get-Random -Minimum 1 -Maximum 7
+            Update-PodeWebRaw -Name 'ExampleRaw' -Value "<h$($size)>Random Size</h$($size)>"
+        }
+    )
+
+    Set-PodeWebHomePage -Content $card -Title 'Update Raw'
+}

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -2003,3 +2003,29 @@ function Out-PodeWebElement
 
     return $Element
 }
+
+function Update-PodeWebRaw
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [string]
+        $Value
+    )
+
+    return @{
+        Operation = 'Update'
+        ObjectType = 'Raw'
+        ID = $Id
+        Name = $Name
+        Value = $Value
+    }
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1452,15 +1452,27 @@ function New-PodeWebRaw
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
         $Value
     )
+
+    $Id = Get-PodeWebElementId -Tag Raw -Id $Id
 
     return @{
         ComponentType = 'Element'
         ObjectType = 'Raw'
         Parent = $ElementData
+        ID = $Id
+        Name = $Name
         Value = $Value
         NoEvents = $true
     }

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -3225,10 +3225,16 @@ class PodeRaw extends PodeContentElement {
 
     new(data, sender, opts) {
         return `<span
+            id='${this.id}'
+            name='${this.name}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
             ${data.Value}
         </span>`;
+    }
+
+    update(data, sender, opts) {
+        this.element.html(data.Value);
     }
 }
 PodeElementFactory.setClass(PodeRaw);
@@ -3244,6 +3250,7 @@ class PodeTimer extends PodeContentElement {
     new(data, sender, opts) {
         return `<span
             id="${this.id}"
+            name='${this.name}'
             class="hide pode-timer ${this.css.classes}"
             style="${this.css.styles}"
             pode-object="${this.getType()}"


### PR DESCRIPTION
### Description of the Change
Adds a new `Update-PodeWebRaw` action, so you can update the content of of a `New-PodeWebRaw` element. The latter function has also add optional `-Id` and `-Name` parameters added, so the update action knows where to find the Raw element.

### Related Issue
Resolves #394 

### Examples
```powershell
New-PodeWebContainer -NoBackground -Content @(
    New-PodeWebRaw -Name 'ExampleRaw' -Value '<h1>Initial Value</h1>'

    New-PodeWebTimer -Interval 10 -ScriptBlock {
        $size = Get-Random -Minimum 1 -Maximum 7
        Update-PodeWebRaw -Name 'ExampleRaw' -Value "<h$($size)>Random Size</h$($size)>"
    }
)
```