### PR TITLE
Set Ajax to have no timeout for long requests

### DIFF
--- a/docs/Tutorials/Basics.md
+++ b/docs/Tutorials/Basics.md
@@ -10,6 +10,8 @@ Start-PodeServer {
 }
 ```
 
+## Cache Static Content
+
 To speed up the loading of pages, enable caching within your `server.psd1` file:
 
 ```powershell
@@ -19,6 +21,20 @@ To speed up the loading of pages, enable caching within your `server.psd1` file:
             Cache = @{
                 Enable = $true
             }
+        }
+    }
+}
+```
+
+## Timeout
+
+The default timeout in Pode is 30 seconds, so if you have elements/Routes you know that will run for longer than this then you'll need to increase the default timeout value. This can be done by adding the following to your `server.psd1` file, where the `Timeout` value is in seconds ([more info](https://badgerati.github.io/Pode/Tutorials/RequestLimits/#timeout)):
+
+```powershell
+@{
+    Server = @{
+        Request = @{
+            Timeout = 60
         }
     }
 }

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -1,7 +1,7 @@
 Import-Module Pode -MaximumVersion 2.99.99 -Force
 Import-Module ..\src\Pode.Web.psd1 -Force
 
-Start-PodeServer {
+Start-PodeServer -Threads 2 {
     # add a simple endpoint
     Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging

--- a/examples/server.psd1
+++ b/examples/server.psd1
@@ -1,5 +1,8 @@
 @{
     Server = @{
+        Request = @{
+            Timeout = 600
+        }
         AutoImport = @{
             Modules = @{
                 Enable = $true

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -370,6 +370,7 @@ function sendAjaxReq(url, data, sender, useActions, successCallback, errorCallba
         processData: opts.processData,
         contentType: opts.contentType,
         mimeType: opts.mimeType,
+        timeout: 0,
         xhrFields: {
             responseType: 'blob'
         },


### PR DESCRIPTION
### Description of the Change
Fix for some AJAX requests timing out after 30 seconds, and update docs to reference increasing Pode's request timeout via `server.psd1`.

### Related Issue
Resolves #529 