### PR TITLE
Enables support to use scoped variables in Pages, Elements, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
 # <img src="https://github.com/Badgerati/Pode/blob/develop/images/icon.png?raw=true" width="25" /> Pode.Web
 
-> This is still a work in progress, until v1.0.0 expect possible breaking changes in some releases.
+> This is the develop branch for Pode,Web v1.0.0, which is currently dependant on an unreleased version of Pode (v2.10.0). If you want the latest released Pode.Web code (v0.8.3), please view the master branch instead.
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/Badgerati/Pode.Web/master/LICENSE.txt)
 [![Documentation](https://img.shields.io/github/v/release/badgerati/pode.web?label=docs)](https://badgerati.github.io/Pode.Web)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 - [🔥 Quick Example](#-quick-example)
 - [🌎 Roadmap](#-roadmap)
 
-This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.6.0+).
+This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.10.0+).
 
-It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge required!
+It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge is required!
 
 You can build charts, forms, tables, general text, tabs, login pages, etc. There's a light, dark, and terminal themes, and you can supply a custom CSS file.
 
@@ -39,7 +39,7 @@ The Pode.Web templates are built using [Bootstrap](https://getbootstrap.com), [j
 
 All documentation and tutorials for Pode.Web can be [found here](https://badgerati.github.io/Pode.Web) - this documentation will be for the latest release.
 
-To see the docs for other releases, branches or tags, you can host the documentation locally. To do so you'll need to have the [`InvokeBuild`](https://github.com/nightroman/Invoke-Build) module installed; then:
+To see the docs for other releases, branches, or tags, you can host the documentation locally. To do so you'll need to have the [`InvokeBuild`](https://github.com/nightroman/Invoke-Build) module installed; then:
 
 ```powershell
 Invoke-Build Docs
@@ -116,6 +116,6 @@ Start-PodeServer {
 
 ## 🌎 Roadmap
 
-You can find a list of the features, enhancements and ideas that will hopefully one day make it into Pode.Web [here in the documentation](https://badgerati.github.io/Pode.Web/roadmap/).
+You can find a list of the features, enhancements, and ideas that will hopefully one day make it into Pode.Web [here in the documentation](https://badgerati.github.io/Pode.Web/roadmap/).
 
 There is also a [Project](https://github.com/users/Badgerati/projects/3) in the beginnings of being setup for Pode.Web, with milestone progression and current roadmap issues. Plus, there is a [Draft Board](https://github.com/users/Badgerati/projects/5) which contains a range of ideas for Pode.Web features/enhancements which are either brilliant, ludicrous, or down right insane! Draft Issues are purely ideas, and any in the design stage might one day make it in! If you see a Draft Issue you which to discuss, or have an idea for one, please dicuss it over on [Discord](https://discord.gg/fRqeGcbF6h) in the `#ideas` or `#pode-web` channel.

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -6,7 +6,7 @@ Pode.Web is a PowerShell module that works along side [Pode](https://github.com/
 
 Before installing Pode.Web, the minimum requirements must be met:
 
-* [Pode](https://github.com/Badgerati/Pode) v2.6.0+
+* [Pode](https://github.com/Badgerati/Pode) v2.10.0+
 
 Which also includes Pode's minimum requirements:
 * OS:

--- a/docs/Tutorials/Security.md
+++ b/docs/Tutorials/Security.md
@@ -1,6 +1,6 @@
 # Security
 
-In Pode v2.6.0 support was added for HTTP [security headers](https://badgerati.github.io/Pode/Tutorials/Middleware/Types/Security/) to be automatically added to requests, such as: Access Control, Cross-Origin, Content Security Policy, and more.
+Support was implemented into Pode for HTTP [security headers](https://badgerati.github.io/Pode/Tutorials/Middleware/Types/Security/) to be automatically added to requests, such as: Access Control, Cross-Origin, Content Security Policy, and more.
 
 Pode.Web uses this feature to automatically set some default headers on requests, to make your site more secure.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,9 @@
 
 > 💝 A lot of my free time, evenings, and weekends goes into making Pode happen; please do consider sponsoring as it will really help! 😊
 
-This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.6.0+).
+This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.10.0+).
 
-It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge required!
+It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge is required!
 
 You can build charts, forms, tables, general text, tabs, login pages, etc. There's a light, dark, and terminal themes, and you can supply a custom CSS file.
 

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -1,4 +1,5 @@
-Import-Module Pode -MaximumVersion 2.99.99 -Force
+#Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\..\Pode\src\Pode.psm1 -Force
 Import-Module ..\src\Pode.Web.psd1 -Force
 
 Start-PodeServer -StatusPageExceptions Show {
@@ -17,9 +18,9 @@ Start-PodeServer -StatusPageExceptions Show {
         if ($username -eq 'morty' -and $password -eq 'pickle') {
             return @{
                 User = @{
-                    ID ='M0R7Y302'
-                    Name = 'Morty'
-                    Type = 'Human'
+                    ID     = 'M0R7Y302'
+                    Name   = 'Morty'
+                    Type   = 'Human'
                     Groups = @('Developer')
                     #AvatarUrl = '/pode.web-static/images/icon.png'
                 }
@@ -33,7 +34,7 @@ Start-PodeServer -StatusPageExceptions Show {
     # set the use of templates
     Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
 
-    # set login page 
+    # set login page
     # -BackgroundImage '/images/galaxy.jpg'
     Set-PodeWebLoginPage -Authentication Example -LoginPath '/auth/login' -LogoutPath '/auth/logout' -PassThru |
         Register-PodeWebPageEvent -Type Load, Unload, BeforeUnload -NoAuth -ScriptBlock {
@@ -83,14 +84,14 @@ Start-PodeServer -StatusPageExceptions Show {
         New-PodeWebParagraph -Content @(
             New-PodeWebText -Value "Look, here's a "
             New-PodeWebLink -Id 'link_test' -Source 'https://github.com/badgerati/pode' -Value 'link' -NewTab
-            New-PodeWebText -Value "! "
+            New-PodeWebText -Value '! '
             New-PodeWebBadge -Id 'bdg_test' -Value 'Sweet!' -Colour Cyan |
                 Register-PodeWebEvent -Type Click -NoAuth -ScriptBlock {
                     Show-PodeWebToast -Message 'Badge was clicked!'
                 }
         )
         New-PodeWebParagraph -Content @(
-            New-PodeWebCode -Id 'code_test' -Value "some code :o"
+            New-PodeWebCode -Id 'code_test' -Value 'some code :o'
         )
         $timer1
         New-PodeWebImage -Id 'pode-img' -Source '/pode.web-static/images/icon.png' -Height 70 -Alignment Right |
@@ -149,20 +150,20 @@ Start-PodeServer -StatusPageExceptions Show {
         }
 
         return (1..$count | ForEach-Object {
-            @{
-                Key = $_
-                Values = @(
-                    @{
-                        Key = 'Example1'
-                        Value = (Get-Random -Maximum 10)
-                    },
-                    @{
-                        Key = 'Example2'
-                        Value = (Get-Random -Maximum 10)
-                    }
-                )
-            }
-        })
+                @{
+                    Key    = $_
+                    Values = @(
+                        @{
+                            Key   = 'Example1'
+                            Value = (Get-Random -Maximum 10)
+                        },
+                        @{
+                            Key   = 'Example2'
+                            Value = (Get-Random -Maximum 10)
+                        }
+                    )
+                }
+            })
     }
 
     $processData = {
@@ -285,13 +286,13 @@ Start-PodeServer -StatusPageExceptions Show {
             }
 
             [ordered]@{
-                Name = $svc.Name
-                Status = "$($svc.Status)"
+                Name    = $svc.Name
+                Status  = "$($svc.Status)"
                 Actions = $btns
             }
         }
     } `
-    -Columns @(
+        -Columns @(
         Initialize-PodeWebTableColumn -Key Actions -Alignment Center
     )
 
@@ -317,7 +318,7 @@ Start-PodeServer -StatusPageExceptions Show {
             New-PodeWebCodeBlock -Value $svc -NoHighlight
         )
     } `
-    -HelpScriptBlock {
+        -HelpScriptBlock {
         Show-PodeWebModal -Name 'Help'
     }
 

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -1,5 +1,4 @@
-#Import-Module Pode -MaximumVersion 2.99.99 -Force
-Import-Module ..\..\Pode\src\Pode.psm1 -Force
+Import-Module Pode -MaximumVersion 2.99.99 -Force
 Import-Module ..\src\Pode.Web.psd1 -Force
 
 Start-PodeServer -StatusPageExceptions Show {
@@ -248,20 +247,24 @@ Start-PodeServer -StatusPageExceptions Show {
         New-PodeWebText -Value 'HELP!'
     )
 
+    $stopName = 'Stop'
+    $startName = 'Start'
+    $editName = 'Edit'
+
     $table = New-PodeWebTable -Name 'Static' -DataColumn Name -AsCard -Filter -SimpleSort -Click -Paginate -ScriptBlock {
-        $stopBtn = New-PodeWebButton -Name 'Stop' -Icon 'stop-circle-outline' -IconOnly -ScriptBlock {
+        $stopBtn = New-PodeWebButton -Name $using:stopName -Icon 'stop-circle-outline' -IconOnly -ScriptBlock {
             Stop-Service -Name $WebEvent.Data.Value -Force | Out-Null
             Show-PodeWebToast -Message "$($WebEvent.Data.Value) stopped"
             Sync-PodeWebTable -Id $ElementData.Parent.ID
         }
 
-        $startBtn = New-PodeWebButton -Name 'Start' -Icon 'play-circle-outline' -IconOnly -ScriptBlock {
+        $startBtn = New-PodeWebButton -Name $using:startName -Icon 'play-circle-outline' -IconOnly -ScriptBlock {
             Start-Service -Name $WebEvent.Data.Value | Out-Null
             Show-PodeWebToast -Message "$($WebEvent.Data.Value) started"
             Sync-PodeWebTable -Id $ElementData.Parent.ID
         }
 
-        $editBtn = New-PodeWebButton -Name 'Edit' -Icon 'square-edit-outline' -IconOnly -ScriptBlock {
+        $editBtn = New-PodeWebButton -Name $using:editName -Icon 'square-edit-outline' -IconOnly -ScriptBlock {
             $svc = Get-Service -Name $WebEvent.Data.Value
             $checked = ($svc.Status -ieq 'running')
 

--- a/examples/scoped-variables.ps1
+++ b/examples/scoped-variables.ps1
@@ -1,4 +1,4 @@
-Import-Module ..\..\Pode\src\Pode.psm1 -Force #-MaximumVersion 2.99.99 -Force
+Import-Module Pode -MaximumVersion 2.99.99 -Force
 Import-Module ..\src\Pode.Web.psm1 -Force
 
 

--- a/examples/scoped-variables.ps1
+++ b/examples/scoped-variables.ps1
@@ -1,0 +1,37 @@
+Import-Module ..\..\Pode\src\Pode.psm1 -Force #-MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psm1 -Force
+
+
+Start-PodeServer -StatusPageExceptions Show {
+    $outer_var = 'Kenobi'
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Use-PodeWebTemplates -Title 'Basic Example' -Theme Dark
+    $state:card_name = 'Hello, there!'
+
+    # set the home page controls (just a simple paragraph)
+    Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Title 'Awesome Homepage' -ScriptBlock {
+        $name = $state:card_name
+        New-PodeWebCard -Name $name -Content @(
+            New-PodeWebParagraph -Value "This is an example homepage, with some example text, including $($using:outer_var)"
+            New-PodeWebParagraph -Value 'Using some example paragraphs'
+        )
+    }
+
+    # add a page to search process (output as json in an appended textbox)
+    Add-PodeWebPage -Name Processes -Icon 'chart-box-outline' -ScriptBlock {
+        New-PodeWebForm -Name 'Search' -ShowReset -SubmitText 'Search' -ResetText 'Clear' -AsCard -ScriptBlock {
+            $procs = @(Get-Process -Name $WebEvent.Data.Name -ErrorAction Ignore |
+                    Select-Object Name, ID, WorkingSet, CPU)
+
+            $procs |
+                New-PodeWebTextbox -Name 'Output' -Multiline -Preformat -AsJson -Size ((6 * $procs.Length) + 2) |
+                Out-PodeWebElement
+        } -Content @(
+            New-PodeWebTextbox -Name 'Name'
+        )
+    }
+}

--- a/src/Pode.Web.psd1
+++ b/src/Pode.Web.psd1
@@ -28,13 +28,13 @@
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '5.0'
 
-    RequiredModules   = @(
-        @{
-            ModuleName    = 'Pode'
-            ModuleVersion = '2.6.0'
-            Guid          = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
-        }
-    )
+    # RequiredModules   = @(
+    #     @{
+    #         ModuleName    = 'Pode'
+    #         ModuleVersion = '2.6.0'
+    #         Guid          = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
+    #     }
+    # )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData       = @{

--- a/src/Pode.Web.psd1
+++ b/src/Pode.Web.psd1
@@ -28,13 +28,13 @@
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion = '5.0'
 
-    # RequiredModules   = @(
-    #     @{
-    #         ModuleName    = 'Pode'
-    #         ModuleVersion = '2.6.0'
-    #         Guid          = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
-    #     }
-    # )
+    RequiredModules   = @(
+        @{
+            ModuleName    = 'Pode'
+            ModuleVersion = '2.10.0'
+            Guid          = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
+        }
+    )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData       = @{

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -73,11 +73,7 @@ function Register-PodeWebElementEventInternal {
             $global:ElementData = $Element
             $global:EventType = $Type
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result
@@ -169,11 +165,7 @@ function Register-PodeWebPageEventInternal {
             $global:PageData = $Page
             $global:EventType = $Type
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -61,13 +61,20 @@ function Register-PodeWebElementEventInternal {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $Element.EndpointName -ScriptBlock {
-            param($Data)
-            $global:ElementData = $using:Element
-            $global:EventType = $using:Type
+        $argList = @(
+            @{ Data = $ArgumentList },
+            $Element,
+            $Type,
+            $eventLogic
+        )
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:eventLogic).UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:eventLogic).ScriptBlock -Arguments $_args -Splat -Return
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $Element.EndpointName -ScriptBlock {
+            param($Data, $Element, $Type, $Logic)
+            $global:ElementData = $Element
+            $global:EventType = $Type
+
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }
@@ -150,13 +157,20 @@ function Register-PodeWebPageEventInternal {
             $auth = (Get-PodeWebState -Name 'auth')
         }
 
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $Page.EndpointName -ScriptBlock {
-            param($Data)
-            $global:PageData = $using:Page
-            $global:EventType = $using:Type
+        $argList = @(
+            @{ Data = $ArgumentList },
+            $Page,
+            $Type,
+            $eventLogic
+        )
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:eventLogic).UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:eventLogic).ScriptBlock -Arguments $_args -Splat -Return
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $Page.EndpointName -ScriptBlock {
+            param($Data, $Page, $Type, $Logic)
+            $global:PageData = $Page
+            $global:EventType = $Type
+
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1085,3 +1085,21 @@ function Protect-PodeWebIconPreset {
 
     return $Preset
 }
+
+function Invoke-PodeWebScriptBlock {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $Logic,
+
+        [Parameter()]
+        $Arguments = $null
+    )
+
+    $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $Arguments -UsingVariables $Logic.UsingVariables -Splat -Return
+    if ($null -eq $result) {
+        $result = @()
+    }
+
+    return $result
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -188,11 +188,7 @@ function New-PodeWebTextbox {
                 param($Element, $Logic)
                 $global:ElementData = $Element
 
-                $_args = @(Merge-PodeScriptblockArguments -UsingVariables $Logic.UsingVariables)
-                $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-                if ($null -eq $result) {
-                    $result = @()
-                }
+                $result = Invoke-PodeWebScriptBlock -Logic $Logic
 
                 Write-PodeJsonResponse -Value @{ Values = $result }
                 $global:ElementData = $null
@@ -565,11 +561,7 @@ function New-PodeWebSelect {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!(Test-PodeWebOutputWrapped -Output $result)) {
                 $result = ($result | Update-PodeWebSelect -Id $ElementData.ID)
@@ -1447,11 +1439,7 @@ function New-PodeWebButton {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result
@@ -1940,11 +1928,7 @@ function New-PodeWebChart {
                 param($Data, $Element, $Logic)
                 $global:ElementData = $Element
 
-                $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-                $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-                if ($null -eq $result) {
-                    $result = @()
-                }
+                $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
                 if (!(Test-PodeWebOutputWrapped -Output $result)) {
                     $result = ($result | Update-PodeWebChart -Id $ElementData.ID)
@@ -2253,8 +2237,7 @@ function New-PodeWebTable {
 
                 $csvFilePath = $Data.CsvPath
                 if ([string]::IsNullOrWhiteSpace($csvFilePath)) {
-                    $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-                    $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
+                    $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
                 }
                 else {
                     $result = Import-Csv -Path $csvFilePath
@@ -2300,11 +2283,7 @@ function New-PodeWebTable {
                 param($Data, $Element, $Logic)
                 $global:ElementData = $Element
 
-                $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-                $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-                if ($null -eq $result) {
-                    $result = @()
-                }
+                $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
                 if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                     Write-PodeJsonResponse -Value $result
@@ -2438,11 +2417,7 @@ function Add-PodeWebTableButton {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result
@@ -2556,11 +2531,7 @@ function New-PodeWebCodeEditor {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             Write-PodeJsonResponse -Value $result
             $global:ElementData = $null
@@ -2690,11 +2661,7 @@ function New-PodeWebForm {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             Write-PodeJsonResponse -Value $result
             $global:ElementData = $null
@@ -2789,11 +2756,7 @@ function New-PodeWebTimer {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             Write-PodeJsonResponse -Value $result
             $global:ElementData = $null
@@ -2931,11 +2894,7 @@ function New-PodeWebTile {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!(Test-PodeWebOutputWrapped -Output $result)) {
                 $result = ($result | Update-PodeWebTile -Id $ElementData.ID)
@@ -2966,11 +2925,7 @@ function New-PodeWebTile {
             param($Data, $Element, $Logic)
             $global:ElementData = $Element
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -31,6 +31,7 @@ function Register-PodeWebEvent {
             -Type $t `
             -ScriptBlock $ScriptBlock `
             -ArgumentList $ArgumentList `
+            -PSSession $PSCmdlet.SessionState `
             -NoAuthentication:$NoAuthentication | Out-Null
     }
 
@@ -76,6 +77,7 @@ function Register-PodeWebMediaEvent {
             -Type $t `
             -ScriptBlock $ScriptBlock `
             -ArgumentList $ArgumentList `
+            -PSSession $PSCmdlet.SessionState `
             -NoAuthentication:$NoAuthentication | Out-Null
     }
 
@@ -124,6 +126,7 @@ function Register-PodeWebPageEvent {
             -Type $t `
             -ScriptBlock $ScriptBlock `
             -ArgumentList $ArgumentList `
+            -PSSession $PSCmdlet.SessionState `
             -NoAuthentication:$NoAuthentication | Out-Null
     }
 

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -328,11 +328,16 @@ function New-PodeWebModal {
             $EndpointName = Get-PodeWebState -Name 'endpoint-name'
         }
 
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
-            param($Data)
+        $argList = @(
+            @{ Data = $ArgumentList },
+            $elementLogic
+        )
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:elementLogic).UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:elementLogic).ScriptBlock -Arguments $_args -Splat -Return
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $EndpointName -ScriptBlock {
+            param($Data, $Logic)
+
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }
@@ -506,11 +511,16 @@ function New-PodeWebSteps {
             $EndpointName = Get-PodeWebState -Name 'endpoint-name'
         }
 
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
-            param($Data)
+        $argList = @(
+            @{ Data = $ArgumentList },
+            $elementLogic
+        )
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:elementLogic).UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:elementLogic).ScriptBlock -Arguments $_args -Splat -Return
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $EndpointName -ScriptBlock {
+            param($Data, $Logic)
+
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }
@@ -590,11 +600,16 @@ function New-PodeWebStep {
             $EndpointName = Get-PodeWebState -Name 'endpoint-name'
         }
 
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
-            param($Data)
+        $argList = @(
+            @{ Data = $ArgumentList },
+            $elementLogic
+        )
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:elementLogic).UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:elementLogic).ScriptBlock -Arguments $_args -Splat -Return
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $EndpointName -ScriptBlock {
+            param($Data, $Logic)
+
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -312,6 +312,13 @@ function New-PodeWebModal {
 
     $routePath = "/elements/modal/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
+        # check for scoped vars
+        $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+        $elementLogic = @{
+            ScriptBlock    = $ScriptBlock
+            UsingVariables = $usingVars
+        }
+
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
@@ -324,7 +331,8 @@ function New-PodeWebModal {
         Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
             param($Data)
 
-            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ScriptBlock -Arguments $Data.Data -Splat -Return
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:elementLogic).UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:elementLogic).ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }
@@ -482,6 +490,13 @@ function New-PodeWebSteps {
     # add route
     $routePath = "/elements/steps/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
+        # check for scoped vars
+        $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+        $elementLogic = @{
+            ScriptBlock    = $ScriptBlock
+            UsingVariables = $usingVars
+        }
+
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
@@ -494,7 +509,8 @@ function New-PodeWebSteps {
         Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
             param($Data)
 
-            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ScriptBlock -Arguments $Data.Data -Splat -Return
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:elementLogic).UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:elementLogic).ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }
@@ -558,6 +574,13 @@ function New-PodeWebStep {
     # add route
     $routePath = "/elements/step/$($Id)"
     if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
+        # check for scoped vars
+        $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+        $elementLogic = @{
+            ScriptBlock    = $ScriptBlock
+            UsingVariables = $usingVars
+        }
+
         $auth = $null
         if (!$NoAuthentication -and !$PageData.NoAuthentication) {
             $auth = (Get-PodeWebState -Name 'auth')
@@ -570,7 +593,8 @@ function New-PodeWebStep {
         Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
             param($Data)
 
-            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ScriptBlock -Arguments $Data.Data -Splat -Return
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:elementLogic).UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:elementLogic).ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }

--- a/src/Public/Layouts.ps1
+++ b/src/Public/Layouts.ps1
@@ -335,13 +335,7 @@ function New-PodeWebModal {
 
         Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $EndpointName -ScriptBlock {
             param($Data, $Logic)
-
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
-
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
             Write-PodeJsonResponse -Value $result
         }
     }
@@ -518,13 +512,7 @@ function New-PodeWebSteps {
 
         Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $EndpointName -ScriptBlock {
             param($Data, $Logic)
-
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
-
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
             Write-PodeJsonResponse -Value $result
         }
     }
@@ -607,13 +595,7 @@ function New-PodeWebStep {
 
         Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $EndpointName -ScriptBlock {
             param($Data, $Logic)
-
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
-
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
             Write-PodeJsonResponse -Value $result
         }
     }

--- a/src/Public/Navigation.ps1
+++ b/src/Public/Navigation.ps1
@@ -88,11 +88,7 @@ function New-PodeWebNavLink {
             param($Data, $Nav, $Logic)
             $global:NavData = $Nav
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
 
             if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result

--- a/src/Public/Navigation.ps1
+++ b/src/Public/Navigation.ps1
@@ -78,12 +78,18 @@ function New-PodeWebNavLink {
             $EndpointName = Get-PodeWebState -Name 'endpoint-name'
         }
 
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList @{ Data = $ArgumentList } -EndpointName $EndpointName -ScriptBlock {
-            param($Data)
-            $global:NavData = $using:nav
+        $argList = @(
+            @{ Data = $ArgumentList },
+            $nav,
+            $navLogic
+        )
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:navLogic).UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:navLogic).ScriptBlock -Arguments $_args -Splat -Return
+        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $EndpointName -ScriptBlock {
+            param($Data, $Nav, $Logic)
+            $global:NavData = $Nav
+
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $Logic.UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $Logic.ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }

--- a/src/Public/Navigation.ps1
+++ b/src/Public/Navigation.ps1
@@ -42,7 +42,11 @@ function New-PodeWebNavLink {
         $NewTab
     )
 
+    # generate nav-link id
     $Id = (Get-PodeWebElementId -Tag 'Nav-Link' -Id $Id -Name $Name)
+
+    # check for scoped vars
+    $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
     $nav = @{
         ComponentType = 'Navigation'
@@ -56,6 +60,11 @@ function New-PodeWebNavLink {
         Disabled      = $Disabled.IsPresent
         InDropdown    = $false
         NewTab        = $NewTab.IsPresent
+    }
+
+    $navLogic = @{
+        ScriptBlock    = $ScriptBlock
+        UsingVariables = $usingVars
     }
 
     $routePath = "/elements/nav-link/$($Id)"
@@ -73,7 +82,8 @@ function New-PodeWebNavLink {
             param($Data)
             $global:NavData = $using:nav
 
-            $result = Invoke-PodeScriptBlock -ScriptBlock $using:ScriptBlock -Arguments $Data.Data -Splat -Return
+            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables ($using:navLogic).UsingVariables)
+            $result = Invoke-PodeScriptBlock -ScriptBlock ($using:navLogic).ScriptBlock -Arguments $_args -Splat -Return
             if ($null -eq $result) {
                 $result = @()
             }

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -488,8 +488,7 @@ function Add-PodeWebPage {
             # if we have a scriptblock, invoke that to get dynamic elements
             $content = $null
             if ($null -ne $global:PageData.Logic.ScriptBlock) {
-                $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $global:PageData.Logic.UsingVariables)
-                $content = Invoke-PodeScriptBlock -ScriptBlock $global:PageData.Logic.ScriptBlock -Arguments $_args -Splat -Return
+                $content = Invoke-PodeWebScriptBlock -Logic $global:PageData.Logic -Arguments $Data.Data
             }
 
             if (($null -eq $content) -or ($content.Length -eq 0)) {
@@ -527,11 +526,7 @@ function Add-PodeWebPage {
                 Set-PodeResponseStatus -Code 403
             }
             else {
-                $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $global:PageData.Help.UsingVariables)
-                $result = Invoke-PodeScriptBlock -ScriptBlock $global:PageData.Help.ScriptBlock -Arguments $_args -Splat -Return
-                if ($null -eq $result) {
-                    $result = @()
-                }
+                $result = Invoke-PodeWebScriptBlock -Logic $global:PageData.Help -Arguments $Data.Data
 
                 if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                     Write-PodeJsonResponse -Value $result
@@ -696,11 +691,7 @@ function Add-PodeWebPageLink {
             param($Data)
             $pageData = (Get-PodeWebState -Name 'pages')[$Data.ID]
 
-            $_args = @(Merge-PodeScriptblockArguments -ArgumentList $Data.Data -UsingVariables $pageData.Logic.UsingVariables)
-            $result = Invoke-PodeScriptBlock -ScriptBlock $pageData.Logic.ScriptBlock -Arguments $_args -Splat -Return
-            if ($null -eq $result) {
-                $result = @()
-            }
+            $result = Invoke-PodeWebScriptBlock -Logic $pageData.Logic -Arguments $Data.Data
 
             if (!$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
                 Write-PodeJsonResponse -Value $result

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -121,10 +121,10 @@ function Set-PodeWebLoginPage {
 
     # setup page meta
     $pageMeta = @{
-        ComponentType = 'Page'
-        ObjectType    = 'Page'
-        ID            = $Id
-        Route         = @{
+        ComponentType   = 'Page'
+        ObjectType      = 'Page'
+        ID              = $Id
+        Route           = @{
             Login  = @{
                 Path = (Get-PodeWebPagePath -Name 'login' -Path $LoginPath -NoAppPath)
                 Url  = (Get-PodeWebPagePath -Name 'login' -Path $LoginPath)
@@ -134,10 +134,19 @@ function Set-PodeWebLoginPage {
                 Url  = (Get-PodeWebPagePath -Name 'logout' -Path $LogoutPath)
             }
         }
-        Name          = 'Login'
-        Content       = $Content
-        SignInMessage = (Protect-PodeWebValue -Value $SignInMessage -Default 'Please sign in' -Encode)
-        IsSystem      = $true
+        Name            = 'Login'
+        Content         = $Content
+        SignInMessage   = (Protect-PodeWebValue -Value $SignInMessage -Default 'Please sign in' -Encode)
+        Logo            = @{
+            IconUrl = $Logo
+            Url     = $LogoUrl
+        }
+        BackgroundImage = $BackgroundImage
+        CopyRight       = $Copyright
+        Authentication  = $Authentication
+        IsOAuth2        = $isOAuth2
+        GrantType       = $grantType
+        IsSystem        = $true
     }
 
     # set auth system urls
@@ -168,17 +177,17 @@ function Set-PodeWebLoginPage {
         Write-PodeWebViewResponse -Path 'login' -Data @{
             Page          = $global:PageData
             Theme         = Get-PodeWebTheme
-            Logo          = $using:Logo
-            LogoUrl       = $using:LogoUrl
+            Logo          = $PageData.Logo.IconUrl
+            LogoUrl       = $PageData.Logo.Url
             Background    = @{
-                Image = $using:BackgroundImage
+                Image = $PageData.BackgroundImage
             }
-            SignInMessage = $global:PageData.SignInMessage
-            Copyright     = $using:Copyright
+            SignInMessage = $PageData.SignInMessage
+            Copyright     = $PageData.Copyright
             Auth          = @{
-                Name      = $using:Authentication
-                IsOAuth2  = $using:isOAuth2
-                GrantType = $using:grantType
+                Name      = $PageData.Authentication
+                IsOAuth2  = $PageData.IsOAuth2
+                GrantType = $PageData.GrantType
             }
         }
 


### PR DESCRIPTION
### Description of the Change
Enables support to use scoped variables, like `$state:` and `$using:`, within Pode.Web Pages and Elements. This uses the new Scoped Variables feature from Pode (https://github.com/Badgerati/Pode/pull/1238), so Pode.Web v1.0.0 will have a dependency on Pode v.2.10.0.

### Related Issue
Resolves #138 
