### PR TITLE
Throw and error if Use-PodeWebTemplates is called more than once

### DIFF
--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -38,6 +38,10 @@ function Use-PodeWebTemplates
         $UseHsts
     )
 
+    if (Get-PodeWebState -Name 'enabled') {
+        throw "Pode.Web templates have already been enabled."
+    }
+
     if ([string]::IsNullOrWhiteSpace($FavIcon)) {
         $FavIcon = '/pode.web/images/favicon.ico'
     }
@@ -50,6 +54,7 @@ function Use-PodeWebTemplates
     }
     Set-PodeWebState -Name 'app-path' -Value ($appPath.ToLowerInvariant())
 
+    Set-PodeWebState -Name 'enabled' -Value $true
     Set-PodeWebState -Name 'title' -Value ([System.Net.WebUtility]::HtmlEncode($Title))
     Set-PodeWebState -Name 'logo' -Value (Add-PodeWebAppPath -Url $Logo)
     Set-PodeWebState -Name 'favicon' -Value (Add-PodeWebAppPath -Url $FavIcon)


### PR DESCRIPTION
### Description of the Change
If `Use-PodeWebTemplates` is called a second time (or a third, etc.), an error will now be thrown.

### Related Issue
Resolves #434 