### PR TITLE
Centralise class/styles, add custom attribute support, and enable hiding element on creation 

### DIFF
--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -68,6 +68,18 @@ Any references to `Out-PodeWebValidation` should be updated to `Show-PodeWebVali
 
 Any references to `Move-PodeWebTab` should be updated to `Move-PodeWebTabs`. This will still do the same logic of moving a Tabs element to the next Tab, but there's now a new `-Direction` parameter to also cycle to the previous Tab.
 
+### Classes
+
+The `Add-PodeWebComponentClass` and `Remove-PodeWebComponentClass` action functions have been renamed to `Add-PodeWebClass` and `Remove-PodeWebClass` respectively.
+
+The `-Class` parameter on both has also been renamed to `-Value`.
+
+### Styles
+
+The `Set-PodeWebComponentStyle` and `Remove-PodeWebComponentStyle` action functions have been renamed to `Add-PodeWebStyle` and `Remove-PodeWebStyle` respectively.
+
+The `-Property` parameter on both has also been renamed to `-Key`.
+
 ## NoForm and NoLabels
 
 In Pode.Web v1.X the new element rendering is more aware if an input element is being rendered within in a Form, or not. Because of this the `-NoForm` and `-NoLabels` parameters are now all redundant, and have been removed from the following functions:
@@ -93,6 +105,20 @@ Because of this change, functions that had `-Layouts` or `-Elements` parameters 
 * `Set-PodeWebHomePage`
 * `Add-PodeWebPage`
 
+## Classes and Styles
+
+All element functions have had the `-CssClass` and `-CssStyle` parameters removed. Instead you can now pipe the element into either `Add-PodeWebClass` or `Add-PodeWebStyle`:
+
+```powershell
+# add a class to an element
+New-PodeWebTextbox -Name 'Example' |
+    Add-PodeWebClass -Value 'my-custom-textbox'
+
+# add a style to an element
+New-PodeWebTextbox -Name 'Example' |
+    Add-PodeWebStyle -Key 'color' -Value 'yellow'
+```
+
 ## Component to Element
 
 Originally there was a differentiation between Layouts and Elements in Pode.Web, but this is now being dropped and everything is just an "Element". Because of this the "Component" catch-all name is also being dropped, which means the following action functions are being renamed:
@@ -101,10 +127,10 @@ Originally there was a differentiation between Layouts and Elements in Pode.Web,
 | ---- | -- |
 | `Hide-PodeWebComponent` | `Hide-PodeWebElement` |
 | `Show-PodeWebComponent` | `Show-PodeWebElement` |
-| `Add-PodeWebComponentClass` | `Add-PodeWebElementClass` |
-| `Remove-PodeWebComponentClass` | `Remove-PodeWebElementClass` |
-| `Set-PodeWebComponentStyle` | `Set-PodeWebElementStyle` |
-| `Remove-PodeWebComponentStyle` | `Remove-PodeWebElementStyle` |
+| `Add-PodeWebComponentClass` | `Add-PodeWebClass` |
+| `Remove-PodeWebComponentClass` | `Remove-PodeWebClass` |
+| `Set-PodeWebComponentStyle` | `Add-PodeWebStyle` |
+| `Remove-PodeWebComponentStyle` | `Remove-PodeWebStyle` |
 
 The parameters of these functions remains unchanged.
 

--- a/docs/Tutorials/Actions/Elements.md
+++ b/docs/Tutorials/Actions/Elements.md
@@ -2,6 +2,9 @@
 
 This page details the actions available to all elements of Pode.Web.
 
+!!! important
+    Most of the functions also have an `-Element` parameter. This parameter should only be used when creating a new element, such as `New-PodeWebTextbox`. Using this function as an action to update an existing element on the frontend will actually just create another new element! For this, use the `-Id` or `-Name`/`-Type` parameters instead.
+
 ## General
 
 ### Out
@@ -20,6 +23,8 @@ $form = New-PodeWebForm -Name 'Search Processes' -AsCard -ScriptBlock {
     New-PodeWebTextbox -Name 'Name'
 )
 ```
+
+## Visibility
 
 ### Hide
 
@@ -49,50 +54,77 @@ Show-PodeWebElement -Id 'card_somename'
 
 ### Add
 
-You can add a class onto an element via [`Add-PodeWebElementClass`](../../../Functions/Actions/Add-PodeWebElementClass). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+You can add a class onto an element via [`Add-PodeWebClass`](../../../Functions/Actions/Add-PodeWebClass). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
 
 ```powershell
-Add-PodeWebElementClass -Type 'Textbox' -Name 'SomeTextboxName' -Class 'my-custom-class'
+Add-PodeWebClass -Type 'Textbox' -Name 'SomeTextboxName' -Value 'my-custom-class'
 
 # or
 
-Add-PodeWebElementClass -Id 'textbox_somename' -Class 'my-custom-class'
+Add-PodeWebClass -Id 'textbox_somename' -Value 'my-custom-class'
 ```
 
 ### Remove
 
-You can remove a class from an element via [`Remove-PodeWebElementClass`](../../../Functions/Actions/Remove-PodeWebElementClass). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+You can remove a class from an element via [`Remove-PodeWebClass`](../../../Functions/Actions/Remove-PodeWebClass). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
 
 ```powershell
-Remove-PodeWebElementClass -Type 'Textbox' -Name 'SomeTextboxName' -Class 'my-custom-class'
+Remove-PodeWebClass -Type 'Textbox' -Name 'SomeTextboxName' -Value 'my-custom-class'
 
 # or
 
-Remove-PodeWebElementClass -Id 'textbox_somename' -Class 'my-custom-class'
+Remove-PodeWebClass -Id 'textbox_somename' -Value 'my-custom-class'
 ```
 
 ## Styles
 
-### Set
+### Add
 
-You can set/update the value of a CSS property on an element via [`Set-PodeWebElementStyle`](../../../Functions/Actions/Set-PodeWebElementStyle). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+You can add/update the value of a CSS property on an element via [`Add-PodeWebStyle`](../../../Functions/Actions/Add-PodeWebStyle). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
 
 ```powershell
-Set-PodeWebElementStyle -Type 'Textbox' -Name 'SomeTextboxName' -Property 'color' -Value 'red'
+Add-PodeWebStyle -Type 'Textbox' -Name 'SomeTextboxName' -Key 'color' -Value 'red'
 
 # or
 
-Set-PodeWebElementStyle -Id 'textbox_somename' -Property 'color' -Value 'red'
+Add-PodeWebStyle -Id 'textbox_somename' -Key 'color' -Value 'red'
 ```
 
 ### Remove
 
-You can remove a CSS property from an element via [`Remove-PodeWebElementStyle`](../../../Functions/Actions/Remove-PodeWebElementStyle). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+You can remove a CSS property from an element via [`Remove-PodeWebStyle`](../../../Functions/Actions/Remove-PodeWebStyle). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
 
 ```powershell
-Remove-PodeWebElementStyle -Type 'Textbox' -Name 'SomeTextboxName' -Property 'color'
+Remove-PodeWebStyle -Type 'Textbox' -Name 'SomeTextboxName' -Key 'color'
 
 # or
 
-Remove-PodeWebElementStyle -Id 'textbox_somename' -Property 'color'
+Remove-PodeWebStyle -Id 'textbox_somename' -Key 'color'
+```
+
+
+## Attributes
+
+### Add
+
+You can add/update the attributes on an element via [`Add-PodeWebAttribute`](../../../Functions/Actions/Add-PodeWebAttribute). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+
+```powershell
+Add-PodeWebAttribute -Type 'Textbox' -Name 'SomeTextboxName' -Key 'hx-confirm' -Value 'Are you sure?'
+
+# or
+
+Add-PodeWebAttribute -Id 'textbox_somename' -Key 'hx-confirm' -Value 'Are you sure?'
+```
+
+### Remove
+
+You can remove an attribute from an element via [`Remove-PodeWebAttribute`](../../../Functions/Actions/Remove-PodeWebAttribute). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+
+```powershell
+Remove-PodeWebAttribute -Type 'Textbox' -Name 'SomeTextboxName' -Key 'hx-confirm'
+
+# or
+
+Remove-PodeWebAttribute -Id 'textbox_somename' -Key 'hx-confirm'
 ```

--- a/docs/Tutorials/ClassAndStyles.md
+++ b/docs/Tutorials/ClassAndStyles.md
@@ -1,15 +1,16 @@
-# Classes and Styles
+# Classes, Styles and Attributes
 
-Nearly every element in Pode.Web has a `-CssClass` and a `-CssStyle` parameter. These parameters allow you to add custom classes/styles on the elements, so you can control their look and functionality.
+Every element can be piped into either [`Add-PodeWebClass`], [`Add-PodeWebStyle`] or [`Add-PodeWebAttribute`]. These functions let you you add custom classes, styles or attributes to elements, during creation, so you can control their look and functionality.
 
 ## Classes
 
-The `-CssClass` parameter accepts an array of strings, which are set on the `class` property on the element. The classes by themselves don't do anything, but you can use them to build custom CSS files and import them via [`Import-PodeWebStylesheet`](../../Functions/Utilities/Import-PodeWebStylesheet); you can also use the custom classes as references in custom JavaScript files, and import these via [`Import-PodeWebJavaScript`](../../Functions/Utilities/Import-PodeWebJavaScript).
+To add a class to an element you can pipe a new element into [`Add-PodeWebClass`], and this will set the values on the element's `class` attribute on the frontend. The classes by themselves don't do anything, but you can use them to build custom CSS files and import them via [`Import-PodeWebStylesheet`](../../Functions/Utilities/Import-PodeWebStylesheet); you can also use the custom classes as references in custom JavaScript files, and import these via [`Import-PodeWebJavaScript`](../../Functions/Utilities/Import-PodeWebJavaScript).
 
 For example, the following would apply the `my-custom-textbox` class to a textbox:
 
 ```powershell
-New-PodeWebTextbox -Name 'Message' -CssClass 'my-custom-textbox'
+New-PodeWebTextbox -Name 'Message' |
+    Add-PodeWebClass -Value 'my-custom-textbox'
 ```
 
 Then you could create some `/public/my-styles.css` file with the following, to set the textbox's text colour to purple:
@@ -32,20 +33,45 @@ $('.my-custom-textbox').off('keyup').on('keyup', (e) => {
 
 and import it via: `Import-PodeWebJavaScript -Url '/my-scripts.js'`.
 
-You can add/remove classes on elements using the [Class actions](../Actions/Elements#classes). (This will add classes onto the element itself, not the parent).
+You can add/remove adhoc classes on elements using the [Class actions](../Actions/Elements#classes). (This will add classes onto the element itself, not the parent).
 
 ## Styles
 
-The `-CssStyle` parameter accepts a hashtable where the key is the name of a CSS property, with an appropriate value for that property. These styles are applied onto the element in the `style` property.
+To add a CSS style to an element you can pipe a new element into [`Add-PodeWebStyle`], and this will set the value on the element's `style` attribute on the frontend. The `-Key` is the name of a CSS style property.
 
 For example, the following would display a paragraph with yellow text:
 
 ```powershell
-New-PodeWebParagraph -CssStyle @{ Color = 'Yellow' } -Content @(
+New-PodeWebParagraph -Content @(
     New-PodeWebText -Value 'And then here is some more text, that also includes a '
     New-PodeWebLink -Value 'link' -Source 'https://google.com'
     New-PodeWebText -Value ' that takes you to Google'
-)
+) |
+    Add-PodeWebStyle -Key 'color' -Value 'yellow'
 ```
 
-You can set/remove CSS style properties on elements using the [Style actions](../Actions/Elements#styles).
+You can add/remove adhoc CSS style properties on elements using the [Style actions](../Actions/Elements#styles).
+
+## Attributes
+
+To add an attribute to an element you can pipe a new element into [`Add-PodeWebAttribute`], and this will set the attribute on the element on the frontend. The `-Key` is the name of an HTML attribute.
+
+For example, the following would add the `hx-confirm` attribute to a button:
+
+```powershell
+New-PodeWebButton -Name 'Example' -ScriptBlock {} |
+    Add-PodeWebAttribute -Key 'hx-confirm' -Value 'Are you sure?'
+```
+
+You can add/remove adhoc attributes on elements using the [Attribute actions](../Actions/Elements#attributes).
+
+## Visibility
+
+You can hide an element on creation by piping it into [`Hide-PodeWebElement`]. For example, the following will hide a textbox initially when it's created:
+
+```powershell
+New-PodeWebTextbox -Name 'Message' |
+    Hide-PodeWebElement
+```
+
+You can later show the element by using the [Visibility actions](../Actions/Elements#visibility).

--- a/examples/class_and_style.ps1
+++ b/examples/class_and_style.ps1
@@ -15,12 +15,16 @@ Start-PodeServer {
 
     # set the home page controls
     $container = New-PodeWebContainer -Content @(
-        New-PodeWebTextbox -Name 'Message' -CssClass 'my-custom-textbox'
-        New-PodeWebParagraph -CssStyle @{ Color = 'Yellow' } -Content @(
+        New-PodeWebTextbox -Name 'Message' |
+            Add-PodeWebClass -Value 'my-custom-textbox'
+
+        New-PodeWebParagraph -Content @(
             New-PodeWebText -Value 'And then here is some more text, that also includes a '
             New-PodeWebLink -Value 'link' -Source 'https://google.com'
             New-PodeWebText -Value ' that takes you to Google'
-        )
+        ) |
+            Add-PodeWebStyle -Key 'color' -Value 'yellow' |
+            Add-PodeWebAttribute -Key 'custom-name' -Value 'joe bloggs'
     )
 
     Set-PodeWebHomePage -Content $container -Title 'Page with STYLE'

--- a/examples/processes.ps1
+++ b/examples/processes.ps1
@@ -40,8 +40,7 @@ Start-PodeServer {
     $form2 = New-PodeWebForm -Name 'Search2' -AsCard -ScriptBlock {
         $processes = Get-Process -Name $WebEvent.Data.Name -ErrorAction Ignore | Select-Object Name, ID, WorkingSet, CPU
         $processes |
-            New-PodeWebTable -Name 'Output' |
-            Out-PodeWebElement
+            New-PodeWebTable -Name 'Output' | Out-PodeWebElement
         Show-PodeWebToast -Message "Found $($processes.Length) processes"
     } -Content @(
         New-PodeWebTextbox -Name 'Name'

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -522,39 +522,21 @@ function Convert-PodeWebAlertTypeToClass
         $Type
     )
 
-    switch ($Type.ToLowerInvariant()) {
-        'error' {
-            return 'danger'
-        }
-
-        'warning' {
-            return 'warning'
-        }
-
-        'tip' {
-            return 'success'
-        }
-
-        'success' {
-            return 'success'
-        }
-
-        'note' {
-            return 'secondary'
-        }
-
-        'info' {
-            return 'info'
-        }
-
-        'important' {
-            return 'primary'
-        }
-
-        default {
-            return 'primary'
-        }
+    $map = @{
+        error       = 'danger'
+        warning     = 'warning'
+        tip         = 'success'
+        success     = 'success'
+        note        = 'secondary'
+        info        = 'info'
+        important   = 'primary'
     }
+
+    if ($map.ContainsKey($Type)) {
+        return $map[$Type]
+    }
+
+    return 'primary'
 }
 
 function Convert-PodeWebAlertTypeToIcon
@@ -565,39 +547,21 @@ function Convert-PodeWebAlertTypeToIcon
         $Type
     )
 
-    switch ($Type.ToLowerInvariant()) {
-        'error' {
-            return 'alert-circle'
-        }
-
-        'warning' {
-            return 'alert'
-        }
-
-        'tip' {
-            return 'thumb-up'
-        }
-
-        'success' {
-            return 'check-circle'
-        }
-
-        'note' {
-            return 'book-open'
-        }
-
-        'info' {
-            return 'information'
-        }
-
-        'important' {
-            return 'bell'
-        }
-
-        default {
-            return 'bell'
-        }
+    $map = @{
+        error       = 'alert-circle'
+        warning     = 'alert'
+        tip         = 'thumb-up'
+        success     = 'check-circle'
+        note        = 'book-open'
+        info        = 'information'
+        important   = 'bell'
     }
+
+    if ($map.ContainsKey($Type)) {
+        return $map[$Type]
+    }
+
+    return 'bell'
 }
 
 function Convert-PodeWebColourToClass
@@ -608,45 +572,22 @@ function Convert-PodeWebColourToClass
         $Colour
     )
 
-    switch ($Colour.ToLowerInvariant()) {
-        'blue' {
-            $css = 'primary'
-        }
-
-        'green' {
-            $css = 'success'
-        }
-
-        'grey' {
-            $css = 'secondary'
-        }
-
-        'red' {
-            $css = 'danger'
-        }
-
-        'yellow' {
-            $css = 'warning'
-        }
-
-        'cyan' {
-            $css = 'info'
-        }
-
-        'light' {
-            $css = 'light'
-        }
-
-        'dark' {
-            $css = 'dark'
-        }
-
-        default {
-            $css = 'primary'
-        }
+    $map = @{
+        blue    = 'primary'
+        green   = 'success'
+        grey    = 'secondary'
+        red     = 'danger'
+        yellow  = 'warning'
+        cyan    = 'info'
+        light   = 'light'
+        dark    = 'dark'
     }
 
-    return $css.ToLowerInvariant()
+    if ($map.ContainsKey($Colour)) {
+        return $map[$Colour]
+    }
+
+    return 'primary'
 }
 
 function Convert-PodeWebButtonSizeToClass
@@ -660,23 +601,16 @@ function Convert-PodeWebButtonSizeToClass
         $FullWidth
     )
 
-    $css = ''
-
-    switch ($Size.ToLowerInvariant()) {
-        'small' {
-            $css = 'btn-sm'
-        }
-
-        'large' {
-            $css = 'btn-lg'
-        }
-    }
+    $css = (@{
+        small = 'btn-sm'
+        large = 'btn-lg'
+    })[$Size]
 
     if ($FullWidth) {
         $css += ' btn-block'
     }
 
-    return $css.ToLowerInvariant()
+    return $css
 }
 
 function Test-PodeWebContent
@@ -847,27 +781,6 @@ function ConvertTo-PodeWebEvents
     }
 
     return $js_events
-}
-
-function ConvertTo-PodeWebStyles
-{
-    param(
-        [Parameter()]
-        [hashtable]
-        $Style
-    )
-
-    $styles = [string]::Empty
-
-    if (($null -eq $Style) -or ($Style.Count -eq 0)) {
-        return $styles
-    }
-
-    foreach ($key in $Style.Keys) {
-        $styles += " $($key.ToLowerInvariant()): $($Style[$key].ToLowerInvariant()) !important;"
-    }
-
-    return $styles
 }
 
 function Protect-PodeWebRange

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -1282,6 +1282,10 @@ function Show-PodeWebElement
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
         [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
@@ -1295,12 +1299,21 @@ function Show-PodeWebElement
         $Name
     )
 
-    return @{
-        Operation = 'Show'
-        ObjectType = 'Element'
-        ID = $Id
-        Type = $Type
-        Name = $Name
+    # update element
+    if ($null -ne $Element) {
+        $Element.Visible = $false
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Show'
+            ObjectType = 'Element'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+        }
     }
 }
 
@@ -1308,6 +1321,10 @@ function Hide-PodeWebElement
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
         [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
@@ -1321,19 +1338,32 @@ function Hide-PodeWebElement
         $Name
     )
 
-    return @{
-        Operation = 'Hide'
-        ObjectType = 'Element'
-        ID = $Id
-        Type = $Type
-        Name = $Name
+    # update element
+    if ($null -ne $Element) {
+        $Element.Visible = $false
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Hide'
+            ObjectType = 'Element'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+        }
     }
 }
 
-function Set-PodeWebElementStyle
+function Add-PodeWebStyle
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
         [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
@@ -1348,29 +1378,50 @@ function Set-PodeWebElementStyle
 
         [Parameter(Mandatory=$true)]
         [string]
-        $Property,
+        $Key,
 
         [Parameter()]
         [string]
         $Value
     )
 
-    return @{
-        Operation = 'Set'
-        ObjectType = 'Element'
-        SubObjectType = 'Style'
-        ID = $Id
-        Type = $Type
-        Name = $Name
-        Property = $Property
-        Value = $Value
+    # update element
+    if ($null -ne $Element) {
+        if ($null -eq $Element.Css) {
+            $Element.Css = @{}
+        }
+
+        if ($null -eq $Element.Css.Styles) {
+            $Element.Css.Styles = @{}
+        }
+
+        $Element.Css.Styles[$key] = $Value
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Set'
+            ObjectType = 'Element'
+            SubObjectType = 'Style'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+            Key = $Key
+            Value = $Value
+        }
     }
 }
 
-function Remove-PodeWebElementStyle
+function Remove-PodeWebStyle
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
         [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
@@ -1385,24 +1436,40 @@ function Remove-PodeWebElementStyle
 
         [Parameter(Mandatory=$true)]
         [string]
-        $Property
+        $Key
     )
 
-    return @{
-        Operation = 'Remove'
-        ObjectType = 'Element'
-        SubObjectType = 'Style'
-        ID = $Id
-        Type = $Type
-        Name = $Name
-        Property = $Property
+    # update element
+    if ($null -ne $Element) {
+        if (($null -ne $Element.Css) -and ($null -ne $Element.Css.Styles)) {
+            $null = $Element.Css.Styles.Remove($Key)
+        }
+
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Remove'
+            ObjectType = 'Element'
+            SubObjectType = 'Style'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+            Key = $Key
+        }
     }
 }
 
-function Add-PodeWebElementClass
+function Add-PodeWebClass
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
         [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
@@ -1416,25 +1483,95 @@ function Add-PodeWebElementClass
         $Name,
 
         [Parameter(Mandatory=$true)]
+        [string[]]
+        $Value
+    )
+
+    # update element
+    if ($null -ne $Element) {
+        if ($null -eq $Element.Css) {
+            $Element.Css = @{}
+        }
+
+        if ($null -eq $Element.Css.Classes) {
+            $Element.Css.Classes = @()
+        }
+
+        $Element.Css.Classes = ($Element.Css.Classes + $Value) | Sort-Object -Unique
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Add'
+            ObjectType = 'Element'
+            SubObjectType = 'Class'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+            Value = $Value
+        }
+    }
+}
+
+function Remove-PodeWebClass
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string[]]
         $Class
     )
 
-    return @{
-        Operation = 'Add'
-        ObjectType = 'Element'
-        SubObjectType = 'Class'
-        ID = $Id
-        Type = $Type
-        Name = $Name
-        Class = $Class
+
+    # update element
+    if ($null -ne $Element) {
+        if (($null -ne $Element.Css) -and ($null -ne $Element.Css.Classes)) {
+            $Element.Css.Classes = $Element.Css.Classes | Where-Object { $_ -inotin $Class }
+        }
+
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Remove'
+            ObjectType = 'Element'
+            SubObjectType = 'Class'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+            Class = $Class
+        }
     }
 }
 
-function Remove-PodeWebElementClass
+function Add-PodeWebAttribute
 {
     [CmdletBinding(DefaultParameterSetName='Id')]
     param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
         [Parameter(Mandatory=$true, ParameterSetName='Id')]
         [string]
         $Id,
@@ -1449,17 +1586,83 @@ function Remove-PodeWebElementClass
 
         [Parameter(Mandatory=$true)]
         [string]
-        $Class
+        $Key,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Value
     )
 
-    return @{
-        Operation = 'Remove'
-        ObjectType = 'Element'
-        SubObjectType = 'Class'
-        ID = $Id
-        Type = $Type
-        Name = $Name
-        Class = $Class
+    # update element
+    if ($null -ne $Element) {
+        if ($null -eq $Element.Attributes) {
+            $Element.Attributes = @{}
+        }
+
+        $Element.Attributes[$Key] = $Value
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Add'
+            ObjectType = 'Element'
+            SubObjectType = 'Attribute'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+            Key = $Key
+            Value = $Value
+        }
+    }
+}
+
+function Remove-PodeWebAttribute
+{
+    [CmdletBinding(DefaultParameterSetName='Id')]
+    param(
+        [Parameter(Mandatory=$true, ParameterSetName='Element', ValueFromPipeline=$true)]
+        [hashtable]
+        $Element,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Key
+    )
+
+    # update element
+    if ($null -ne $Element) {
+        if ($null -ne $Element.Attributes) {
+            $null = $Element.Attributes.Remove($Key)
+        }
+
+        return $Element
+    }
+
+    # send frontend action
+    else {
+        return @{
+            Operation = 'Remove'
+            ObjectType = 'Element'
+            SubObjectType = 'Attribute'
+            ID = $Id
+            Type = $Type
+            Name = $Name
+            Key = $Key
+        }
     }
 }
 

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -1537,14 +1537,14 @@ function Remove-PodeWebClass
 
         [Parameter(Mandatory=$true)]
         [string[]]
-        $Class
+        $Value
     )
 
 
     # update element
     if ($null -ne $Element) {
         if (($null -ne $Element.Css) -and ($null -ne $Element.Css.Classes)) {
-            $Element.Css.Classes = $Element.Css.Classes | Where-Object { $_ -inotin $Class }
+            $Element.Css.Classes = $Element.Css.Classes | Where-Object { $_ -inotin $Value }
         }
 
         return $Element
@@ -1559,7 +1559,7 @@ function Remove-PodeWebClass
             ID = $Id
             Type = $Type
             Name = $Name
-            Class = $Class
+            Value = $Value
         }
     }
 }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -62,14 +62,6 @@ function New-PodeWebTextbox
 
         [Parameter()]
         [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
-        [string[]]
         $EndpointName,
 
         [ValidateRange(0, [int]::MaxValue)]
@@ -146,8 +138,6 @@ function New-PodeWebTextbox
             Disabled = $Disabled.IsPresent
             IsAutoComplete = ($null -ne $AutoComplete)
             Value = $items
-            CssClasses = ($CssClass -join ' ')
-            CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
             Prepend = @{
                 Enabled = (![string]::IsNullOrWhiteSpace($PrependText) -or ![string]::IsNullOrWhiteSpace($PrependIcon))
                 Text = $PrependText
@@ -215,14 +205,6 @@ function New-PodeWebFileUpload
         [string[]]
         $Accept = '*/*',
 
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
         [switch]
         $Required
     )
@@ -237,8 +219,6 @@ function New-PodeWebFileUpload
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = $Id
         Accept = ($Accept -join ',')
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
         Required = $Required.IsPresent
     }
@@ -263,15 +243,7 @@ function New-PodeWebParagraph
         [Parameter()]
         [ValidateSet('Left', 'Right', 'Center')]
         [string]
-        $Alignment = 'Left',
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Alignment = 'Left'
     )
 
     # ensure elements are correct
@@ -289,8 +261,6 @@ function New-PodeWebParagraph
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Content = $Content
         Alignment = $Alignment.ToLowerInvariant()
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -310,14 +280,6 @@ function New-PodeWebCodeBlock
         [Parameter()]
         [string]
         $Language = [string]::Empty,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [switch]
         $Scrollable,
@@ -342,8 +304,6 @@ function New-PodeWebCodeBlock
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Language = $Language.ToLowerInvariant()
         Scrollable = $Scrollable.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -358,15 +318,7 @@ function New-PodeWebCode
 
         [Parameter(Mandatory=$true)]
         [string]
-        $Value,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Value
     )
 
     $Id = Get-PodeWebElementId -Tag Code -Id $Id
@@ -377,8 +329,6 @@ function New-PodeWebCode
         Parent = $ElementData
         ID = $Id
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -406,14 +356,6 @@ function New-PodeWebCheckbox
         [Parameter(ParameterSetName='Multiple')]
         [string[]]
         $DisplayOptions,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter(ParameterSetName='Multiple')]
         [switch]
@@ -451,8 +393,6 @@ function New-PodeWebCheckbox
         AsSwitch = $AsSwitch.IsPresent
         Checked = $Checked.IsPresent
         Disabled = $Disabled.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Required = $Required.IsPresent
     }
 }
@@ -481,14 +421,6 @@ function New-PodeWebRadio
         [string[]]
         $DisplayOptions,
 
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
         [switch]
         $Inline,
 
@@ -512,8 +444,6 @@ function New-PodeWebRadio
         DisplayOptions = @(Protect-PodeWebValues -Value $DisplayOptions -Default $Options -EqualCount -Encode)
         Inline = $Inline.IsPresent
         Disabled = $Disabled.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Required = $Required.IsPresent
     }
 }
@@ -558,14 +488,6 @@ function New-PodeWebSelect
         [int]
         $Size = 4,
 
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
         [switch]
         $Multiple,
 
@@ -599,8 +521,6 @@ function New-PodeWebSelect
         SelectedValue = $SelectedValue
         Multiple = $Multiple.IsPresent
         Size = $Size
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoAuthentication = $NoAuthentication.IsPresent
         Required = $Required.IsPresent
         Disabled = $Disabled.IsPresent
@@ -666,14 +586,6 @@ function New-PodeWebRange
         [int]
         $Max = 100,
 
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
         [switch]
         $Disabled,
 
@@ -706,8 +618,6 @@ function New-PodeWebRange
         Max = $Max
         Disabled = $Disabled.IsPresent
         ShowValue = $ShowValue.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Required = $Required.IsPresent
     }
 }
@@ -744,14 +654,6 @@ function New-PodeWebProgress
         [ValidateSet('Blue', 'Grey', 'Green', 'Red', 'Yellow', 'Cyan', 'Light', 'Dark')]
         [string]
         $Colour = 'Blue',
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [switch]
         $ShowValue,
@@ -795,8 +697,6 @@ function New-PodeWebProgress
         Animated = $Animated.IsPresent
         Colour = $Colour
         ColourType = $ColourType
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -828,15 +728,7 @@ function New-PodeWebImage
 
         [Parameter()]
         [string]
-        $Width = 0,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Width = 0
     )
 
     $Id = Get-PodeWebElementId -Tag Img -Id $Id
@@ -851,8 +743,6 @@ function New-PodeWebImage
         Alignment = $Alignment.ToLowerInvariant()
         Height = (ConvertTo-PodeWebSize -Value $Height -Default 'auto' -Type 'px')
         Width = (ConvertTo-PodeWebSize -Value $Width -Default 'auto' -Type 'px')
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -879,15 +769,7 @@ function New-PodeWebHeader
 
         [Parameter()]
         [string]
-        $Icon,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Icon
     )
 
     $Id = Get-PodeWebElementId -Tag Header -Id $Id
@@ -901,8 +783,6 @@ function New-PodeWebHeader
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Secondary = [System.Net.WebUtility]::HtmlEncode($Secondary)
         Icon = $Icon
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -926,15 +806,7 @@ function New-PodeWebQuote
 
         [Parameter()]
         [string]
-        $Source,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Source
     )
 
     $Id = Get-PodeWebElementId -Tag Quote -Id $Id
@@ -947,8 +819,6 @@ function New-PodeWebQuote
         Alignment = $Alignment.ToLowerInvariant()
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Source = [System.Net.WebUtility]::HtmlEncode($Source)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -968,14 +838,6 @@ function New-PodeWebList
         [Parameter(Mandatory=$true, ParameterSetName='Values')]
         [string[]]
         $Values,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [switch]
         $Numbered
@@ -997,8 +859,6 @@ function New-PodeWebList
         })
         Items = $Items
         Numbered = $Numbered.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -1009,15 +869,7 @@ function New-PodeWebListItem
     param(
         [Parameter(Mandatory=$true)]
         [hashtable[]]
-        $Content,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Content
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -1030,8 +882,6 @@ function New-PodeWebListItem
         ID = (Get-PodeWebElementId -Tag ListItem)
         Content = $Content
         NoEvents = $true
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1051,14 +901,6 @@ function New-PodeWebLink
         [string]
         $Value,
 
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
         [switch]
         $NewTab
     )
@@ -1073,8 +915,6 @@ function New-PodeWebLink
         Source = (Add-PodeWebAppPath -Url $Source)
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         NewTab = $NewTab.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1101,14 +941,6 @@ function New-PodeWebText
         $Alignment = 'Left',
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [string]
         $Pronunciation,
 
@@ -1127,8 +959,6 @@ function New-PodeWebText
         Style = $Style
         InParagraph = $InParagraph.IsPresent
         Alignment = $Alignment.ToLowerInvariant()
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -1139,15 +969,7 @@ function New-PodeWebLine
     param(
         [Parameter()]
         [string]
-        $Id,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Id
     )
 
     return @{
@@ -1155,8 +977,6 @@ function New-PodeWebLine
         ObjectType = 'Line'
         Parent = $ElementData
         ID = (Get-PodeWebElementId -Tag Line -Id $Id)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -1176,15 +996,7 @@ function New-PodeWebHidden
         [Parameter(Mandatory=$true)]
         [AllowEmptyString()]
         [string]
-        $Value,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Value
     )
 
     $Id = Get-PodeWebElementId -Tag Hidden -Id $Id -Name $Name
@@ -1196,8 +1008,6 @@ function New-PodeWebHidden
         Name = $Name
         ID = $Id
         Value = $Value
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -1221,14 +1031,6 @@ function New-PodeWebCredential
         [Parameter()]
         [string]
         $HelpText,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string]
@@ -1262,8 +1064,6 @@ function New-PodeWebCredential
         ID = $Id
         HelpText = [System.Net.WebUtility]::HtmlEncode($HelpText)
         ReadOnly = $ReadOnly.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Placeholders = @{
             Username = (Protect-PodeWebValue -Value $DisplayUsername -Default 'Username' -Encode)
             Password = (Protect-PodeWebValue -Value $DisplayPassword -Default 'Password' -Encode)
@@ -1292,14 +1092,6 @@ function New-PodeWebDateTime
         [Parameter()]
         [string]
         $HelpText,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string]
@@ -1341,8 +1133,6 @@ function New-PodeWebDateTime
         ID = $Id
         HelpText = [System.Net.WebUtility]::HtmlEncode($HelpText)
         ReadOnly = $ReadOnly.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Placeholders = @{
             Date = (Protect-PodeWebValue -Value $DisplayDate -Default 'Date' -Encode)
             Time = (Protect-PodeWebValue -Value $DisplayTime -Default 'Time' -Encode)
@@ -1401,14 +1191,6 @@ function New-PodeWebMinMax
         $AppendIcon,
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [string]
         $DisplayMin,
 
@@ -1444,8 +1226,6 @@ function New-PodeWebMinMax
         }
         HelpText = [System.Net.WebUtility]::HtmlEncode($HelpText)
         ReadOnly = $ReadOnly.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Prepend = @{
             Enabled = (![string]::IsNullOrWhiteSpace($PrependText) -or ![string]::IsNullOrWhiteSpace($PrependIcon))
             Text = $PrependText
@@ -1538,14 +1318,6 @@ function New-PodeWebButton
 
         [Parameter()]
         [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
-        [string[]]
         $EndpointName,
 
         [Parameter(ParameterSetName='ScriptBlock')]
@@ -1594,8 +1366,6 @@ function New-PodeWebButton
         ColourType = $ColourType
         Outline = $Outline.IsPresent
         SizeType = $sizeType
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NewLine = $NewLine.IsPresent
         NewTab = $NewTab.IsPresent
         NoEvents = $true
@@ -1653,15 +1423,7 @@ function New-PodeWebAlert
 
         [Parameter(Mandatory=$true, ParameterSetName='Content')]
         [hashtable[]]
-        $Content,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Content
     )
 
     # ensure content are correct
@@ -1683,8 +1445,6 @@ function New-PodeWebAlert
         IconType = $iconType
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
         Content = $Content
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1703,14 +1463,6 @@ function New-PodeWebIcon
         [Parameter()]
         [string]
         $Colour,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string]
@@ -1743,8 +1495,6 @@ function New-PodeWebIcon
         ID = $Id
         Name = $Name
         Colour = $Colour
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Title = $Title
         Flip = $Flip
         Rotate = $Rotate
@@ -1765,14 +1515,6 @@ function New-PodeWebSpinner
         $Colour,
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [string]
         $Title
     )
@@ -1787,8 +1529,6 @@ function New-PodeWebSpinner
         Parent = $ElementData
         ID = (Get-PodeWebElementId -Tag Spinner -Id $Id)
         Colour = $Colour
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Title = $Title
         NoEvents = $true
     }
@@ -1809,15 +1549,7 @@ function New-PodeWebBadge
 
         [Parameter(Mandatory=$true)]
         [string]
-        $Value,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Value
     )
 
     $Id = Get-PodeWebElementId -Tag Alert -Id $Id
@@ -1831,8 +1563,6 @@ function New-PodeWebBadge
         Colour = $Colour
         ColourType = $ColourType.ToLowerInvariant()
         Value = [System.Net.WebUtility]::HtmlEncode($Value)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -1858,15 +1588,7 @@ function New-PodeWebComment
 
         [Parameter()]
         [DateTime]
-        $TimeStamp,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $TimeStamp
     )
 
     $Id = Get-PodeWebElementId -Tag Comment -Id $Id
@@ -1880,8 +1602,6 @@ function New-PodeWebComment
         Username = [System.Net.WebUtility]::HtmlEncode($Username)
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
         TimeStamp = $TimeStamp
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
     }
 }
@@ -1934,14 +1654,6 @@ function New-PodeWebChart
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string[]]
@@ -2051,8 +1763,6 @@ function New-PodeWebChart
             RefreshInterval = ($RefreshInterval * 1000)
             NoRefresh = $NoRefresh.IsPresent
             NoLegend = $NoLegend.IsPresent
-            CssClasses = ($CssClass -join ' ')
-            CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
             Min = @{
                 X = $MinX
                 Y = $MinY
@@ -2122,14 +1832,6 @@ function New-PodeWebCounterChart
         $DisplayName,
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [int]
         $MaxItems = 30,
 
@@ -2182,8 +1884,6 @@ function New-PodeWebCounterChart
         -Append `
         -TimeLabels `
         -AutoRefresh `
-        -CssClass $CssClass `
-        -CssStyle $CssStyle `
         -MinX $MinX `
         -MinY $MinY `
         -MaxX $MaxX `
@@ -2248,14 +1948,6 @@ function New-PodeWebTable
         [Alias('PageAmount')]
         [int]
         $PageSize = 20,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string[]]
@@ -2369,8 +2061,6 @@ function New-PodeWebTable
             RefreshInterval = ($RefreshInterval * 1000)
             NoRefresh = $NoRefresh.IsPresent
             NoAuthentication = $NoAuthentication.IsPresent
-            CssClasses = ($CssClass -join ' ')
-            CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
             Paging = @{
                 Enabled = $Paginate.IsPresent
                 Size = $PageSize
@@ -2607,14 +2297,6 @@ function New-PodeWebCodeEditor
         $Value,
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [scriptblock]
         $Upload,
 
@@ -2652,8 +2334,6 @@ function New-PodeWebCodeEditor
         Value = $Value
         ReadOnly = $ReadOnly.IsPresent
         Uploadable = $uploadable
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoAuthentication = $NoAuthentication.IsPresent
     }
 
@@ -2720,14 +2400,6 @@ function New-PodeWebForm
 
         [Parameter()]
         [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
-        [string[]]
         $EndpointName,
 
         [Parameter()]
@@ -2779,8 +2451,6 @@ function New-PodeWebForm
         Message = $Message
         Content = $Content
         NoHeader = $NoHeader.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Method = $Method
         Action = (Protect-PodeWebValue -Value $Action -Default $routePath)
         NoEvents = $true
@@ -2847,14 +2517,6 @@ function New-PodeWebTimer
 
         [Parameter()]
         [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
-        [string[]]
         $EndpointName,
 
         [Parameter()]
@@ -2876,8 +2538,6 @@ function New-PodeWebTimer
         Name = $Name
         ID = $Id
         Interval = ($Interval * 1000)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoEvents = $true
         NoAuthentication = $NoAuthentication.IsPresent
     }
@@ -2945,14 +2605,6 @@ function New-PodeWebTile
 
         [Parameter()]
         [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
-        [string[]]
         $EndpointName,
 
         [Parameter()]
@@ -3009,8 +2661,6 @@ function New-PodeWebTile
         Icon = $Icon
         Colour = $Colour
         ColourType = $ColourType
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         AutoRefresh = $AutoRefresh.IsPresent
         RefreshInterval = ($RefreshInterval * 1000)
         NoRefresh = $NoRefresh.IsPresent
@@ -3094,14 +2744,6 @@ function New-PodeWebFileStream
         $Height = 20,
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [int]
         $Interval = 10,
 
@@ -3133,8 +2775,6 @@ function New-PodeWebFileStream
         Url = (Add-PodeWebAppPath -Url $Url)
         Interval = ($Interval * 1000)
         Icon = $Icon
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoHeader = $NoHeader.IsPresent
     }
 
@@ -3159,15 +2799,7 @@ function New-PodeWebIFrame
 
         [Parameter()]
         [string]
-        $Title,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Title
     )
 
     if ([string]::IsNullOrWhiteSpace($Title)) {
@@ -3183,8 +2815,6 @@ function New-PodeWebIFrame
         Url = (Add-PodeWebAppPath -Url $Url)
         Title = $Title
         NoEvents = $true
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -3212,14 +2842,6 @@ function New-PodeWebAudio
         [Parameter()]
         [string]
         $NotSupportedText,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string]
@@ -3268,8 +2890,6 @@ function New-PodeWebAudio
         Loop = $Loop.IsPresent
         NoControls = $NoControls.IsPresent
         NoDownload = $NoDownload.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -3332,14 +2952,6 @@ function New-PodeWebVideo
         $NotSupportedText,
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [string]
         $Width = 20,
 
@@ -3396,8 +3008,6 @@ function New-PodeWebVideo
         NoControls = $NoControls.IsPresent
         NoDownload = $NoDownload.IsPresent
         NoPictureInPicture = $NoPictureInPicture.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -14,14 +14,6 @@ function New-PodeWebGrid
         [int]
         $Width = 0,
 
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
         [switch]
         $Vertical
     )
@@ -40,8 +32,6 @@ function New-PodeWebGrid
         Cells = $Cells
         Width = $Width
         ID = (Get-PodeWebElementId -Tag Grid -Id $Id)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -64,15 +54,7 @@ function New-PodeWebCell
         [Parameter()]
         [ValidateSet('Left', 'Right', 'Center')]
         [string]
-        $Alignment = 'Left',
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Alignment = 'Left'
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -86,8 +68,6 @@ function New-PodeWebCell
         Width = (Protect-PodeWebRange -Value $Width -Min 1 -Max 12)
         ID = (Get-PodeWebElementId -Tag Cell -Id $Id)
         Alignment = $Alignment.ToLowerInvariant()
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -102,14 +82,6 @@ function New-PodeWebTabs
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Tabs,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [int]
@@ -132,8 +104,6 @@ function New-PodeWebTabs
         ObjectType = 'Tabs'
         ID = (Get-PodeWebElementId -Tag Tabs -Id $Id)
         Tabs = $Tabs
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Cycle = @{
             Enabled = $Cycle.IsPresent
             Interval = ($CycleInterval * 1000)
@@ -163,15 +133,7 @@ function New-PodeWebTab
 
         [Parameter()]
         [string]
-        $Icon,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Icon
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -186,8 +148,6 @@ function New-PodeWebTab
         ID = (Get-PodeWebElementId -Tag Tab -Id $Id -Name $Name)
         Content = $Content
         Icon = $Icon
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -210,14 +170,6 @@ function New-PodeWebCard
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Content,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string]
@@ -243,8 +195,6 @@ function New-PodeWebCard
         Content = $Content
         NoTitle = $NoTitle.IsPresent
         NoHide  = $NoHide.IsPresent
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Icon = $Icon
     }
 }
@@ -260,14 +210,6 @@ function New-PodeWebContainer
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Content,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [switch]
         $NoBackground,
@@ -285,8 +227,6 @@ function New-PodeWebContainer
         ObjectType = 'Container'
         ID = (Get-PodeWebElementId -Tag Container -Id $Id)
         Content = $Content
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         NoBackground = $NoBackground.IsPresent
         Hide = $Hide.IsPresent
     }
@@ -338,14 +278,6 @@ function New-PodeWebModal
         [Parameter()]
         [object[]]
         $ArgumentList,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [string[]]
@@ -412,8 +344,6 @@ function New-PodeWebModal
         Size = $Size
         AsForm = $AsForm.IsPresent
         ShowSubmit = ($null -ne $ScriptBlock)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Method = $Method
         Action = (Protect-PodeWebValue -Value $Action -Default $routePath)
     }
@@ -437,15 +367,7 @@ function New-PodeWebHero
 
         [Parameter()]
         [hashtable[]]
-        $Content,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Content
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -459,8 +381,6 @@ function New-PodeWebHero
         Title = [System.Net.WebUtility]::HtmlEncode($Title)
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
         Content = $Content
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -474,15 +394,7 @@ function New-PodeWebCarousel
 
         [Parameter(Mandatory=$true)]
         [hashtable[]]
-        $Slides,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Slides
     )
 
     if (!(Test-PodeWebContent -Content $Slides -ComponentType Layout -ObjectType Slide)) {
@@ -494,8 +406,6 @@ function New-PodeWebCarousel
         ObjectType = 'Carousel'
         ID = (Get-PodeWebElementId -Tag Carousel -Id $Id)
         Slides = $Slides
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -513,15 +423,7 @@ function New-PodeWebSlide
 
         [Parameter()]
         [string]
-        $Message,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Message
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -535,8 +437,6 @@ function New-PodeWebSlide
         ID = (Get-PodeWebElementId -Tag Slide)
         Title = [System.Net.WebUtility]::HtmlEncode($Title)
         Message = [System.Net.WebUtility]::HtmlEncode($Message)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -555,14 +455,6 @@ function New-PodeWebSteps
         [Parameter(Mandatory=$true)]
         [hashtable[]]
         $Steps,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter(Mandatory=$true)]
         [scriptblock]
@@ -618,8 +510,6 @@ function New-PodeWebSteps
         ObjectType = 'Steps'
         ID = $Id
         Steps = $Steps
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -654,14 +544,6 @@ function New-PodeWebStep
         [Parameter()]
         [string[]]
         $EndpointName,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
 
         [Parameter()]
         [Alias('NoAuth')]
@@ -709,8 +591,6 @@ function New-PodeWebStep
         Content = $Content
         Icon = $Icon
         IsDynamic = ($null -ne $ScriptBlock)
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }
 
@@ -796,14 +676,6 @@ function New-PodeWebAccordion
         $Bellows,
 
         [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle,
-
-        [Parameter()]
         [int]
         $CycleInterval = 15,
 
@@ -830,8 +702,6 @@ function New-PodeWebAccordion
         ID = (Get-PodeWebElementId -Tag Accordion -Id $Id -Name $Name)
         Name = $Name
         Bellows = $Bellows
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
         Mode = $Mode
         Cycle = @{
             Enabled = $Cycle.IsPresent
@@ -862,15 +732,7 @@ function New-PodeWebBellow
 
         [Parameter()]
         [string]
-        $Icon,
-
-        [Parameter()]
-        [string[]]
-        $CssClass,
-
-        [Parameter()]
-        [hashtable]
-        $CssStyle
+        $Icon
     )
 
     if (!(Test-PodeWebContent -Content $Content -ComponentType Layout, Element)) {
@@ -885,7 +747,5 @@ function New-PodeWebBellow
         ID = (Get-PodeWebElementId -Tag Bellow -Id $Id -Name $Name)
         Content = $Content
         Icon = $Icon
-        CssClasses = ($CssClass -join ' ')
-        CssStyles = (ConvertTo-PodeWebStyles -Style $CssStyle)
     }
 }

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -214,7 +214,9 @@ class PodeElement {
         var result = this.build('icon', {
             ID: `${this.id}_icon`,
             Name: name,
-            CssClasses: `${padRight ? 'mRight02' : ''} ${padTop ? 'mTop-02' : ''}`
+            Css: {
+                Classes: `${padRight ? 'mRight02' : ''} ${padTop ? 'mTop-02' : ''}`
+            }
         }, null, null);
 
         this.icon = result.elements[0];

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -139,9 +139,11 @@ class PodeElement {
             appendType: ((data.Output ?? {}).AppendType ?? 'append').toLowerCase()
         };
         this.element = null;
+        this.container = null;
         this.icon = null;
         this.url = `/elements/${this.getType()}/${data.ID}`;
         this.disabled = data.Disabled ?? false;
+        this.visible = data.Visible ?? true;
 
         this.parent = null;
         this.children = [];
@@ -154,9 +156,11 @@ class PodeElement {
         };
 
         this.css = {
-            classes: data.CssClasses ?? '',
-            styles: data.CssStyles ?? ''
+            classes: (data.Css ?? {}).Classes ?? [],
+            styles: (data.Css ?? {}).Styles ?? {}
         };
+
+        this.attributes = data.Attributes ?? {};
 
         this.setParent(opts.parent, data, sender, opts);
         PodeElementFactory.setObject(this.uuid, this);
@@ -223,6 +227,7 @@ class PodeElement {
         }
 
         this.element = this.get();
+        this.container = this.getContainer();
         this.created = true;
         return this;
     }
@@ -231,12 +236,12 @@ class PodeElement {
         switch (subType) {
             case 'style':
                 switch (action) {
-                    case 'set':
-                        this.setStyle(data.Property, data.Value, sender, {...data, ...opts});
+                    case 'add':
+                        this.addStyle(data.Key, data.Value, sender, {...data, ...opts});
                         break;
 
                     case 'remove':
-                        this.removeStyle(data.Property, sender, {...data, ...opts});
+                        this.removeStyle(data.Key, sender, {...data, ...opts});
                         break;
                 }
                 break;
@@ -244,11 +249,11 @@ class PodeElement {
             case 'class':
                 switch (action) {
                     case 'add':
-                        this.addClass(data.Class, sender, {...data, ...opts});
+                        this.addClass(data.Value, sender, {...data, ...opts});
                         break;
 
                     case 'remove':
-                        this.removeClass(data.Class, sender, {...data, ...opts});
+                        this.removeClass(data.Value, sender, {...data, ...opts});
                         break;
                 }
                 break;
@@ -257,6 +262,18 @@ class PodeElement {
                 switch (action) {
                     case 'show':
                         this.showValidation(data.Message, sender, {...data, ...opts});
+                        break;
+                }
+                break;
+
+            case 'attribute':
+                switch (action) {
+                    case 'add':
+                        this.addAttribute(data.Key, data.Value, sender, {...data, ...opts})
+                        break;
+
+                    case 'remove':
+                        this.removeAttribute(data.Key, sender, {...data, ...opts});
                         break;
                 }
                 break;
@@ -394,6 +411,8 @@ class PodeElement {
 
         // render content, load and bind this element
         this.element = this.get();
+        this.container = this.getContainer();
+        this.setBaseAttributes();
         this.renderContentArea(data);
         this.load(data, sender, opts);
         this.bind(data, sender, opts);
@@ -412,6 +431,34 @@ class PodeElement {
 
                 c.finalise(null, null, null, true, null);
             });
+        }
+    }
+
+    setBaseAttributes() {
+        // add classes
+        if (this.css.classes) {
+            convertToArray(this.css.classes).forEach((c) => {
+                this.addClass(c);
+            });
+        }
+
+        // add styles
+        if (this.css.styles) {
+            Object.keys(this.css.styles).forEach((p) => {
+                this.addStyle(p, this.css.styles[p]);
+            });
+        }
+
+        // add attributes
+        if (this.attributes) {
+            Object.keys(this.attributes).forEach((p) => {
+                this.addAttribute(p, this.attributes[p]);
+            });
+        }
+
+        // hide element
+        if (!this.visible) {
+            this.hide();
         }
     }
 
@@ -672,6 +719,11 @@ class PodeElement {
         return $(`[pode-id="${this.uuid}"]`);
     }
 
+    getContainer() {
+        var obj = $(`[pode-container-for="${this.uuid}"]`);
+        return obj && obj.length > 0 ? obj : undefined;
+    }
+
     checkParentType(type) {
         return this.parent ? this.parent.getType() === type.toLowerCase() : false;
     }
@@ -733,36 +785,46 @@ class PodeElement {
     }
 
     show(data, sender, opts) {
-        this.element.show();
+        (this.container ?? this.element).show();
+        this.visible = true;
     }
 
     hide(data, sender, opts) {
-        this.element.hide();
+        (this.container ?? this.element).hide();
+        this.visible = false;
     }
 
     sync(data, sender, opts) {
         this.load(data, sender, opts);
     }
 
-    setStyle(property, value, sender, opts) {
-        setElementStyle(this.element[0], property, value);
+    addAttribute(name, value, sender, opts) {
+        this.element.attr(name, value);
     }
 
-    removeStyle(property, sender, opts) {
-        setElementStyle(this.element[0], property);
+    removeAttribute(name, sender, opts) {
+        this.element.attr(name, null);
+    }
+
+    addStyle(name, value, sender, opts) {
+        setElementStyle((this.container ?? this.element)[0], name, value);
+    }
+
+    removeStyle(name, sender, opts) {
+        setElementStyle((this.container ?? this.element)[0], name);
     }
 
     addClass(clazz, sender, opts) {
-        addClass(this.element, clazz);
+        addClass((this.container ?? this.element), clazz);
     }
 
     removeClass(clazz, sender, opts) {
-        removeClass(this.element, clazz, !((opts ?? {}).AsPattern ?? false));
+        removeClass((this.container ?? this.element), clazz, !((opts ?? {}).AsPattern ?? false));
     }
 
     replaceClass(oldClass, newClass, sender, opts) {
-        removeClass(this.element, oldClass, !((opts ?? {}).AsPattern ?? false));
-        addClass(this.element, newClass);
+        removeClass((this.container ?? this.element), oldClass, !((opts ?? {}).AsPattern ?? false));
+        addClass((this.container ?? this.element), newClass);
     }
 
     showValidation(message, sender, opts) {
@@ -1111,7 +1173,7 @@ class PodeFormElement extends PodeContentElement {
                     var width = this.inForm || !this.width ? '' : `width:${this.width}`;
 
                     html = `<${divTag}
-                        class='pode-form-${this.getType()} ${formGroup} ${this.css.classes}'
+                        class='pode-form-${this.getType()} ${formGroup}'
                         style='${width}'
                         ${idProps}
                         ${events}>
@@ -1120,7 +1182,7 @@ class PodeFormElement extends PodeContentElement {
                 }
 
                 // overload html from super
-                opts.html = html;
+                opts.html = `<span pode-container-for='${this.uuid}'>${html}</span>`;
                 break;
         }
 
@@ -1219,8 +1281,7 @@ class PodeFormMultiElement extends PodeFormElement {
         return `<div
             id='${this.id}'
             name='${this.name}'
-            class='form-row ${this.css.classes}'
-            style='${this.css.styles}'
+            class='form-row'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             ${this.events(data.Events)}>
@@ -1288,8 +1349,7 @@ class PodeBadge extends PodeTextualElement {
     new(data, sender, opts) {
         return `<span
             id='${this.id}'
-            class='badge badge-${data.ColourType} pode-text ${this.css.classes}'
-            style='${this.css.styles}'
+            class='badge badge-${data.ColourType} pode-text'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             ${this.events(data.Events)}>
@@ -1318,8 +1378,7 @@ class PodeText extends PodeTextualElement {
     new(data, sender, opts) {
         var html = `<span
             id='${this.id}'
-            class='pode-text ${this.css.classes}'
-            style='${this.css.styles}'
+            class='pode-text'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 ${data.Value}
@@ -1363,7 +1422,7 @@ class PodeText extends PodeTextualElement {
             html = `<p class='text-${data.Alignment}'>${html}</p>`
         }
 
-        return html;
+        return `<span pode-container-for='${this.uuid}'>${html}</span>`;
     }
 
     static find(data, sender, filter, opts) {
@@ -1402,8 +1461,8 @@ class PodeSpinner extends PodeContentElement {
 
         return `<span
             id='${this.id}'
-            class="spinner-border spinner-border-sm ${this.css.classes}"
-            style="${colour} ${this.css.styles}"
+            class="spinner-border spinner-border-sm"
+            style="${colour}"
             role="status"
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
@@ -1425,8 +1484,7 @@ class PodeLink extends PodeTextualElement {
         return `<a
             href='${data.Source}'
             id='${this.id}'
-            class="pode-text ${this.css.classes}"
-            style="${this.css.styles}"
+            class="pode-text"
             target='${data.NewTab ? '_blank' : '_self'}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
@@ -1468,8 +1526,8 @@ class PodeIcon extends PodeContentElement {
 
         return `<span
             id='${this.id}'
-            class='mdi ${this.getName()} ${size} ${spin} ${flip} ${rotate} ${this.css.classes}'
-            style='${colour} ${this.css.styles}'
+            class='mdi ${this.getName()} ${size} ${spin} ${flip} ${rotate}'
+            style='${colour}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             ${title}
@@ -1525,8 +1583,7 @@ class PodeButton extends PodeFormElement {
             if (this.dynamic) {
                 html = `<button
                     type='button'
-                    class='btn btn-icon-only pode-button ${this.css.classes}'
-                    style='${this.css.styles}'
+                    class='btn btn-icon-only pode-button'
                     id='${this.id}'
                     name='${this.name}'
                     pode-data-value='${data.DataValue}'
@@ -1540,8 +1597,7 @@ class PodeButton extends PodeFormElement {
             else {
                 html = `<a
                     role='button'
-                    class='btn btn-icon-only pode-link-button ${this.css.classes}'
-                    style='${this.css.styles}'
+                    class='btn btn-icon-only pode-link-button'
                     id='${this.id}'
                     name='${this.name}'
                     pode-data-value='${data.DataValue}'
@@ -1564,8 +1620,7 @@ class PodeButton extends PodeFormElement {
             if (this.dynamic) {
                 html = `<button
                     type='button'
-                    class='btn btn-${colour} ${data.SizeType} pode-button ${this.css.classes}'
-                    style='${this.css.styles}'
+                    class='btn btn-${colour} ${data.SizeType} pode-button'
                     id='${this.id}'
                     name='${this.name}'
                     pode-data-value='${data.DataValue}'
@@ -1580,8 +1635,7 @@ class PodeButton extends PodeFormElement {
             else {
                 html = `<a
                     role='button'
-                    class='btn btn-${colour} ${data.SizeType} pode-link-button ${this.css.classes}'
-                    style='${this.css.styles}'
+                    class='btn btn-${colour} ${data.SizeType} pode-link-button'
                     id='${this.id}'
                     name='${this.name}'
                     href='${data.Url}'
@@ -1691,8 +1745,7 @@ class PodeContainer extends PodeContentElement {
     new(data, sender, opts) {
         return `<div
             id="${this.id}"
-            class="container pode-container ${this.css.classes}"
-            style="${this.css.styles}"
+            class="container pode-container"
             pode-object="${this.getType()}"
             pode-transparent="${data.NoBackground}"
             pode-hidden="${data.Hide}"
@@ -1724,8 +1777,7 @@ class PodeForm extends PodeContentElement {
         var html = `<form
             id="${this.id}"
             name="${this.name}"
-            class="pode-form ${this.css.classes}"
-            style="${this.css.styles}"
+            class="pode-form"
             method="${this.method}"
             action="${this.action}"
             pode-object="${this.getType()}"
@@ -1741,7 +1793,7 @@ class PodeForm extends PodeContentElement {
         </form>`;
 
         if (data.Message) {
-            html += `<p class='card-text'>${data.Message}</p>`;
+            html += `<p class='card-text' pode-container-for='${this.uuid}'>${data.Message}</p>`;
         }
 
         return html;
@@ -1874,8 +1926,7 @@ class PodeCard extends PodeContentElement {
 
         return `<div
             id="${this.id}"
-            class="card pode-card ${this.css.classes}"
-            style="${this.css.styles}"
+            class="card pode-card"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
                 ${header}
@@ -1905,8 +1956,7 @@ class PodeAlert extends PodeTextualElement {
     new(data, sender, opts) {
         return `<div
             id="${this.id}"
-            class="alert alert-${data.ClassType} ${this.css.classes}"
-            style="${this.css.styles}"
+            class="alert alert-${data.ClassType}"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'
             role="alert"
@@ -1981,36 +2031,37 @@ class PodeTable extends PodeRefreshableElement {
             </button>`;
         });
 
-        return `${msg}<div
-            id='${this.id}'
-            name='${this.name}'
-            class="${this.css.classes}"
-            style='${this.css.styles}'
-            role='table'
-            pode-object='${this.getType()}'
-            pode-id='${this.uuid}'
-            pode-data-column='${this.dataColumn}'>
-                ${filter}
-                <div class="table-responsive">
-                    <table
-                        class='table table-striped table-hover ${data.Compact ? 'table-sm' : ''} ${data.Click ? 'pode-table-click' : ''}'
-                        pode-dynamic='${this.dynamic}'>
-                            <thead></thead>
-                            <tbody></tbody>
-                    </table>
-                    <div class='text-center'>
-                        <span id='${this.id}_spinner' class='spinner-grow text-inbuilt-sec-theme' role='status' style='display: none'></span>
+        return `<span pode-container-for='${this.uuid}'>
+            ${msg}
+            <div
+                id='${this.id}'
+                name='${this.name}'
+                role='table'
+                pode-object='${this.getType()}'
+                pode-id='${this.uuid}'
+                pode-data-column='${this.dataColumn}'>
+                    ${filter}
+                    <div class="table-responsive">
+                        <table
+                            class='table table-striped table-hover ${data.Compact ? 'table-sm' : ''} ${data.Click ? 'pode-table-click' : ''}'
+                            pode-dynamic='${this.dynamic}'>
+                                <thead></thead>
+                                <tbody></tbody>
+                        </table>
+                        <div class='text-center'>
+                            <span id='${this.id}_spinner' class='spinner-grow text-inbuilt-sec-theme' role='status' style='display: none'></span>
+                        </div>
                     </div>
-                </div>
-                <div role='controls'>
-                    <div class="btn-group mr-2">
-                    ${this.buildRefreshButton(false)}
-                    ${exportBtn}
-                    ${customBtns}
+                    <div role='controls'>
+                        <div class="btn-group mr-2">
+                        ${this.buildRefreshButton(false)}
+                        ${exportBtn}
+                        ${customBtns}
+                        </div>
+                        ${paging}
                     </div>
-                    ${paging}
-                </div>
-        </div>`;
+            </div>
+        </span>`;
     }
 
     getPagingInfo() {
@@ -2478,7 +2529,7 @@ class PodeTable extends PodeRefreshableElement {
             });
 
             elements.forEach((e) => {
-                e.refresh(null, true).bind(data, sender, opts);
+                e.finalise(null, rowData, sender, true, opts);
             });
         }
 
@@ -2591,7 +2642,12 @@ class PodeTable extends PodeRefreshableElement {
                 if (Array.isArray(item[key]) || (item[key] && item[key].ObjectType)) {
                     renderResult = this.render(item[key], null, this, { subId: index });
                     value += renderResult.html;
-                    elements.push(...(renderResult.elements));
+                    convertToArray(renderResult.elements).forEach((e) => {
+                        elements.push({
+                            key: key,
+                            item: e
+                        });
+                    });
                 }
                 else if (item[key] != null) {
                     value += item[key];
@@ -2606,7 +2662,7 @@ class PodeTable extends PodeRefreshableElement {
             body.append(value);
 
             elements.forEach((e) => {
-                e.refresh(null, true).bind(data, sender, opts);
+                e.item.finalise(null, item[e.key], sender, true, opts);
             });
         });
 
@@ -2680,8 +2736,7 @@ class PodeAccordion extends PodeCyclingElement {
     new(data, sender, opts) {
         return `<div
             id="${this.id}"
-            class="accordion ${this.css.classes}"
-            style="${this.css.styles}"
+            class="accordion"
             name='${this.name}'
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
@@ -2721,8 +2776,7 @@ class PodeBellow extends PodeCyclingChildElement {
 
         return `<div
             id='${this.id}'
-            class='card bellow ${this.css.classes}'
-            style='${this.css.styles}'
+            class='card bellow'
             name='${this.name}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
@@ -2788,8 +2842,7 @@ class PodeParagraph extends PodeTextualElement {
     new(data, sender, opts) {
         return `<p
             id="${this.id}"
-            class="text-${data.Alignment} ${this.css.classes}"
-            style="${this.css.styles}"
+            class="text-${data.Alignment}"
             pode-object="${this.getType()}"
             pode-id="${this.uuid}">
                 <span pode-content-for='${this.uuid}' class='pode-text'>
@@ -2814,8 +2867,7 @@ class PodeHeader extends PodeTextualElement {
 
         return `<span
             id='${this.id}'
-            class='h${this.size} header d-block ${this.css.classes}'
-            style='${this.css.styles}'
+            class='h${this.size} header d-block'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 ${icon}
@@ -2867,13 +2919,13 @@ class PodeTextbox extends PodeFormElement {
         // multiline textbox
         if (this.multiline) {
             html = `<textarea
-                class='form-control ${this.css.classes}'
+                class='form-control'
                 id='${this.id}'
                 name='${this.name}'
                 pode-object='${this.getType()}'
                 pode-id='${this.uuid}'
                 rows='${data.Size}'
-                style='${width} ${this.css.styles}'
+                style='${width}'
                 ${placeholder}
                 ${autofocus}
                 ${events}
@@ -2897,12 +2949,12 @@ class PodeTextbox extends PodeFormElement {
 
             html += `<input
                 type='${inputType}'
-                class='form-control ${this.css.classes}'
+                class='form-control'
                 id='${this.id}'
                 name='${this.name}'
                 pode-object='${this.getType()}'
                 pode-id='${this.uuid}'
-                style='${width} ${this.css.styles}'
+                style='${width}'
                 placeholder='${data.Placeholder ?? ''}'
                 ${autofocus}
                 ${value}
@@ -2981,7 +3033,7 @@ class PodeFileUpload extends PodeFormElement {
     }
 
     new(data, sender, opts) {
-        return `<div class='custom-file'>
+        return `<div class='custom-file' pode-container-for='${this.uuid}'>
             <input
                 type='file'
                 class="custom-file-input"
@@ -2989,7 +3041,6 @@ class PodeFileUpload extends PodeFormElement {
                 name="${this.name}"
                 pode-object="${this.getType()}"
                 pode-id='${this.uuid}'
-                style="${this.css.styles}"
                 accept="${data.Accept}">
             <label class='custom-file-label' for='${this.id}'>Choose file</label>
         </div>`;
@@ -3026,8 +3077,7 @@ class PodeAudio extends PodeMediaElement {
         return `<audio
             id='${this.id}'
             name='${this.name}'
-            class='${this.css.classes}'
-            style="width:${data.Width};${this.css.styles}"
+            style="width:${data.Width}"
             pode-object="${this.getType()}"
             pode-id="${this.uuid}"
             ${!data.NoControls ? 'controls' : ''}
@@ -3069,8 +3119,7 @@ class PodeVideo extends PodeMediaElement {
         return `<video
             id='${this.id}'
             name='${this.name}'
-            class='${this.css.classes}'
-            style="width:${data.Width};height:${data.Height};${this.css.styles}"
+            style="width:${data.Width};height:${data.Height}"
             pode-object="${this.getType()}"
             pode-id="${this.uuid}"
             ${!data.NoControls ? 'controls' : ''}
@@ -3108,8 +3157,7 @@ class PodeCodeBlock extends PodeTextualElement {
     new(data, sender, opts) {
         return `<pre
             id="${this.id}"
-            class='code-block ${data.Scrollable ? 'pre-scrollable' : ''} ${this.css.classes}'
-            style="${this.css.styles}"
+            class='code-block ${data.Scrollable ? 'pre-scrollable' : ''}'
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
                 <button type='button' class='btn btn-icon-only pode-code-copy' title='Copy to clipboard' data-toggle='tooltip'>
@@ -3150,8 +3198,7 @@ class PodeCode extends PodeTextualElement {
     new(data, sender, opts) {
         return `<code
             id="${this.id}"
-            class="pode-text ${this.css.classes}"
-            style="${this.css.styles}"
+            class="pode-text"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
                 ${data.Value}
@@ -3172,8 +3219,7 @@ class PodeQuote extends PodeTextualElement {
 
         return `<blockquote
             id='${this.id}'
-            class='blockquote text-${data.Alignment} ${this.css.classes}'
-            style='${this.css.styles}'
+            class='blockquote text-${data.Alignment}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 <p class='pode-text mb-0'>${data.Value}</p>
@@ -3195,8 +3241,6 @@ class PodeIFrame extends PodeContentElement {
             src="${data.Url}"
             title="${data.Title}"
             id="${this.id}"
-            class="${this.css.classes}"
-            style="${this.css.styles}"
             name="${this.name}"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
@@ -3227,8 +3271,7 @@ class PodeLine extends PodeContentElement {
     new(data, sender, opts) {
         return `<hr
             id="${this.id}"
-            class="my-4 ${this.css.classes}"
-            style="${this.css.styles}"
+            class="my-4"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>`;
     }
@@ -3270,8 +3313,7 @@ class PodeTimer extends PodeContentElement {
         return `<span
             id="${this.id}"
             name='${this.name}'
-            class="hide pode-timer ${this.css.classes}"
-            style="${this.css.styles}"
+            class="hide pode-timer"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
         </span>`;
@@ -3312,8 +3354,8 @@ class PodeImage extends PodeContentElement {
         return `<img
             src='${data.Source}'
             id='${this.id}'
-            class='${fluid} rounded ${location} ${this.css.classes}'
-            style='height:${data.Height};width:${data.Width};${this.css.styles}'
+            class='${fluid} rounded ${location}'
+            style='height:${data.Height};width:${data.Width}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             ${title}
@@ -3334,8 +3376,7 @@ class PodeComment extends PodeContentElement {
 
         return `<div
             id="${this.id}"
-            class="media ${this.css.classes}"
-            style="${this.css.styles}"
+            class="media"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
                 <img src="${data.Icon}" class="align-self-start mr-3" alt="${data.Username} icon">
@@ -3365,8 +3406,7 @@ class PodeHero extends PodeContentElement {
 
         return `<div
             id="${this.id}"
-            class="jumbotron ${this.css.classes}"
-            style="${this.css.styles}"
+            class="jumbotron"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
                 <h1 class="display-4">${data.Title}</h1>
@@ -3391,8 +3431,7 @@ class PodeTile extends PodeRefreshableElement {
 
         return `<div
             id="${this.id}"
-            class="container pode-tile alert-${data.ColourType} rounded ${this.css.classes}"
-            style="${this.css.styles}"
+            class="container pode-tile alert-${data.ColourType} rounded"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'
             name="${this.name}">
@@ -3469,8 +3508,7 @@ class PodeGrid extends PodeContentElement {
 
         return `<div
             id="${this.id}"
-            class="container pode-grid ${this.css.classes}"
-            style="${this.css.styles}"
+            class="container pode-grid"
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'>
                 ${rows}
@@ -3498,8 +3536,7 @@ class PodeCell extends PodeContentElement {
 
         html += `<div
             id='${this.id}'
-            class='text-${data.Alignment} ${width} ${this.css.classes}'
-            style='${this.css.styles}'
+            class='text-${data.Alignment} ${width}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 <div pode-content-for='${this.uuid}'></div>
@@ -3528,8 +3565,6 @@ class PodeTabs extends PodeCyclingElement {
     new(data, sender, opts) {
         return `<div
             id="${this.id}"
-            class="${this.css.classes}"
-            style="${this.css.styles}"
             pode-object="${this.getType()}"
             pode-id="${this.uuid}">
                 <ul class="nav nav-tabs" role="tablist"></ul>
@@ -3582,8 +3617,7 @@ class PodeTab extends PodeCyclingChildElement {
     new(data, sender, opts) {
         return `<div
             id='${this.id}_content'
-            class='tab-pane fade show ${this.child.isFirst ? 'active' : ''} ${this.css.classes}'
-            style='${this.css.styles}'
+            class='tab-pane fade show ${this.child.isFirst ? 'active' : ''}'
             pode-object="${this.getType()}"
             pode-id="${this.uuid}"
             role='tabpanel'
@@ -3627,8 +3661,7 @@ class PodeCarousel extends PodeCyclingElement {
     new(data, sender, opts) {
         return `<div
             id="${this.id}"
-            class="carousel slide ${this.css.classes}"
-            style="${this.css.styles}"
+            class="carousel slide"
             data-ride="carousel"
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
@@ -3687,8 +3720,7 @@ class PodeSlide extends PodeCyclingChildElement {
 
         return `<div
             id='${this.id}'
-            class='carousel-item ${this.child.isFirst ? 'active' : ''} ${this.css.classes}'
-            style='${this.css.styles}'
+            class='carousel-item ${this.child.isFirst ? 'active' : ''}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 <div class='d-flex w-100 h-100' pode-content-for='${this.uuid}'></div>
@@ -3732,8 +3764,7 @@ class PodeCodeEditor extends PodeContentElement {
         return `<div
             id="${this.id}"
             name="${this.name}"
-            class="pode-code-editor ${this.css.classes}"
-            style="${this.css.styles}"
+            class="pode-code-editor"
             pode-object="${this.getType()}"
             pode-id="${this.uuid}"
             ${this.events(data.Events)}>
@@ -3843,8 +3874,6 @@ class PodeChart extends PodeRefreshableElement {
         return `${message}<div
             id="${this.id}"
             name="${this.name}"
-            class="${this.css.classes}"
-            style="${this.css.styles}"
             role='chart'
             pode-object="${this.getType()}"
             pode-id="${this.uuid}">
@@ -4117,8 +4146,7 @@ class PodeModal extends PodeContentElement {
 
         return `<div
             id="${this.id}"
-            class="modal fade ${this.css.classes}"
-            style="${this.css.styles}"
+            class="modal fade"
             pode-object="${this.getType()}"
             pode-id="${this.uuid}"
             name="${this.name}"
@@ -4273,8 +4301,6 @@ class PodeList extends PodeContentElement {
 
         return `<${listTag}
             id='${this.id}'
-            class='${this.css.classes}'
-            style='${this.css.styles}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 ${content}
@@ -4293,8 +4319,6 @@ class PodeListItem extends PodeContentElement {
     new(data, sender, opts) {
         return `<li
             id='${this.id}'
-            class='${this.css.classes}'
-            style='${this.css.styles}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 <span pode-content-for='${this.uuid}'></span>
@@ -4316,8 +4340,7 @@ class PodeHidden extends PodeFormElement {
         return `<input
             type="hidden"
             id="${this.id}"
-            class="form-control ${this.css.classes}"
-            style="${this.css.styles}"
+            class="form-control"
             name="${this.name}"
             value="${data.Value}"
             pode-object="${this.getType()}"
@@ -4358,8 +4381,7 @@ class PodeSelect extends PodeFormElement {
 
         return `<select
             id='${this.id}'
-            class='custom-select ${this.css.classes}'
-            style='${this.css.styles}'
+            class='custom-select'
             name='${this.name}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
@@ -4434,7 +4456,7 @@ class PodeRange extends PodeFormElement {
             max='${data.Max}'>
         <label class=''>/${data.Max}</label>`;
 
-        return `<span class='range-wrapper ${this.css.classes}' style='${this.css.styles}' for='${this.id}'>
+        return `<span class='range-wrapper' for='${this.id}' pode-container-for='${this.uuid}'>
             <input
                 type='range'
                 id='${this.id}'
@@ -4497,14 +4519,13 @@ class PodeProgress extends PodeContentElement {
         var striped = this.striped ? 'progress-bar-striped' : '';
         var animated = this.animated ? 'progress-bar-animated' : '';
 
-        var html = `<div
-            class='progress'>
+        var html = `<div class='progress'>
                 <div
                     id='${this.id}'
                     name='${this.name}'
-                    class='progress-bar bg-${data.ColourType ?? 'primary'} ${showValue} ${striped} ${animated} ${this.css.classes}'
+                    class='progress-bar bg-${data.ColourType ?? 'primary'} ${showValue} ${striped} ${animated}'
                     role='progressbar'
-                    style='width: ${data.Percentage ?? 0}%;${this.css.styles}'
+                    style='width: ${data.Percentage ?? 0}%'
                     aria-valuenow='${data.Value ?? 0}'
                     aria-valuemin='${data.Min ?? 0}'
                     aria-valuemax='${data.Max ?? 100}'
@@ -4521,7 +4542,7 @@ class PodeProgress extends PodeContentElement {
             </div>`;
         }
 
-        return html;
+        return `<span pode-container-for='${this.uuid}'>${html}<span>`;
     }
 
     load(data, sender, opts) {
@@ -4587,7 +4608,7 @@ class PodeCheckbox extends PodeFormElement {
                 return;
             }
 
-            options += `<div class='custom-control ${divClass} ${inline} ${this.css.classes}' style='${this.css.styles}'>
+            options += `<div class='custom-control ${divClass} ${inline}'>
                 <input
                     type='checkbox'
                     id='${this.id}_option${index}'
@@ -4602,7 +4623,7 @@ class PodeCheckbox extends PodeFormElement {
             </div>`;
         });
 
-        return `<div'>${options}</div>`;
+        return `<div pode-container-for='${this.uuid}'>${options}</div>`;
     }
 
     update(data, sender, opts) {
@@ -4679,7 +4700,7 @@ class PodeRadio extends PodeFormElement {
                 return;
             }
 
-            options += `<div class='custom-control custom-radio ${inline} ${this.css.classes}' style='${this.css.styles}'>
+            options += `<div class='custom-control custom-radio ${inline}'>
                 <input
                     type='radio'
                     id='${this.id}_option${index}'
@@ -4694,7 +4715,7 @@ class PodeRadio extends PodeFormElement {
             </div>`;
         });
 
-        return `<div>${options}</div>`;
+        return `<div pode-container-for='${this.uuid}'>${options}</div>`;
     }
 
     //TODO: same as the comment for "select" - CheckboxOption ?
@@ -4884,8 +4905,7 @@ class PodeFileStream extends PodeContentElement {
         return `<div
             id='${this.id}'
             name='${this.name}'
-            class="card file-stream ${this.css.classes}"
-            style='${this.css.styles}'
+            class="card file-stream"
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'>
                 ${header}
@@ -5039,8 +5059,7 @@ class PodeSteps extends PodeContentElement {
     new(data, sender, opts) {
         return `<div
             id="${this.id}"
-            class="bs-stepper linear ${this.css.classes}"
-            style="${this.css.styles}"
+            class="bs-stepper linear"
             role="stepper"
             pode-object="${this.getType()}"
             pode-id="${this.uuid}">
@@ -5117,8 +5136,7 @@ class PodeStep extends PodeContentElement {
 
         return `<div
             id='${this.id}'
-            class='bs-stepper-pane content fade ${this.child.isFirst ? 'active' : ''} ${this.css.classes}'
-            style='${this.css.styles}'
+            class='bs-stepper-pane content fade ${this.child.isFirst ? 'active' : ''}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             role='tabpanel'
@@ -5211,8 +5229,6 @@ class PodeBreadcrumb extends PodeBreadcrumbElement {
 
         return `<div
             id='${this.id}'
-            class='${this.css.classes}'
-            style='${this.css.styles}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             pode-content-for='${this.uuid}'>
@@ -5249,8 +5265,7 @@ class PodeBreadcrumbItem extends PodeBreadcrumbElement {
         }
 
         return `<li
-            class='breadcrumb-item d-inline-block ${data.Active ? 'active' : ''} ${this.css.classes}'
-            style='${this.css.styles}'
+            class='breadcrumb-item d-inline-block ${data.Active ? 'active' : ''}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             ${data.Active ? "aria-current='page'" : ''}>


### PR DESCRIPTION
### Description of the Change
* Renames `Add-PodeWebElementClass` and `Remove-PodeWebElementClass` to `Add-PodeWebClass` and `Remove-PodeWebClass` respectively. Also renames their `-Class` parameter to `-Value`.
* Renames `Set-PodeWebElementStyle` and `Remove-PodeWebElementStyle` to `Add-PodeWebStyle` and `Remove-PodeWebStyle` respectively. Also renames their `-Property` parameter to `-Key`.
* Adds two new `Add-PodeWebAttribute` and `Remove-PodeWebAttribute` actions.
* Removes `-CssClass` and `-CssStyle` from all elements, instead they should be piped into the above `Add-` actions now.
* Centalises the setting of class/style on the frontend into the PodeElement class - including attributes.
* Each of the above action functions, plus `Hide-PodeWebElement`, now have a new `-Element` parameter. This parameter is solely for piping in `New-` elements to add class, styles, attributes, or hide the element on creation.

### Related Issue
Resolves #447 and #448

### Examples
* Add class:
```powershell
New-PodeWebTextbox -Name 'Message' |
    Add-PodeWebClass -Value 'my-custom-textbox'
```

* Add style:
```powershell
New-PodeWebParagraph -Content @(
    New-PodeWebText -Value 'And then here is some more text, that also includes a '
    New-PodeWebLink -Value 'link' -Source 'https://google.com'
    New-PodeWebText -Value ' that takes you to Google'
) |
    Add-PodeWebStyle -Key 'color' -Value 'yellow'
```

* Add attribute:
```powershell
New-PodeWebButton -Name 'Example' -ScriptBlock {} |
    Add-PodeWebAttribute -Key 'hx-confirm' -Value 'Are you sure?'
```

* Hide on creation:
```powershell
New-PodeWebTextbox -Name 'Message' |
    Hide-PodeWebElement
```