### PR TITLE
Add support for initial Date/Time values on the DateTime element

### DIFF
--- a/docs/Tutorials/Elements/DateTime.md
+++ b/docs/Tutorials/Elements/DateTime.md
@@ -39,3 +39,10 @@ New-PodeWebDateTime -Name 'Example' -Type Time
 ## Display Name
 
 By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.
+
+## Initial Value
+
+You can create the DateTime element with initial values by using the `-DateValue` and/or `-TimeValue` parameters. When setting these values the formats should be as follows:
+
+* `-DateValue 'yyyy-mm-dd'`
+* `-TimeValue 'hh:mm'`

--- a/docs/Tutorials/Elements/Textbox.md
+++ b/docs/Tutorials/Elements/Textbox.md
@@ -81,3 +81,10 @@ By default the label displays the `-Name` of the element. You can change the val
 The `-Width` of a textbox has the default unit of `%`. If `0` is specified then `auto` is used instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.
 
 The `-Height` of the textbox is how many lines are displayed when the textbox is multilined.
+
+## Initial Value
+
+You can create the Textbox with an initial value by using the `-Value` parameter. When using this parameter for a Textbox of type Date or Time the formats should be as follows:
+
+* Date: `-Value 'yyyy-mm-dd'`
+* Time: `-Value 'hh:mm'`

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -28,7 +28,7 @@ Start-PodeServer {
         New-PodeWebTextbox -Name 'Password' -Type Password -PrependIcon Lock
         New-PodeWebTextbox -Name 'Date' -Type Date
         New-PodeWebTextbox -Name 'Time' -Type Time
-        New-PodeWebDateTime -Name 'DateTime'
+        New-PodeWebDateTime -Name 'DateTime' -DateValue '2023-12-23' -TimeValue '13:37'
         New-PodeWebCredential -Name 'Credentials'
         New-PodeWebMinMax -Name 'CPU' -AppendIcon 'percent' -ReadOnly
         New-PodeWebCheckbox -Name 'Switches' -Options @('Terms', 'Privacy') -AsSwitch

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1310,6 +1310,14 @@ function New-PodeWebDateTime
         [string[]]
         $Type = @('Date', 'Time'),
 
+        [Parameter()]
+        [string]
+        $DateValue,
+
+        [Parameter()]
+        [string]
+        $TimeValue,
+
         [switch]
         $ReadOnly,
 
@@ -1336,6 +1344,10 @@ function New-PodeWebDateTime
         }
         Type = @($Type)
         Required = $Required.IsPresent
+        Values = @{
+            Date = (Protect-PodeWebValue -Value $DateValue -Default '' -Encode)
+            Time = (Protect-PodeWebValue -Value $TimeValue -Default '' -Encode)
+        }
     }
 }
 

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -4693,7 +4693,8 @@ class PodeDateTime extends PodeFormMultiElement {
                 ReadOnly: this.readonly,
                 Required: this.required,
                 DynamicLabel: true,
-                DisplayName: data.Placeholders.Date
+                DisplayName: data.Placeholders.Date,
+                Value: data.Values.Date
             }, {
                 help: { enabled: true, id: this.id }
             }));
@@ -4707,7 +4708,8 @@ class PodeDateTime extends PodeFormMultiElement {
                 ReadOnly: this.readonly,
                 Required: this.required,
                 DynamicLabel: true,
-                DisplayName: data.Placeholders.Time
+                DisplayName: data.Placeholders.Time,
+                Value: data.Values.Time
             }, {
                 help: { enabled: true, id: this.id }
             }));


### PR DESCRIPTION
### Description of the Change
Add support for initial Date/Time values on the DateTime element via two new `-DateValue` and `-TimeValue` parameters on `New-PodeWebDateTime`.

### Related Issue
Resolves #364 

### Examples
```powershell
New-PodeWebDateTime -Name 'DateTime' -DateValue '2023-12-23' -TimeValue '13:37'
```
