### PR TITLE
Add -ScriptBlock and -Icon support for Home pages, plus -NoNavigation support for all Pages

### DIFF
--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -103,14 +103,24 @@ Set-PodeWebHomePage -Content @(
 )
 ```
 
-If you want to hide the title on the home page, you can pass `-NoTitle`.
+or, you can do this dynamically by supplying `-ScriptBlock` instead:
+
+```powershell
+Set-PodeWebHomePage -ScriptBlock {
+    New-PodeWebHero -Title 'Welcome!' -Message 'This is the home page' -Content @(
+        New-PodeWebText -Value 'Here is some text!' -InParagraph -Alignment Center
+    )
+}
+```
+
+If you want to hide the title on the home page, you can pass `-NoTitle`. You can also change the home page icon via `-Icon`.
 
 ## Webpage
 
 By adding a page to your site, Pode.Web will add a link to it on your site's sidebar navigation. You can also group pages together so you can collapse groups of them. To add a page to your site you use [`Add-PodeWebPage`](../../Functions/Pages/Add-PodeWebPage), and you can give your page a `-Name` and an `-Icon` to display on the sidebar. Pages can either be [static](#static) or [dynamic](#dynamic).
 
 !!! note
-    The `-Icon` is the name of a [Material Design Icon](https://materialdesignicons.com), a list of which can be found on their [website](https://pictogrammers.github.io/@mdi/font/5.4.55/). When supplyig the name, just supply the part after `mdi-`. For example, `mdi-github` should be `-Icon 'github'`.
+    The `-Icon` is the name of a [Material Design Icon](https://materialdesignicons.com), a list of which can be found on their [website](https://pictogrammers.github.io/@mdi/font/5.4.55/). When supplying the name, just supply the part after `mdi-`. For example, `mdi-github` should be `-Icon 'github'`.
 
 For example, to add a simple Charts page to your site, to show a Windows counter:
 
@@ -271,7 +281,10 @@ Add-PodeWebPage -Name Charts -Hide -Content @(
 )
 ```
 
-Alternatively, you can also hide the sidebar on a page by using the `-NoSidebar` switch; useful for dashboard pages:
+
+## Hide Navigations
+
+You can hide the sidebar on a page (home or webpage) by using the `-NoSidebar` switch; useful for dashboard pages:
 
 ```powershell
 Add-PodeWebPage -Name Charts -NoSidebar -Content @(
@@ -280,6 +293,8 @@ Add-PodeWebPage -Name Charts -NoSidebar -Content @(
     )
 )
 ```
+
+Conversely, you can also hide the top navigation bar by using the `-NoNavigation` switch as well.
 
 ## Convert Module
 

--- a/examples/dynamic-pages.ps1
+++ b/examples/dynamic-pages.ps1
@@ -10,11 +10,12 @@ Start-PodeServer {
     Use-PodeWebTemplates -Title 'Dynamic Pages' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
-    $section = New-PodeWebCard -Name 'Welcome' -NoTitle -Content @(
-        New-PodeWebParagraph -Value 'This is an example homepage, with some example text'
-        New-PodeWebParagraph -Value 'Using some example paragraphs'
-    )
-    Set-PodeWebHomePage -Content $section -Title 'Awesome Homepage'
+    Set-PodeWebHomePage -Title 'Awesome Homepage' -Icon 'cat' -ScriptBlock {
+        New-PodeWebCard -Name 'Welcome' -NoTitle -Content @(
+            New-PodeWebParagraph -Value 'This is an example homepage, with some example text'
+            New-PodeWebParagraph -Value 'Using some example paragraphs'
+        )
+    }
 
     Add-PodeWebPage -Name Example -ArgumentList 'Title', 'BodyText' -ScriptBlock {
         param($title, $text)

--- a/examples/processes.ps1
+++ b/examples/processes.ps1
@@ -4,6 +4,7 @@ Import-Module ..\src\Pode.Web.psm1 -Force
 Start-PodeServer {
     # endpoint
     Add-PodeEndpoint -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # login/auth
     Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
@@ -46,7 +47,7 @@ Start-PodeServer {
         New-PodeWebTextbox -Name 'Name'
     )
 
-    Add-PodeWebPage -Name Processes2 -Icon 'chart-box-outline' -Content $form2
+    Add-PodeWebPage -Name Processes2 -Icon 'chart-box-outline' -Content $form2 -NoNavigation
 
     # processes - show top "x" processes
     $form3 = New-PodeWebForm -Name 'TopX' -AsCard -ScriptBlock {

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -312,6 +312,16 @@ function Get-PodeWebHomeName
     return $name
 }
 
+function Get-PodeWebHomeIcon
+{
+    $icon = (Get-PodeWebState -Name 'pages')['/'].Icon
+    if ([string]::IsNullOrWhiteSpace($icon)) {
+        return 'home'
+    }
+
+    return $icon
+}
+
 function Get-PodeWebCookie
 {
     param(

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -77,6 +77,7 @@ function Use-PodeWebTemplates
         $page = Get-PodeWebFirstPublicPage
         if ($null -ne $page) {
             Move-PodeResponseUrl -Url (Get-PodeWebPagePath -Page $page)
+            return
         }
 
         Write-PodeWebViewResponse -Path 'index' -Data @{

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -363,7 +363,7 @@ div#pode-nav {
     margin-left: 1em;
 }
 
-div#pode-page-title {
+#pode-page-title.nav-padding {
     margin-top: 4em;
 }
 
@@ -680,7 +680,7 @@ div.no-form {
     bottom: 0;
     left: 0;
     z-index: 100;
-    padding: 48px 0 0;
+    padding: 0 0 0;
     box-shadow: inset -1px 0 0 rgba(0, 0, 0, .2);
 }
 
@@ -715,6 +715,10 @@ div.no-form {
 .sidebar-heading {
     font-size: .75rem;
     text-transform: uppercase;
+}
+
+.sidebar.nav-padding {
+    padding-top: 48px;
 }
 
 .nav-item.nav-page-item a.nav-link:hover > div {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -6,78 +6,14 @@
     })
 
     <body id="normal-page" pode-theme="$($data.Theme)" pode-app-path="$($data.AppPath)" $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
-        <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow navbar-expand-lg">
-            <button type='button' class='btn btn-icon-only' id='menu-toggle'>
-                <span class='mdi mdi-menu-open'></span>
-            </button>
-
-            <a class="navbar-brand col-md-3 col-lg-2 mr-0 px-3" href="$($data.AppPath)/">
-                $(
-                    $title = Get-PodeWebState -Name 'title'
-                    $logo = Get-PodeWebState -Name 'logo'
-
-                    if (![string]::IsNullOrWhiteSpace($logo)) {
-                        "<img src='$($logo)' width='30' height='30' class='d-inline-block align-top' alt='$($title)' loading='lazy'>"
-                    }
-
-                    $title
-                )
-            </a>
-
-            <button class="navbar-toggler position-absolute d-md-none collapsed" type="button" data-toggle="collapse" data-target="#sidebarMenu" aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-
-            <div id='pode-nav'>
-                <div id='pode-nav-social'>
-                    $(
-                        $socials = Get-PodeWebState -Name 'social'
-                        foreach ($key in $socials.Keys) {
-                            $social = $socials[$key]
-
-                            "<a href='$($social.Url.ToLowerInvariant())' target='_blank' title='$($social.Tooltip)' data-toggle='tooltip'>
-                                <span class='mdi mdi-$($key.ToLowerInvariant())'></span>
-                            </a>"
-                        }
-                    )
-                </div>
-
-                <div id='pode-nav-items'>
-                    <ul class="navbar-nav mr-auto">
-                    </ul>
-                </div>
-            </div>
-
-            $(if ($data.Auth.Enabled) {
-                if ($data.Auth.Authenticated) {
-                    "<form class='form-inline' action='$($data.AppPath)/logout' method='POST' style='margin-bottom: 0'>
-                        <span class='navbar-text mRight1 welcome-msg'>"
-                            if (![string]::IsNullOrWhiteSpace($data.Auth.Avatar)) {
-                                "<img id='avatar' src='$($data.Auth.Avatar)'>"
-                            }
-                            else {
-                                "<span id='avatar' class='mdi mdi-account'></span>"
-                            }
-                            "Hello, $([System.Net.WebUtility]::HtmlEncode($data.Auth.Username))
-                        </span>"
-                        if ($data.Auth.Logout) {
-                            "<button class='btn btn-danger my-2 my-sm-0 mBottom-06 mRight05' type='submit'>
-                                <span class='mdi mdi-logout mRight02'></span>
-                                Sign out
-                            </button>"
-                        }
-                    "</form>"
+        $(
+            if (!$data.Page.NoNavigation) {
+                Use-PodeWebPartialView -Path 'shared/navbar' -Data @{
+                    Auth = $data.Auth
+                    AppPath = $data.AppPath
                 }
-                else {
-                    "<form class='form-inline' action='$($data.AppPath)/login' method='GET' style='margin-bottom: 0'>
-                        <button class='btn btn-success my-2 my-sm-0 mBottom-06 mRight05' type='submit'>
-                            <span class='mdi mdi-login mRight02'></span>
-                            Sign in
-                        </button>
-                    </form>"
-                }
-            })
-        </nav>
+            }
+        )
 
         <div class="container-fluid">
             <div class="row">
@@ -87,7 +23,12 @@
                         $hideSidebar = 'hide-on-start'
                     }
 
-                    "<nav id='sidebarMenu' class='col-md-3 col-lg-2 d-md-block bg-light sidebar collapse $($hideSidebar)'>"
+                    $navPadding = [string]::Empty
+                    if (!$data.Page.NoNavigation) {
+                        $navPadding = 'nav-padding'
+                    }
+
+                    "<nav id='sidebarMenu' class='col-md-3 col-lg-2 d-md-block bg-light sidebar collapse $($hideSidebar) $($navPadding)'>"
                 )
                     $(
                         $noPageFilter = Get-PodeWebState -Name 'no-page-filter'
@@ -117,7 +58,7 @@
                             <li class="nav-item nav-page-item">
                                 <a class="nav-link $(if ($data.Page.Name -ieq 'home') { 'active' })" href="$($data.AppPath)/">
                                     <div>
-                                        <span class="mdi mdi-home mdi-size-22 mRight02"></span>
+                                        <span class="mdi mdi-$(Get-PodeWebHomeIcon) mdi-size-22 mRight02"></span>
                                         $(Get-PodeWebHomeName)
                                     </div>
                                 </a>
@@ -203,32 +144,39 @@
                 </div>
 
                 <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-md-4">
-                    $(if (!$data.Page.NoTitle) {
-                        "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom'>
-                            <h1 class='h2'>"
-                                if ($data.Page.ShowBack) {
-                                    "<a href='$($data.Page.Url)'><span class='mdi mdi-arrow-left'></span></a>"
-                                }
-                                if (![string]::IsNullOrWhiteSpace($data.Page.Icon)) {
-                                    "<span class='mdi mdi-$($data.Page.Icon.ToLowerInvariant()) pode-page-title-icon'></span>"
-                                }
-                                $data.Page.Title
-                            "</h1>"
-                            if ($data.Page.ShowHelp) {
-                                "<span class='mdi mdi-help-circle-outline pode-page-help' for='$($data.Page.Url)' title='Help' data-toggle='tooltip'></span>"
-                            }
-                        "</div>"
-                    }
-                    else {
-                        "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2'></div>"
-                    }
+                    $(
+                        $navPadding = [string]::Empty
+                        if (!$data.Page.NoNavigation) {
+                            $navPadding = 'nav-padding'
+                        }
 
-                    if (!$data.Page.NoBreadcrumb) {
-                        "<nav id='pode-breadcrumb' aria-label='breadcrumb'>
-                            <ol class='breadcrumb'>
-                            </ol>
-                        </nav>"
-                    })
+                        if (!$data.Page.NoTitle) {
+                            "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom $($navPadding)'>
+                                <h1 class='h2'>"
+                                    if ($data.Page.ShowBack) {
+                                        "<a href='$($data.Page.Url)'><span class='mdi mdi-arrow-left'></span></a>"
+                                    }
+                                    if (![string]::IsNullOrWhiteSpace($data.Page.Icon)) {
+                                        "<span class='mdi mdi-$($data.Page.Icon.ToLowerInvariant()) pode-page-title-icon'></span>"
+                                    }
+                                    $data.Page.Title
+                                "</h1>"
+                                if ($data.Page.ShowHelp) {
+                                    "<span class='mdi mdi-help-circle-outline pode-page-help' for='$($data.Page.Url)' title='Help' data-toggle='tooltip'></span>"
+                                }
+                            "</div>"
+                        }
+                        else {
+                            "<div id='pode-page-title' class='d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 $($navPadding)'></div>"
+                        }
+
+                        if (!$data.Page.NoBreadcrumb) {
+                            "<nav id='pode-breadcrumb' aria-label='breadcrumb'>
+                                <ol class='breadcrumb'>
+                                </ol>
+                            </nav>"
+                        }
+                    )
 
                     <content id="pode-content"></content>
                 </main>

--- a/src/Templates/Views/shared/navbar.pode
+++ b/src/Templates/Views/shared/navbar.pode
@@ -1,0 +1,72 @@
+<nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow navbar-expand-lg">
+    <button type='button' class='btn btn-icon-only' id='menu-toggle'>
+        <span class='mdi mdi-menu-open'></span>
+    </button>
+
+    <a class="navbar-brand col-md-3 col-lg-2 mr-0 px-3" href="$($data.AppPath)/">
+        $(
+            $title = Get-PodeWebState -Name 'title'
+            $logo = Get-PodeWebState -Name 'logo'
+
+            if (![string]::IsNullOrWhiteSpace($logo)) {
+                "<img src='$($logo)' width='30' height='30' class='d-inline-block align-top' alt='$($title)' loading='lazy'>"
+            }
+
+            $title
+        )
+    </a>
+
+    <button class="navbar-toggler position-absolute d-md-none collapsed" type="button" data-toggle="collapse" data-target="#sidebarMenu" aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div id='pode-nav'>
+        <div id='pode-nav-social'>
+            $(
+                $socials = Get-PodeWebState -Name 'social'
+                foreach ($key in $socials.Keys) {
+                    $social = $socials[$key]
+
+                    "<a href='$($social.Url.ToLowerInvariant())' target='_blank' title='$($social.Tooltip)' data-toggle='tooltip'>
+                        <span class='mdi mdi-$($key.ToLowerInvariant())'></span>
+                    </a>"
+                }
+            )
+        </div>
+
+        <div id='pode-nav-items'>
+            <ul class="navbar-nav mr-auto">
+            </ul>
+        </div>
+    </div>
+
+    $(if ($data.Auth.Enabled) {
+        if ($data.Auth.Authenticated) {
+            "<form class='form-inline' action='$($data.AppPath)/logout' method='POST' style='margin-bottom: 0'>
+                <span class='navbar-text mRight1 welcome-msg'>"
+                    if (![string]::IsNullOrWhiteSpace($data.Auth.Avatar)) {
+                        "<img id='avatar' src='$($data.Auth.Avatar)'>"
+                    }
+                    else {
+                        "<span id='avatar' class='mdi mdi-account'></span>"
+                    }
+                    "Hello, $([System.Net.WebUtility]::HtmlEncode($data.Auth.Username))
+                </span>"
+                if ($data.Auth.Logout) {
+                    "<button class='btn btn-danger my-2 my-sm-0 mBottom-06 mRight05' type='submit'>
+                        <span class='mdi mdi-logout mRight02'></span>
+                        Sign out
+                    </button>"
+                }
+            "</form>"
+        }
+        else {
+            "<form class='form-inline' action='$($data.AppPath)/login' method='GET' style='margin-bottom: 0'>
+                <button class='btn btn-success my-2 my-sm-0 mBottom-06 mRight05' type='submit'>
+                    <span class='mdi mdi-login mRight02'></span>
+                    Sign in
+                </button>
+            </form>"
+        }
+    })
+</nav>


### PR DESCRIPTION
### Description of the Change
This adds `-ScriptBlock` parameter support for Home pages, so Home page contents can be rendered dynamically. Also adds `-NoNavigation` support, to hide the navbar on certain pages, for Pages and Home pages.

Oh, and adds `-Icon` support for Home pages - so you can change the icon!

### Related Issue
Resolves #358 

### Examples
* `-ScriptBlock` on home page:
```powershell
Set-PodeWebHomePage -Title 'Awesome Homepage' -Icon 'cat' -ScriptBlock {
    New-PodeWebCard -Name 'Welcome' -NoTitle -Content @(
        New-PodeWebParagraph -Value 'This is an example homepage, with some example text'
        New-PodeWebParagraph -Value 'Using some example paragraphs'
    )
}
```

* `-NoNavigation` on pages (also home pages too):
```powershell
Add-PodeWebPage -Name Example -ScriptBlock {} -NoNavigation
```