### PR TITLE
Remove use of -NoNewLine, and fix JSON rendering

### DIFF
--- a/docs/Tutorials/Elements/Textbox.md
+++ b/docs/Tutorials/Elements/Textbox.md
@@ -6,9 +6,9 @@
 
 A textbox element is a form input element; you can render a textbox, single and multiline, to your page using [`New-PodeWebTextbox`](../../../Functions/Elements/New-PodeWebTextbox).
 
-A textbox by default is a normal plain single lined textbox, however you can customise its `-Type` to Email/Password/etc. To change the textbox to be multilined you ca supply `-Multiline`.
+A textbox by default is a normal plain single lined textbox, however you can customise its `-Type` to Email/Password/etc. To change the textbox to be a multiline textbox you can supply the `-Multiline` switch.
 
-Textboxes also allow you to specify `-AutoComplete` values.
+Textboxes also allow you to specify `-AutoComplete` values ([see here](#autocomplete)).
 
 ## Single
 
@@ -80,7 +80,7 @@ By default the label displays the `-Name` of the element. You can change the val
 
 The `-Width` of a textbox has the default unit of `%`. If `0` is specified then `auto` is used instead. Any custom value such as `100px` can be used, but if a plain number is used then `%` is appended.
 
-The `-Height` of the textbox is how many lines are displayed when the textbox is multilined.
+The `-Height` of the textbox is how many lines are displayed when the textbox is multiline.
 
 ## Initial Value
 

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -427,6 +427,10 @@ function Update-PodeWebTextbox
         $AsJson,
 
         [Parameter()]
+        [switch]
+        $JsonInline,
+
+        [Parameter()]
         [ValidateSet('Unchanged', 'Disabled', 'Enabled')]
         [string]
         $ReadOnlyState = 'Unchanged',
@@ -446,8 +450,8 @@ function Update-PodeWebTextbox
     }
 
     end {
-        if (!$AsJson) {
-            $items = ($items | Out-String -NoNewline)
+        if (!$AsJson -and ($items.Length -gt 0)) {
+            $items = ($items | Out-String).Trim()
         }
         
         return @{
@@ -457,6 +461,7 @@ function Update-PodeWebTextbox
             ID = $Id
             Name = $Name
             AsJson = $AsJson.IsPresent
+            JsonInline = $JsonInline.IsPresent
             ReadOnlyState = $ReadOnlyState
             DisabledState = $DisabledState
         }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -96,7 +96,11 @@ function New-PodeWebTextbox
         $DynamicLabel,
 
         [switch]
-        $AsJson
+        $AsJson,
+
+        [Parameter(ParameterSetName='Multi')]
+        [switch]
+        $JsonInline
     )
 
     begin {
@@ -154,6 +158,7 @@ function New-PodeWebTextbox
             DynamicLabel = $DynamicLabel.IsPresent
             MaxLength = $MaxLength
             AsJson = $AsJson.IsPresent
+            JsonInline = $JsonInline.IsPresent
         }
 
         # create autocomplete route

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -3226,11 +3226,6 @@ class PodeTextbox extends PodeFormElement {
         var placeholder = data.Placeholder ? `placeholder='${data.Placeholder}'` : '';
         var events = this.events(data.Events);
 
-        var value = '';
-        if (data.Value) {
-            value = this.multiline ? data.Value : `value='${data.Value}'`;
-        }
-
         // multiline textbox
         if (this.multiline) {
             html = `<textarea
@@ -3244,7 +3239,7 @@ class PodeTextbox extends PodeFormElement {
                 ${placeholder}
                 ${autofocus}
                 ${events}
-                ${maxLength}>${value}</textarea>`;
+                ${maxLength}></textarea>`;
         }
 
         // single line textbox
@@ -3272,7 +3267,6 @@ class PodeTextbox extends PodeFormElement {
                 style='${width}'
                 placeholder='${data.Placeholder ?? ''}'
                 ${autofocus}
-                ${value}
                 ${events}
                 ${maxLength}>`;
 
@@ -3322,20 +3316,22 @@ class PodeTextbox extends PodeFormElement {
         // update value
         if (data.Value) {
             if (data.AsJson) {
-                data.Value = JSON.stringify(data.Value, null, 4);
+                data.Value = data.JsonInline || !this.multiline
+                    ? JSON.stringify(data.Value)
+                    : JSON.stringify(data.Value, null, 4);
             }
         
-            this.get().val(data.Value);
+            this.element.val(data.Value);
         }
 
         // resize textbox rows
         if (this.multiline && data.Size) {
-            this.get().attr('rows', data.Size);
+            this.element.attr('rows', data.Size);
         }
     }
 
     clear(data, sender, opts) {
-        this.get().val('');
+        this.element.val('');
     }
 }
 PodeElementFactory.setClass(PodeTextbox);


### PR DESCRIPTION
### Description of the Change
Changes `Out-String -NoNewLine` in `Update-PodeWebTextbox` to work like `New-PodeWebTextbox`:
```powershell
$items = ($items | Out-String).Trim()
```

Also fixes a JSON rendering issue; on a none-multiline textbox the JSON is rendering "inline" by default, and for a multiline textbox there's a new switch `-JsonInline`.

### Related Issue
Resolves #476 
