### PR TITLE
Add actions for Icons, Toggle/Hover support, and -Icon parameter can now accept New-PodeWebIcon

### DIFF
--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -141,3 +141,17 @@ The `-Component` parameter on `Register-PodeWebEvent` and `Register-PodeWebMedia
 ## ReadOnly and Disabled
 
 In some places the ReadOnly/Disabled parameters were being used as if they were the same thing - these have been split out into two different parameters. Because of this split, the `-ReadOnly` parameter on `New-PodeWebSelect` is now `-Disabled`, and its counterpart of `Update-PodeWebSelect` has had its `-ReadOnlyState` parameter renamed to `-DisabledState`.
+
+## Icons
+
+### Login Page
+
+This was already deprecated previously in in v0.X release, but: the old `-Icon` and `-IconUrl` aliases, for `-Logo` and `-LogoUrl` respectively, have now been removed.
+
+### Notifications
+
+The `-Icon` parameter on `Show-PodeWebNotification` has been renamed to `-IconUrl` - to signify that it's not a Material Design Icon, but instead a URL path to an image file.
+
+### Comments
+
+The `-Icon` parameter on `New-PodeWebComment` has been renamed to `-AvatarUrl` - to signify that it's not a Material Design Icon, but instead a URL path to an image file.

--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -146,7 +146,7 @@ In some places the ReadOnly/Disabled parameters were being used as if they were 
 
 ### Login Page
 
-This was already deprecated previously in in v0.X release, but: the old `-Icon` and `-IconUrl` aliases, for `-Logo` and `-LogoUrl` respectively, have now been removed.
+This was already deprecated previously in in v0.X release, but: the old `-Icon` and `-IconUrl` aliases, for `-Logo` and `-LogoUrl` respectively, have now been removed on `Set-PodeWebLoginPage`.
 
 ### Notifications
 

--- a/docs/Tutorials/Actions/Elements.md
+++ b/docs/Tutorials/Actions/Elements.md
@@ -76,6 +76,30 @@ Remove-PodeWebClass -Type 'Textbox' -Name 'SomeTextboxName' -Value 'my-custom-cl
 Remove-PodeWebClass -Id 'textbox_somename' -Value 'my-custom-class'
 ```
 
+### Rename
+
+You can rename one class to another class on an element by using [`Rename-PodeWebClass`]. You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+
+```powershell
+Rename-PodeWebClass -Type 'Textbox' -Name 'SomeTextboxName' -From 'my-custom-class' -To 'my-other-class'
+
+# or
+
+Rename-PodeWebClass -Id 'textbox_somename' -From 'my-custom-class' -To 'my-other-class'
+```
+
+### Switch
+
+You can toggle a class to be added/removed by using [`Switch-PodeWebClass`]. By default this will toggle a class between being added/removed, but you can specify the state to be added or removed by supplying the `-State` parameter. You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+
+```powershell
+Switch-PodeWebClass -Type 'Textbox' -Name 'SomeTextboxName' -Value 'my-custom-class'
+
+# or
+
+Switch-PodeWebClass -Id 'textbox_somename' -Value 'my-custom-class' -State Remove
+```
+
 ## Styles
 
 ### Add

--- a/docs/Tutorials/Actions/Elements.md
+++ b/docs/Tutorials/Actions/Elements.md
@@ -78,7 +78,7 @@ Remove-PodeWebClass -Id 'textbox_somename' -Value 'my-custom-class'
 
 ### Rename
 
-You can rename one class to another class on an element by using [`Rename-PodeWebClass`]. You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+You can rename one class to another class on an element by using [`Rename-PodeWebClass`](../../../Functions/Actions/Rename-PodeWebClass). You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
 
 ```powershell
 Rename-PodeWebClass -Type 'Textbox' -Name 'SomeTextboxName' -From 'my-custom-class' -To 'my-other-class'
@@ -90,7 +90,7 @@ Rename-PodeWebClass -Id 'textbox_somename' -From 'my-custom-class' -To 'my-other
 
 ### Switch
 
-You can toggle a class to be added/removed by using [`Switch-PodeWebClass`]. By default this will toggle a class between being added/removed, but you can specify the state to be added or removed by supplying the `-State` parameter. You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
+You can toggle a class to be added/removed by using [`Switch-PodeWebClass`](../../../Functions/Actions/Switch-PodeWebClass). By default this will toggle a class between being added/removed, but you can specify the state to be added or removed by supplying the `-State` parameter. You can update an element either by `-Id`, or by the element's `-Name` and `-Type`:
 
 ```powershell
 Switch-PodeWebClass -Type 'Textbox' -Name 'SomeTextboxName' -Value 'my-custom-class'

--- a/docs/Tutorials/Actions/Icon.md
+++ b/docs/Tutorials/Actions/Icon.md
@@ -1,0 +1,41 @@
+# Icons
+
+This page details the actions available to Icon elements.
+
+## Update
+
+To update the name, colour, size, etc. of an Icon element, you can use [`Update-PodeWebIcon`](../../../Functions/Actions/Update-PodeWebIcon):
+
+```powershell
+New-PodeWebContainer -Content @(
+    New-PodeWebIcon -Id 'my-icon' -Name 'home' -Spin
+
+    New-PodeWebButton -Name 'Update Icon' -ScriptBlock {
+        Update-PodeWebIcon -Id 'my-icon' -Name 'cat' -Colour 'yellow' -Spin:$false
+    }
+)
+```
+
+## Switch
+
+To switch the state of an Icon between the Base/Toggle presets, or specifically to either the Base, Toggle or Hover presets via the `-State` parameter, you can use [`Switch-PodeWebIcon`]:
+
+```powershell
+New-PodeWebContainer -Content @(
+    $toggle = New-PodeWebIcon -Id 'my-icon' -Name 'home' -Spin
+    New-PodeWebIcon -Id 'my-icon' -Name 'home' -ToggleIcon $toggle
+
+    # swap between base/toggle
+    New-PodeWebButton -Name 'Switch Icon - Default' -ScriptBlock {
+        Switch-PodeWebIcon -Id 'my-icon'
+    }
+
+    # swap to only toggle
+    New-PodeWebButton -Name 'Switch Icon - Default' -ScriptBlock {
+        Switch-PodeWebIcon -Id 'my-icon' -State Toggle
+    }
+)
+```
+
+!!! note
+    The default behaviour without `-State` is to swap between the Base and Toggle icons.

--- a/docs/Tutorials/Actions/Icon.md
+++ b/docs/Tutorials/Actions/Icon.md
@@ -18,7 +18,7 @@ New-PodeWebContainer -Content @(
 
 ## Switch
 
-To switch the state of an Icon between the Base/Toggle presets, or specifically to either the Base, Toggle or Hover presets via the `-State` parameter, you can use [`Switch-PodeWebIcon`]:
+To switch the state of an Icon between the Base/Toggle presets, or specifically to either the Base, Toggle or Hover presets via the `-State` parameter, you can use [`Switch-PodeWebIcon`](../../../Functions/Actions/Switch-PodeWebIcon):
 
 ```powershell
 New-PodeWebContainer -Content @(

--- a/docs/Tutorials/Elements/Icon.md
+++ b/docs/Tutorials/Elements/Icon.md
@@ -48,7 +48,7 @@ New-PodeWebIcon -Name 'home' -Size 40
 
 ### Toggle
 
-You can set a predefined icon set for icon toggling by passing a new icon to the `-ToggleIcon` parameter. To create the icon preset use the [`New-PodeWebIconPreset`] function - this has the `-Name` and other parameters as optional, and if not defined the base Icon's details are used instead. To swap from the base icon to the toggle icon you can use the [`Switch-PodeWebIcon`] action function as detailed [here](../../Actions/Icon#switch).
+You can set a predefined icon set for icon toggling by passing a new icon to the `-ToggleIcon` parameter. To create the icon preset use the [`New-PodeWebIconPreset`](../../../Functions/Elements/New-PodeWebIconPreset) function - this has the `-Name` and other parameters as optional, and if not defined the base Icon's details are used instead. To swap from the base icon to the toggle icon you can use the [`Switch-PodeWebIcon`](../../../Functions/Actions/Switch-PodeWebIcon) action function as detailed [here](../../Actions/Icon#switch).
 
 For example:
 
@@ -64,7 +64,7 @@ New-PodeWebIcon -Name 'home' -ToggleIcon $toggle
 
 ### Hover
 
-Similar to the toggle icon preset above, you can do the same with a hover icon preset by supplying a [`New-PodeWebIconPreset`] to the `-HoverIcon` parameter. This icon can also be switched to by using [`Switch-PodeWebIcon`] as well, but with a hover icon Pode.Web will automatically swap to this icon when the icon is hovered over.
+Similar to the toggle icon preset above, you can do the same with a hover icon preset by supplying a [`New-PodeWebIconPreset`](../../../Functions/Elements/New-PodeWebIconPreset) to the `-HoverIcon` parameter. This icon can also be switched to by using [`Switch-PodeWebIcon`](../../../Functions/Actions/Switch-PodeWebIcon) as well, but with a hover icon Pode.Web will automatically swap to this icon when the icon is hovered over.
 
 ```powershell
 # this will add a hover icon to change from outlined checkbox to a full one on hover

--- a/docs/Tutorials/Elements/Icon.md
+++ b/docs/Tutorials/Elements/Icon.md
@@ -32,3 +32,42 @@ You can rotate an icon by a fixed number of degrees by supplying a value, 45-315
 ### Spin
 
 You can make an icon spin by supplying the `-Spin` switch.
+
+## Size
+
+By default the size of the icon is based on the element the icon is within - such as a paragraph or a header. However, you can override this size by supplying a value for the `-Size` parameter.
+
+!!! important
+    The `-Size` parameter only accepts value between 0-50, and in increments of 5. A value of 0 will use the default sizing rules for icons.
+
+```powershell
+New-PodeWebIcon -Name 'home' -Size 40
+```
+
+## Icon Presets
+
+### Toggle
+
+You can set a predefined icon set for icon toggling by passing a new icon to the `-ToggleIcon` parameter. To create the icon preset use the [`New-PodeWebIconPreset`] function - this has the `-Name` and other parameters as optional, and if not defined the base Icon's details are used instead. To swap from the base icon to the toggle icon you can use the [`Switch-PodeWebIcon`] action function as detailed [here](../../Actions/Icon#switch).
+
+For example:
+
+```powershell
+# this will add a toggle icon to make the base icon go yellow and spin:
+$toggle = New-PodeWebIconPreset -Colour Yellow -Spin
+New-PodeWebIcon -Name 'cat' -ToggleIcon $toggle
+
+# this will add a toggle icon to change the base icon completely
+$toggle = New-PodeWebIconPreset -Name 'cat'
+New-PodeWebIcon -Name 'home' -ToggleIcon $toggle
+```
+
+### Hover
+
+Similar to the toggle icon preset above, you can do the same with a hover icon preset by supplying a [`New-PodeWebIconPreset`] to the `-HoverIcon` parameter. This icon can also be switched to by using [`Switch-PodeWebIcon`] as well, but with a hover icon Pode.Web will automatically swap to this icon when the icon is hovered over.
+
+```powershell
+# this will add a hover icon to change from outlined checkbox to a full one on hover
+$hover = New-PodeWebIconPreset -Name 'mdi-checkbox-multiple-marked'
+New-PodeWebIcon -Name 'mdi-checkbox-multiple-marked-outline' -HoverIcon $hover
+```

--- a/docs/Tutorials/Icons.md
+++ b/docs/Tutorials/Icons.md
@@ -1,8 +1,8 @@
 # Icons
 
-All icons rendered in Pode.Web are done using [Material Design Icons](https://materialdesignicons.com). This applies to pretty much all `-Icon` parameters, except for the one on [`Set-PodeWebLoginPage`](../../Functions/Pages/Set-PodeWebLoginPage) which is actually the path to an image (This has been changed to `-Logo`, though `-Icon` is still an alias for now).
+All icons rendered in Pode.Web are done using [Material Design Icons](https://materialdesignicons.com), this applies to all `-Icon` parameters.
 
-A list of searchable icons can be [found here](https://pictogrammers.github.io/@mdi/font/5.4.55/). When you've found the one you need, you only have to supply the part after `mdi-`. For example let's say you need the `mdi-github` icon, then you only need to supply the `github` part:
+A list of searchable icons can be [found here](https://pictogrammers.github.io/@mdi/font/7.2.96/). When you've found the one you need, you only have to supply the partof the name after `mdi-`. For example let's say you need the `mdi-github` icon, then you only need to supply the `github` part of the name:
 
 ```powershell
 New-PodeWebButton -Name 'Repository' -Icon 'github' -Url 'https://github.com/Badgerati/Pode.Web'
@@ -11,3 +11,19 @@ New-PodeWebButton -Name 'Repository' -Icon 'github' -Url 'https://github.com/Bad
 Which would look like below:
 
 ![icon_example](../../images/icon_example.png)
+
+## Name or Element
+
+On elements such as a Button ([`New-PodeWebButton`]), when you supply the `-Icon` parameter this can be done in one of two ways:
+
+1. You can supply just the name of the icon, such as the example at the top of this page.
+2. You can supply a more dynamic icon by using [`New-PodeWebIcon`] instead.
+
+In the case of 2., the following is the same example as above but using [`New-PodeWebIcon`] instead:
+
+```powershell
+$icon = New-PodeWebIcon -Name 'github' -Spin
+New-PodeWebButton -Name 'Repository' -Icon $icon -Url 'https://github.com/Badgerati/Pode.Web'
+```
+
+Notice this time though, the icon is set to spin instead!

--- a/docs/Tutorials/Icons.md
+++ b/docs/Tutorials/Icons.md
@@ -14,12 +14,12 @@ Which would look like below:
 
 ## Name or Element
 
-On elements such as a Button ([`New-PodeWebButton`]), when you supply the `-Icon` parameter this can be done in one of two ways:
+On elements such as a Button ([`New-PodeWebButton`](../../Functions/Elements/New-PodeWebButton)), when you supply the `-Icon` parameter this can be done in one of two ways:
 
 1. You can supply just the name of the icon, such as the example at the top of this page.
-2. You can supply a more dynamic icon by using [`New-PodeWebIcon`] instead.
+2. You can supply a more dynamic icon by using [`New-PodeWebIcon`](../../Functions/Elements/New-PodeWebIcon) instead.
 
-In the case of 2., the following is the same example as above but using [`New-PodeWebIcon`] instead:
+In the case of 2., the following is the same example as above but using [`New-PodeWebIcon`](../../Functions/Elements/New-PodeWebIcon) instead:
 
 ```powershell
 $icon = New-PodeWebIcon -Name 'github' -Spin

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -136,8 +136,8 @@ Start-PodeServer -StatusPageExceptions Show {
     )
 
     $section3 = New-PodeWebCard -Name 'Comments' -Icon 'comment' -Content @(
-        New-PodeWebComment -Icon '/pode.web/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
-        New-PodeWebComment -Icon '/pode.web/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
+        New-PodeWebComment -AvatarUrl '/pode.web/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
+        New-PodeWebComment -AvatarUrl '/pode.web/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
     )
 
     $codeEditor = New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor' -AsCard
@@ -187,7 +187,7 @@ Start-PodeServer -StatusPageExceptions Show {
     $hero = New-PodeWebHero -Title 'Welcome!' -Message 'This is the home page for the full.ps1 example' -Content @(
         New-PodeWebText -Value 'Here you will see examples for close to everything Pode.Web can do.' -InParagraph -Alignment Center
         New-PodeWebParagraph -Alignment Center -Content @(
-            New-PodeWebButton -Name 'Repository' -Icon Link -Url 'https://github.com/Badgerati/Pode.Web' -NewTab
+            New-PodeWebButton -Name 'Repository' -Icon (New-PodeWebIcon -Name Link -HoverIcon (New-PodeWebIconPreset -Spin)) -Url 'https://github.com/Badgerati/Pode.Web' -NewTab
         )
     )
 
@@ -223,7 +223,7 @@ Start-PodeServer -StatusPageExceptions Show {
         New-PodeWebTab -Name 'Bar' -Icon 'chart-bar' -Content @(
             New-PodeWebChart -Name 'Bar Example 2' -NoAuth -Type Bar -ScriptBlock $chartData -AsCard
         )
-        New-PodeWebTab -Name 'Doughnut' -Icon 'chart-donut' -Content @(
+        New-PodeWebTab -Name 'Doughnut' -Icon (New-PodeWebIcon -Name 'chart-donut' -HoverIcon (New-PodeWebIconPreset -Spin)) -Content @(
             New-PodeWebChart -Name 'Doughnut Example 1' -NoAuth -Type Doughnut -ScriptBlock $chartData -AsCard
         )
     )
@@ -290,7 +290,10 @@ Start-PodeServer -StatusPageExceptions Show {
                 Actions = $btns
             }
         }
-    }
+    } `
+    -Columns @(
+        Initialize-PodeWebTableColumn -Key Actions -Alignment Center
+    )
 
     Add-PodeStaticRoute -Path '/download' -Source '.\storage' -DownloadOnly
 

--- a/examples/icons.ps1
+++ b/examples/icons.ps1
@@ -11,7 +11,7 @@ Start-PodeServer -Threads 2 {
 
     # set the home page controls
     $card1 = New-PodeWebCard -Content @(
-        New-PodeWebIcon -Name 'refresh'
+        New-PodeWebIcon -Name 'refresh' -Id 'refresh-icon' -HoverIcon (New-PodeWebIconPreset -Colour Green -Spin)
         New-PodeWebIcon -Name 'refresh' -Colour Green
         New-PodeWebIcon -Name 'refresh' -Flip Horizontal
         New-PodeWebIcon -Name 'refresh' -Rotate 180
@@ -19,6 +19,13 @@ Start-PodeServer -Threads 2 {
     )
 
     $card2 = New-PodeWebCard -Content @(
+        New-PodeWebButton -Name 'Update' -ScriptBlock {
+            Update-PodeWebIcon -Id 'refresh-icon' -Name 'cat' -Colour Yellow -Title 'Cat' -Size 40
+            # Switch-PodeWebIcon -Id 'refresh-icon'
+        }
+    )
+
+    $card3 = New-PodeWebCard -Content @(
         New-PodeWebTable -Name Example -ScriptBlock {
             return @{
                 Icon = (New-PodeWebIcon -Name 'refresh' -Spin -Colour Yellow |
@@ -29,5 +36,5 @@ Start-PodeServer -Threads 2 {
         }
     )
 
-    Set-PodeWebHomePage -Content $card1, $card2 -Title 'Icons'
+    Set-PodeWebHomePage -Content $card1, $card2, $card3 -Title 'Icons'
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -942,3 +942,97 @@ function Set-PodeWebSecurity
         -Scripts 'self', 'unsafe-inline' `
         -Image 'self', 'data'
 }
+
+function Test-PodeWebParameter
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        $Parameters,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        $Value
+    )
+
+    if ($Parameters.ContainsKey($Name)) {
+        return $Value
+    }
+
+    return $null
+}
+
+function Protect-PodeWebIconType
+{
+    param(
+        [Parameter()]
+        [object]
+        $Icon,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Element
+    )
+
+    # just null or string
+    if (($null -eq $Icon) -or ($Icon -is [string])) {
+        return $Icon
+    }
+
+    # if hashtable, check object type
+    if (($Icon -is [hashtable]) -and ($Icon.ObjectType -ieq 'icon')) {
+        return $Icon
+    }
+
+    # error
+    throw "Icon for '$($Element)' is not a string or hashtable from New-PodeWebIcon"
+}
+
+function Protect-PodeWebIconPreset
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]
+        $Icon,
+
+        [Parameter()]
+        [hashtable]
+        $Preset
+    )
+
+    if (($null -eq $Preset) -or ($Preset.Length -eq 0)) {
+        return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Preset.Name)) {
+        $Preset.Name = $Icon.Name
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Preset.Colour)) {
+        $Preset.Colour = $Icon.Colour
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Preset.Title)) {
+        $Preset.Title = $Icon.Title
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Preset.Flip)) {
+        $Preset.Flip = $Icon.Flip
+    }
+
+    if ($Preset.Rotate -le -1) {
+        $Preset.Rotate = $Icon.Rotate
+    }
+
+    if ($Preset.Size -le -1) {
+        $Preset.Size = $Icon.Size
+    }
+
+    if ($null -eq $Preset.Spin) {
+        $Preset.Spin = $Icon.Spin
+    }
+
+    return $Preset
+}

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -132,7 +132,7 @@ function New-PodeWebTab
         $Content,
 
         [Parameter()]
-        [string]
+        [object]
         $Icon
     )
 
@@ -147,7 +147,7 @@ function New-PodeWebTab
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = (Get-PodeWebElementId -Tag Tab -Id $Id -Name $Name)
         Content = $Content
-        Icon = $Icon
+        Icon = (Protect-PodeWebIconType -Icon $Icon -Element 'Tab')
     }
 }
 
@@ -176,7 +176,7 @@ function New-PodeWebCard
         $Buttons,
 
         [Parameter()]
-        [string]
+        [object]
         $Icon,
 
         [switch]
@@ -204,7 +204,7 @@ function New-PodeWebCard
         Buttons = $Buttons
         NoTitle = $NoTitle.IsPresent
         NoHide  = $NoHide.IsPresent
-        Icon = $Icon
+        Icon = (Protect-PodeWebIconType -Icon $Icon -Element 'Card')
     }
 }
 
@@ -262,7 +262,7 @@ function New-PodeWebModal
         $Content,
 
         [Parameter()]
-        [string]
+        [object]
         $Icon,
 
         [Parameter()]
@@ -346,7 +346,7 @@ function New-PodeWebModal
         Name = $Name
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = $Id
-        Icon = $Icon
+        Icon = (Protect-PodeWebIconType -Icon $Icon -Element 'Modal')
         Content = $Content
         CloseText = [System.Net.WebUtility]::HtmlEncode($CloseText)
         SubmitText = [System.Net.WebUtility]::HtmlEncode($SubmitText)
@@ -547,7 +547,7 @@ function New-PodeWebStep
         $ArgumentList,
 
         [Parameter()]
-        [string]
+        [object]
         $Icon,
 
         [Parameter()]
@@ -598,7 +598,7 @@ function New-PodeWebStep
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = $Id
         Content = $Content
-        Icon = $Icon
+        Icon = (Protect-PodeWebIconType -Icon $Icon -Element 'Step')
         IsDynamic = ($null -ne $ScriptBlock)
     }
 }
@@ -740,7 +740,7 @@ function New-PodeWebBellow
         $Content,
 
         [Parameter()]
-        [string]
+        [object]
         $Icon
     )
 
@@ -755,6 +755,6 @@ function New-PodeWebBellow
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = (Get-PodeWebElementId -Tag Bellow -Id $Id -Name $Name)
         Content = $Content
-        Icon = $Icon
+        Icon = (Protect-PodeWebIconType -Icon $Icon -Element 'Bellow')
     }
 }

--- a/src/Public/Navigation.ps1
+++ b/src/Public/Navigation.ps1
@@ -27,7 +27,7 @@ function New-PodeWebNavLink
         $ArgumentList,
 
         [Parameter()]
-        [string]
+        [object]
         $Icon,
 
         [switch]
@@ -52,7 +52,7 @@ function New-PodeWebNavLink
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = $Id
         Url = (Add-PodeWebAppPath -Url $Url)
-        Icon = $Icon
+        Icon = (Protect-PodeWebIconType -Icon $Icon -Element 'Nav Link')
         IsDynamic = ($null -ne $ScriptBlock)
         Disabled = $Disabled.IsPresent
         InDropdown = $false
@@ -111,7 +111,7 @@ function New-PodeWebNavDropdown
         $Items,
 
         [Parameter()]
-        [string]
+        [object]
         $Icon,
 
         [switch]
@@ -132,7 +132,7 @@ function New-PodeWebNavDropdown
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
         ID = (Get-PodeWebElementId -Tag 'Nav-Dropdown' -Id $Id -Name $Name)
         Items = $Items
-        Icon = $Icon
+        Icon = (Protect-PodeWebIconType -Icon $Icon -Element 'Nav Dropdown')
         Disabled = $Disabled.IsPresent
         Hover = $Hover.IsPresent
         InDropdown = $false

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -11,12 +11,10 @@ function Set-PodeWebLoginPage
         $Content,
 
         [Parameter()]
-        [Alias('Icon')]
         [string]
         $Logo,
 
         [Parameter()]
-        [Alias('IconUrl')]
         [string]
         $LogoUrl,
 

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -975,6 +975,14 @@ a.nav-link .mdi:before {
     top: 3px;
 }
 
+.mdi-size-5::before {
+    font-size: 5px;
+}
+
+.mdi-size-10::before {
+    font-size: 10px;
+}
+
 .mdi-size-15::before {
     font-size: 15px;
 }
@@ -985,6 +993,30 @@ a.nav-link .mdi:before {
 
 .mdi-size-22::before {
     font-size: 22px;
+}
+
+.mdi-size-25::before {
+    font-size: 25px;
+}
+
+.mdi-size-30::before {
+    font-size: 30px;
+}
+
+.mdi-size-35::before {
+    font-size: 35px;
+}
+
+.mdi-size-40::before {
+    font-size: 40px;
+}
+
+.mdi-size-45::before {
+    font-size: 45px;
+}
+
+.mdi-size-50::before {
+    font-size: 50px;
 }
 
 .dropdown-menu .mdi {


### PR DESCRIPTION
### Description of the Change

#### Icons
This adds two new `Update-PodeWebIcon` and `Switch-PodeWebIcon` actions. The former lets you simply update the details of an icon - the colour, size, title, and icon used. The latter lets you toggle between the base icon, and the toggle/hover icon pre-sets defined - this will toggle between base/toggle by default, but you can specify the desired state explicitly.

For the toggle/hover presets, these can be set against a `New-PodeWebIcon` using the new `-ToggleIcon` and `-HoverIcon` parameters, and by supplying `New-PodeWebIconPreset` to either/both. This means you could have a static refresh icon, and then on hover it starts spinning and turns green - without needing to use `Update-PodeWebIcon`.

You can now also supply `New-PodeWebIcon` to any `-Icon` parameter, such as on buttons; cards; headers, etc.. You can still pass a raw string which is just the name of the icon to use, but by using `New-PodeWebIcon` instead you could have a button with a spinning icon - or one that spins on button/icon hover.

#### Classes
Two new `Rename-PodeWebClass` and `Switch-PodeWebClass` have been added. The former renames a class on an element from one to another, and the latter toggles a class on/off.

#### Breaking Changes
* The `-Icon` and `-IconUrl` aliases for `-Logo` and `-LogoUrl` on `Set-PodeWebLoginPage` have been removed
* The `-Icon` parameter on `Show-PodeWebNotification` has been renamed to `-IconUrl`
* The `-Icon` parameter on `New-PodeWebComment` has been renamed to `-AvatarUrl`

### Related Issue
Resolve #450 
Resolves #446 

### Examples
#### Icons
```powershell
# update
Update-PodeWebIcon -Id 'my-icon' -Name 'cat' -Colour 'yellow' -Spin:$false

# switch
Switch-PodeWebIcon -Id 'my-icon'

# this will add a toggle icon to make the base icon go yellow and spin:
$toggle = New-PodeWebIconPreset -Colour Yellow -Spin
New-PodeWebIcon -Name 'cat' -ToggleIcon $toggle

# this will add a toggle icon to change the base icon completely
$toggle = New-PodeWebIconPreset -Name 'cat'
New-PodeWebIcon -Name 'home' -ToggleIcon $toggle

# this will add a hover icon to change from outlined checkbox to a full one on hover
$hover = New-PodeWebIconPreset -Name 'mdi-checkbox-multiple-marked'
New-PodeWebIcon -Name 'mdi-checkbox-multiple-marked-outline' -HoverIcon $hover

# button using New-PodeWebIcon instead of string
$icon = New-PodeWebIcon -Name 'github' -Spin
New-PodeWebButton -Name 'Repository' -Icon $icon -Url 'https://github.com/Badgerati/Pode.Web'
```

#### Classes
```powershell
# rename
Rename-PodeWebClass -Id 'textbox_somename' -From 'my-custom-class' -To 'my-other-class'

# switch
Switch-PodeWebClass -Id 'textbox_somename' -Value 'my-custom-class' -State Remove
```
