### PR TITLE
Add icon support to Update-PodeWebTile, and Update-PodeWebHeader

### DIFF
--- a/docs/Tutorials/Actions/Header.md
+++ b/docs/Tutorials/Actions/Header.md
@@ -4,7 +4,7 @@ This page details the actions available to Headers.
 
 ## Update
 
-To update the value or icon of a Header on the page, you can use [`Update-PodeWebHeader`](../../../Functions/Actions/Update-PodeWebHeader):
+To update the value, icon, or size of a Header on the page, you can use [`Update-PodeWebHeader`](../../../Functions/Actions/Update-PodeWebHeader):
 
 ```powershell
 New-PodeWebContainer -NoBackground -Content @(
@@ -17,3 +17,6 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+!!! note
+    A `-Size` of `0` will leave the Header size unchanged - this is the default.

--- a/docs/Tutorials/Actions/Header.md
+++ b/docs/Tutorials/Actions/Header.md
@@ -1,0 +1,19 @@
+# Headers
+
+This page details the actions available to Headers.
+
+## Update
+
+To update the value or icon of a Header on the page, you can use [`Update-PodeWebHeader`](../../../Functions/Actions/Update-PodeWebHeader):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebHeader -Id 'my-header' -Size 1 -Value 'My Header' -Icon 'home'
+
+    New-PodeWebButton -Name 'Update Header' -ScriptBlock {
+        $rand = Get-Random -Minimum 0 -Maximum 3
+        $icon = (@('cat', 'home', 'information'))[$rand]
+        Update-PodeWebHeader -Id 'my-header' -Value "My Header $($rand)" -Icon $icon
+    }
+)
+```

--- a/docs/Tutorials/Actions/Text.md
+++ b/docs/Tutorials/Actions/Text.md
@@ -6,12 +6,15 @@ This action differs slightly, as it doesn't just update elements created by [`Ne
 
 * Alert
 * Badge
+* Button
 * Code
 * CodeBlock
 * Header
+* Link
 * Paragraph
 * Quote
 * Text
+* Tile
 
 ## Update
 

--- a/docs/Tutorials/Actions/Tiles.md
+++ b/docs/Tutorials/Actions/Tiles.md
@@ -4,7 +4,7 @@ This page details the actions available to Tiles.
 
 ## Update
 
-To update the value or the colour of a tile on the page, you can use [`Update-PodeWebTile`](../../../Functions/Actions/Update-PodeWebTile):
+To update the value, colour or icon of a Tile on the page, you can use [`Update-PodeWebTile`](../../../Functions/Actions/Update-PodeWebTile):
 
 ```powershell
 New-PodeWebContainer -NoBackground -Content @(
@@ -22,7 +22,7 @@ New-PodeWebContainer -NoBackground -Content @(
 
 ## Sync
 
-To force a tile to refresh its data you can use [`Sync-PodeWebTile`](../../../Functions/Actions/Sync-PodeWebTile):
+To force a Tile to refresh its data you can use [`Sync-PodeWebTile`](../../../Functions/Actions/Sync-PodeWebTile):
 
 ```powershell
 New-PodeWebContainer -NoBackground -Content @(

--- a/examples/tiles.ps1
+++ b/examples/tiles.ps1
@@ -28,7 +28,7 @@ Start-PodeServer -Threads 2 {
             New-PodeWebCell -Content @(New-PodeWebTile -Name Example5 -ScriptBlock {} -Colour Dark)
             New-PodeWebCell -Content @(New-PodeWebTile -Name Example6 -ScriptBlock {} -Colour Cyan -ClickScriptBlock {
                 Show-PodeWebToast -Message 'oooooo'
-                Update-PodeWebTile -Name Example1 -Colour Red
+                Update-PodeWebTile -Name Example1 -Colour Red -Icon (@('cat', 'information', 'home')[(Get-Random -Minimum 0 -Maximum 3)])
                 Sync-PodeWebTile -Name Example2
             })
         )

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -1205,7 +1205,11 @@ function Update-PodeWebTile
         [Parameter()]
         [ValidateSet('', 'Blue', 'Grey', 'Green', 'Red', 'Yellow', 'Cyan', 'Light', 'Dark')]
         [string]
-        $Colour = ''
+        $Colour = '',
+
+        [Parameter()]
+        [string]
+        $Icon
     )
 
     $colourType = Convert-PodeWebColourToClass -Colour $Colour
@@ -1218,6 +1222,7 @@ function Update-PodeWebTile
         Name = $Name
         Colour = $Colour
         ColourType = $ColourType
+        Icon = $Icon
     }
 }
 
@@ -2006,15 +2011,11 @@ function Out-PodeWebElement
 
 function Update-PodeWebRaw
 {
-    [CmdletBinding(DefaultParameterSetName='Id')]
+    [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [Parameter(Mandatory=$true)]
         [string]
         $Id,
-
-        [Parameter(Mandatory=$true, ParameterSetName='Name')]
-        [string]
-        $Name,
 
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
@@ -2025,7 +2026,32 @@ function Update-PodeWebRaw
         Operation = 'Update'
         ObjectType = 'Raw'
         ID = $Id
-        Name = $Name
         Value = $Value
+    }
+}
+
+function Update-PodeWebHeader
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Id,
+
+        [Parameter(ValueFromPipeline=$true)]
+        [string]
+        $Value,
+
+        [Parameter()]
+        [string]
+        $Icon
+    )
+
+    return @{
+        Operation = 'Update'
+        ObjectType = 'Header'
+        ID = $Id
+        Value = $Value
+        Icon = $Icon
     }
 }

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -2044,7 +2044,12 @@ function Update-PodeWebHeader
 
         [Parameter()]
         [string]
-        $Icon
+        $Icon,
+
+        [Parameter()]
+        [ValidateSet(0, 1, 2, 3, 4, 5, 6)]
+        [int]
+        $Size = 0
     )
 
     return @{
@@ -2053,5 +2058,6 @@ function Update-PodeWebHeader
         ID = $Id
         Value = $Value
         Icon = $Icon
+        Size = $Size
     }
 }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1473,10 +1473,6 @@ function New-PodeWebRaw
         [string]
         $Id,
 
-        [Parameter()]
-        [string]
-        $Name,
-
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
         $Value
@@ -1489,7 +1485,6 @@ function New-PodeWebRaw
         ObjectType = 'Raw'
         Parent = $ElementData
         ID = $Id
-        Name = $Name
         Value = $Value
         NoEvents = $true
     }

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -2803,17 +2803,18 @@ PodeElementFactory.setClass(PodeParagraph);
 class PodeHeader extends PodeTextualElement {
     static type = 'header';
 
-    constructor(...args) {
-        super(...args);
+    constructor(data, sender, opts) {
+        super(data, sender, opts);
+        this.size = data.Size ?? 1;
     }
 
     new(data, sender, opts) {
         var subHeader = data.Secondary ? `<small class='text-muted'>${data.Secondary}</small>` : '';
         var icon = this.setIcon(data.Icon);
 
-        return `<h${data.Size}
+        return `<span
             id='${this.id}'
-            class='header ${this.css.classes}'
+            class='h${this.size} header d-block ${this.css.classes}'
             style='${this.css.styles}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
@@ -2822,7 +2823,17 @@ class PodeHeader extends PodeTextualElement {
                     ${data.Value}
                 </span>
                 ${subHeader}
-        </h${data.Size}>`;
+        </span>`;
+    }
+
+    update(data, sender, opts) {
+        super.update(data, sender, opts);
+
+        // update size
+        if (data.Size && data.Size > 0) {
+            this.replaceClass(`h${this.size}`, `h${data.Size}`);
+            this.size = data.Size;
+        }
     }
 }
 PodeElementFactory.setClass(PodeHeader);

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -757,7 +757,7 @@ class PodeElement {
     }
 
     removeClass(clazz, sender, opts) {
-        removeClass(this.element, clazz, !(opts.AsPattern ?? false));
+        removeClass(this.element, clazz, !((opts ?? {}).AsPattern ?? false));
     }
 
     replaceClass(oldClass, newClass, sender, opts) {

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -761,7 +761,7 @@ class PodeElement {
     }
 
     replaceClass(oldClass, newClass, sender, opts) {
-        removeClass(this.element, oldClass, !(opts.AsPattern ?? false));
+        removeClass(this.element, oldClass, !((opts ?? {}).AsPattern ?? false));
         addClass(this.element, newClass);
     }
 
@@ -772,10 +772,6 @@ class PodeElement {
 
     new(data, sender, opts) {
         throw `${this.getType()} "new" method not implemented`
-    }
-
-    update(data, sender, opts) {
-        throw `${this.getType()} "update" method not implemented`
     }
 
     move(data, sender, opts) {
@@ -816,6 +812,13 @@ class PodeElement {
 
     close(data, sender, opts) {
         throw `${this.getType()} "close" method not implemented`
+    }
+
+    update(data, sender, opts) {
+        // update icon
+        if (this.icon && data.Icon) {
+            this.icon.replace(data.Icon);
+        }
     }
 
     bind(data, sender, opts) {
@@ -875,6 +878,8 @@ class PodeTextualElement extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         if (this.textual && data.Value) {
             if (this.element.hasClass('pode-text')) {
                 this.element.text(decodeHTML(data.Value));
@@ -1139,6 +1144,8 @@ class PodeFormElement extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         // disable / enable control
         if (data.DisabledState) {
             switch (data.DisabledState.toLowerCase()) {
@@ -1240,6 +1247,9 @@ class PodeMediaElement extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
+        // skip if no sources/tracks
         if (!data.Sources && !data.Tracks) {
             return;
         }
@@ -1620,11 +1630,6 @@ class PodeButton extends PodeFormElement {
 
     update(data, sender, opts) {
         super.update(data, sender, opts);
-
-        // update icon
-        if (data.Icon) {
-            replaceClass(this.element.find('span.mdi'), 'mdi-\\w+', `mdi-${data.Icon.toLowerCase()}`);
-        }
 
         // update display name
         if (data.DisplayName) {
@@ -2804,12 +2809,11 @@ class PodeHeader extends PodeTextualElement {
 
     new(data, sender, opts) {
         var subHeader = data.Secondary ? `<small class='text-muted'>${data.Secondary}</small>` : '';
-
         var icon = this.setIcon(data.Icon);
 
         return `<h${data.Size}
             id='${this.id}'
-            class='${this.css.classes}'
+            class='header ${this.css.classes}'
             style='${this.css.styles}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
@@ -3074,11 +3078,11 @@ class PodeVideo extends PodeMediaElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         if (data.Thumbnail) {
             this.element.attr('thumbnail', data.Thumbnail);
         }
-
-        super.update(data, sender, opts);
     }
 }
 PodeElementFactory.setClass(PodeVideo);
@@ -3189,6 +3193,8 @@ class PodeIFrame extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         if (data.Url) {
             this.element.attr('src', data.Url);
         }
@@ -3228,7 +3234,6 @@ class PodeRaw extends PodeContentElement {
     new(data, sender, opts) {
         return `<span
             id='${this.id}'
-            name='${this.name}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
             ${data.Value}
@@ -3236,6 +3241,7 @@ class PodeRaw extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
         this.element.html(data.Value);
     }
 }
@@ -3425,6 +3431,7 @@ class PodeTile extends PodeRefreshableElement {
     update(data, sender, opts) {
         super.update(data, sender, opts);
 
+        /// update the colour
         if (data.Colour) {
             this.replaceClass('alert-\\w+', `alert-${data.ColourType}`, null, {AsPattern: true});
         }
@@ -3776,6 +3783,8 @@ class PodeCodeEditor extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         // set value
         if (data.Value) {
             this.editor.setValue(data.Value);
@@ -3874,6 +3883,9 @@ class PodeChart extends PodeRefreshableElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
+        // convert chart data points to array
         data.Data = convertToArray(data.Data);
         if (data.Data.length === 0) {
             return;
@@ -4520,6 +4532,8 @@ class PodeProgress extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         // value
         if (data.Value) {
             this.element.attr('aria-valuenow', data.Value);
@@ -4581,6 +4595,8 @@ class PodeCheckbox extends PodeFormElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         // get checkbox
         var checkbox = this.getCheckbox(data.OptionId);
         if (!checkbox) {
@@ -4957,6 +4973,8 @@ class PodeFileStream extends PodeContentElement {
     }
 
     update(data, sender, opts) {
+        super.update(data, sender, opts);
+
         if (data.Url && this.file.url !== data.Url) {
             this.stop(data, sender, opts);
             this.clear(data, sender, opts);

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -852,27 +852,27 @@ th .mdi::before {
     vertical-align: sub;
 }
 
-h1.header .mdi::before {
+.h1.header .mdi::before {
     font-size: 2.5rem;
 }
 
-h2.header .mdi::before {
+.h2.header .mdi::before {
     font-size: 2rem;
 }
 
-h3.header .mdi::before {
+.h3.header .mdi::before {
     font-size: 1.75rem;
 }
 
-h4.header .mdi::before {
+.h4.header .mdi::before {
     font-size: 1.5rem;
 }
 
-h5.header .mdi::before {
+.h5.header .mdi::before {
     font-size: 1.25rem;
 }
 
-h6.header .mdi::before {
+.h6.header .mdi::before {
     font-size: 1rem;
 }
 

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -852,27 +852,27 @@ th .mdi::before {
     vertical-align: sub;
 }
 
-h1 .mdi::before {
+h1.header .mdi::before {
     font-size: 2.5rem;
 }
 
-h2 .mdi::before {
+h2.header .mdi::before {
     font-size: 2rem;
 }
 
-h3 .mdi::before {
+h3.header .mdi::before {
     font-size: 1.75rem;
 }
 
-h4 .mdi::before {
+h4.header .mdi::before {
     font-size: 1.5rem;
 }
 
-h5 .mdi::before {
+h5.header .mdi::before {
     font-size: 1.25rem;
 }
 
-h6 .mdi::before {
+h6.header .mdi::before {
     font-size: 1rem;
 }
 


### PR DESCRIPTION
### Description of the Change
Add `-Icon` support onto `Update-PodeWebTile`. Also adds a new `Update-PodeWebHeader` to update the value, icon, and size of a Header.

### Related Issue
Resolves #407 

### Examples
* For Tiles:
```powershell
Update-PodeWebTile -Name Example1 -Icon (@('cat', 'information', 'home')[(Get-Random -Minimum 0 -Maximum 3)])
```

* For Headers
```powershell
Update-PodeWebHeader -Id 'example2' -Icon (@('cat', 'information', 'home')[(Get-Random -Minimum 0 -Maximum 3)]) -Size 2
```