### PR TITLE
Add Update-PodeWebImage support

### DIFF
--- a/docs/Tutorials/Actions/Image.md
+++ b/docs/Tutorials/Actions/Image.md
@@ -1,0 +1,18 @@
+# Images
+
+This page details the actions available to Image elements.
+
+## Update
+
+To update the source, title, or size of an Image element, you can use [`Update-PodeWebImage`](../../../Functions/Actions/Update-PodeWebImage):
+
+```powershell
+New-PodeWebContainer -Content @(
+    New-PodeWebImage -Id 'my-image' -Source 'https://raw.githubusercontent.com/Badgerati/Pode.Web/develop/src/Templates/Public/images/icon.png' -Height 70
+
+    New-PodeWebButton -Name 'Update Image' -ScriptBlock {
+        $value = Get-Random -Minimum 70 -Maximum 141
+        Update-PodeWebImage -Id 'my-image' -Title "Example$($value)" -Height $value
+    }
+)
+```

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -93,7 +93,11 @@ Start-PodeServer -StatusPageExceptions Show {
             New-PodeWebCode -Id 'code_test' -Value "some code :o"
         )
         $timer1
-        New-PodeWebImage -Source '/pode.web/images/icon.png' -Height 70 -Alignment Right
+        New-PodeWebImage -Id 'pode-img' -Source '/pode.web/images/icon.png' -Height 70 -Alignment Right |
+            Register-PodeWebEvent -Type Click -NoAuth -ScriptBlock {
+                $value = Get-Random -Minimum 70 -Maximum 141
+                Update-PodeWebImage -Id 'pode-img' -Title "Hello$($value)!" -Height $value
+            }
         New-PodeWebQuote -Value 'Pode is awesome!' -Source 'Badgerati'
         New-PodeWebButton -Name 'Click Me' -DataValue 'PowerShell Rules!' -NoAuth -Icon 'console-line' -Colour Green -ScriptBlock {
             Show-PodeWebToast -Message "Message of the day: $($WebEvent.Data.Value)"

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -852,8 +852,15 @@ function ConvertTo-PodeWebSize
         [Parameter(Mandatory=$true)]
         [ValidateSet('px', '%', 'em')]
         [string]
-        $Type
+        $Type,
+
+        [switch]
+        $AllowNull
     )
+
+    if ($AllowNull -and [string]::IsNullOrEmpty($Value)) {
+        return $null
+    }
 
     $pattern = Get-PodeWebNumberRegex
     $defIsNumber = ($Default -match $pattern)

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -2264,3 +2264,39 @@ function Update-PodeWebHeader
         Size = $Size
     }
 }
+
+function Update-PodeWebImage
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Source,
+
+        [Parameter()]
+        [string]
+        $Title,
+
+        [Parameter()]
+        [string]
+        $Height,
+
+        [Parameter()]
+        [string]
+        $Width
+    )
+
+    return @{
+        Operation = 'Update'
+        ObjectType = 'Image'
+        ID = $Id
+        Source = (Add-PodeWebAppPath -Url $Source)
+        Title = $Title
+        Height = (ConvertTo-PodeWebSize -Value $Height -Default 'auto' -Type 'px' -AllowNull)
+        Width = (ConvertTo-PodeWebSize -Value $Width -Default 'auto' -Type 'px' -AllowNull)
+    }
+}

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -767,9 +767,9 @@ function resetForm(form, isInner = false) {
     }
 }
 
-function setElementStyle(obj, property, value) {
+function setElementStyle(obj, property, value, notImportant) {
     if (value) {
-        obj.style.setProperty(property, value, 'important');
+        obj.style.setProperty(property, value, (notImportant ? undefined : 'important'));
     }
     else {
         obj.style.setProperty(property, null);


### PR DESCRIPTION
### Description of the Change
Adds a new `Update-PodeWebImage` action, so we can update the source, title, height, and/or width of an image.

### Related Issue
Resolves #362 

### Examples
```powershell
New-PodeWebContainer -Content @(
    New-PodeWebImage -Id 'my-image' -Source 'https://raw.githubusercontent.com/Badgerati/Pode.Web/develop/src/Templates/Public/images/icon.png' -Height 70
    New-PodeWebButton -Name 'Update Image' -ScriptBlock {
        $value = Get-Random -Minimum 70 -Maximum 141
        Update-PodeWebImage -Id 'my-image' -Title "Example$($value)" -Height $value
    }
)
```
