### PR TITLE
Adds built-in support for handling sessions with Tab scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ examples/issues/
 pkg/
 yarn.lock
 min-maps/
-.vscode/
 
 
 # Code Runner

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+    "editor.formatOnSave": true,
+    "editor.formatOnType": false,
+    "editor.minimap.enabled": false,
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "powershell.codeFormatting.alignPropertyValuePairs": true,
+    "powershell.codeFormatting.autoCorrectAliases": true,
+    "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": true,
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
+    "powershell.codeFormatting.trimWhitespaceAroundPipe": true,
+    "powershell.codeFormatting.useConstantStrings": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": true,
+    "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.useCorrectCasing": false,
+    "powershell.codeFormatting.openBraceOnSameLine": true,
+    "powershell.codeFormatting.newLineAfterOpenBrace": true,
+    "powershell.codeFormatting.newLineAfterCloseBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+    "powershell.codeFormatting.whitespaceBetweenParameters": false,
+    "powershell.codeFormatting.whitespaceInsideBrace": true,
+    "files.trimTrailingWhitespace": true,
+    "files.associations": {
+        "*.pode": "html"
+    },
+    "[html]": {
+        "editor.formatOnSave": false
+    },
+    "javascript.format.insertSpaceAfterCommaDelimiter": true,
+    "javascript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "javascript.format.insertSpaceAfterKeywordsInControlFlowStatements": true,
+    "javascript.format.insertSpaceBeforeAndAfterBinaryOperators": true,
+    "javascript.format.insertSpaceBeforeFunctionParenthesis": false
+}

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -1,4 +1,5 @@
 Import-Module Pode -MaximumVersion 2.99.99 -Force
+# Import-Module ..\..\Pode\src\Pode.psm1 -Force
 Import-Module ..\src\Pode.Web.psd1 -Force
 
 Start-PodeServer -StatusPageExceptions Show {

--- a/examples/sessions-tabs.ps1
+++ b/examples/sessions-tabs.ps1
@@ -1,0 +1,48 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+# Import-Module ..\..\Pode\src\Pode.psm1 -Force
+Import-Module ..\src\Pode.Web.psd1 -Force
+
+Start-PodeServer -StatusPageExceptions Show {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+
+    # enable sessions and authentication
+    Enable-PodeSessionMiddleware -Duration 600 -Extend -Scope Tab
+
+    New-PodeAuthScheme -Form | Add-PodeAuth -Name Example -SuccessUseOrigin -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID   = 'M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+
+    # set the use of templates
+    Use-PodeWebTemplates -Title 'Sessions' -Theme Dark
+
+    # set login page
+    Set-PodeWebLoginPage -Authentication Example -PassThru
+
+
+    # set home page with session counter
+    Add-PodeWebPage -Name 'Home' -Path '/' -NoTitle -HomePage -ScriptBlock {
+        #lorem
+        $session:Views++
+
+        New-PodeWebCard -Name 'Counter' -Content @(
+            New-PodeWebParagraph -Value "You have viewed this page $($session:Views) time(s)!"
+        )
+    }
+}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -15,40 +15,38 @@ function Get-PodeWebAuthData {
 function Get-PodeWebAuthUsername {
     param(
         [Parameter()]
-        $AuthData
+        $User
     )
 
-    # nothing if no auth data
-    if (($null -eq $AuthData) -or ($null -eq $AuthData.User)) {
+    # nothing if no user
+    if ($null -eq $User) {
         return [string]::Empty
     }
 
-    $user = $AuthData.User
-
     # check username prop
     $prop = (Get-PodeWebState -Name 'auth-props').Username
-    if (![string]::IsNullOrWhiteSpace($prop) -and ![string]::IsNullOrWhiteSpace($user.$prop)) {
-        return $user.$prop
+    if (![string]::IsNullOrEmpty($prop) -and ![string]::IsNullOrEmpty($User.$prop)) {
+        return $User.$prop
     }
 
     # name
-    if (![string]::IsNullOrWhiteSpace($user.Name)) {
-        return $user.Name
+    if (![string]::IsNullOrEmpty($User.Name)) {
+        return $User.Name
     }
 
     # full name
-    if (![string]::IsNullOrWhiteSpace($user.FullName)) {
-        return $user.FullName
+    if (![string]::IsNullOrEmpty($User.FullName)) {
+        return $User.FullName
     }
 
     # username
-    if (![string]::IsNullOrWhiteSpace($user.Username)) {
-        return $user.Username
+    if (![string]::IsNullOrEmpty($User.Username)) {
+        return $User.Username
     }
 
     # email - split on @ though
-    if (![string]::IsNullOrWhiteSpace($user.Email)) {
-        return ($user.Email -split '@')[0]
+    if (![string]::IsNullOrEmpty($User.Email)) {
+        return ($User.Email -split '@')[0]
     }
 
     # nothing
@@ -58,35 +56,33 @@ function Get-PodeWebAuthUsername {
 function Get-PodeWebAuthGroups {
     param(
         [Parameter()]
-        $AuthData
+        $User
     )
 
     # nothing if no auth data
-    if (($null -eq $AuthData) -or ($null -eq $AuthData.User)) {
+    if ($null -eq $User) {
         return @()
     }
 
-    $user = $AuthData.User
-
     # check group prop
     $prop = (Get-PodeWebState -Name 'auth-props').Group
-    if (![string]::IsNullOrWhiteSpace($prop) -and !(Test-PodeWebArrayEmpty -Array $user.$prop)) {
-        return @($user.$prop)
+    if (![string]::IsNullOrEmpty($prop) -and !(Test-PodeWebArrayEmpty -Array $User.$prop)) {
+        return @($User.$prop)
     }
 
     # groups
-    if (!(Test-PodeWebArrayEmpty -Array $user.Groups)) {
-        return @($user.Groups)
+    if (!(Test-PodeWebArrayEmpty -Array $User.Groups)) {
+        return @($User.Groups)
     }
 
     # roles
-    if (!(Test-PodeWebArrayEmpty -Array $user.Roles)) {
-        return @($user.Roles)
+    if (!(Test-PodeWebArrayEmpty -Array $User.Roles)) {
+        return @($User.Roles)
     }
 
     # scopes
-    if (!(Test-PodeWebArrayEmpty -Array $user.Scopes)) {
-        return @($user.Scopes)
+    if (!(Test-PodeWebArrayEmpty -Array $User.Scopes)) {
+        return @($User.Scopes)
     }
 
     # nothing
@@ -96,25 +92,23 @@ function Get-PodeWebAuthGroups {
 function Get-PodeWebAuthAvatarUrl {
     param(
         [Parameter()]
-        $AuthData
+        $User
     )
 
     # nothing if no auth data
-    if (($null -eq $AuthData) -or ($null -eq $AuthData.User)) {
+    if ($null -eq $User) {
         return [string]::Empty
     }
 
-    $user = $AuthData.User
-
     # nothing if no property set
     $prop = (Get-PodeWebState -Name 'auth-props').Avatar
-    if (![string]::IsNullOrWhiteSpace($prop) -and ![string]::IsNullOrWhiteSpace($user.$prop)) {
-        return (Add-PodeWebAppPath -Url $user.$prop)
+    if (![string]::IsNullOrEmpty($prop) -and ![string]::IsNullOrEmpty($User.$prop)) {
+        return (Add-PodeWebAppPath -Url $User.$prop)
     }
 
     # avatar url
-    if (![string]::IsNullOrWhiteSpace($user.AvatarUrl)) {
-        return (Add-PodeWebAppPath -Url $user.AvatarUrl)
+    if (![string]::IsNullOrEmpty($User.AvatarUrl)) {
+        return (Add-PodeWebAppPath -Url $User.AvatarUrl)
     }
 
     return [string]::Empty
@@ -123,25 +117,23 @@ function Get-PodeWebAuthAvatarUrl {
 function Get-PodeWebAuthTheme {
     param(
         [Parameter()]
-        $AuthData
+        $User
     )
 
     # nothing if no auth data
-    if (($null -eq $AuthData) -or ($null -eq $AuthData.User)) {
+    if ($null -eq $User) {
         return $null
     }
 
-    $user = $AuthData.User
-
     # nothing if no property set
     $prop = (Get-PodeWebState -Name 'auth-props').Theme
-    if (![string]::IsNullOrWhiteSpace($prop) -and ![string]::IsNullOrWhiteSpace($user.$prop)) {
-        return $user.$prop
+    if (![string]::IsNullOrEmpty($prop) -and ![string]::IsNullOrEmpty($User.$prop)) {
+        return $User.$prop
     }
 
     # theme
-    if (![string]::IsNullOrWhiteSpace($user.Theme)) {
-        return $user.Theme
+    if (![string]::IsNullOrEmpty($User.Theme)) {
+        return $User.Theme
     }
 
     return [string]::Empty
@@ -197,6 +189,11 @@ function Test-PodeWebPageAccess {
     # if page has no access restriction, just return
     if (!$hasGroups -and !$hasUsers) {
         return $true
+    }
+
+    # if no auth object, just return
+    if ($null -eq $Auth) {
+        return $false
     }
 
     # check groups

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -180,7 +180,7 @@ function Get-PodeWebTheme {
 
     # check auth data
     if ([string]::IsNullOrWhiteSpace($theme)) {
-        $theme = Get-PodeWebAuthTheme -AuthData (Get-PodeWebAuthData)
+        $theme = Get-PodeWebAuthTheme -User (Get-PodeAuthUser)
     }
 
     # check state

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -6,7 +6,7 @@ class PodeElementFactory {
     static classMap = new Map();
     static objMap = new Map();
 
-    constructor() {}
+    constructor() { }
 
     static setClass(clazz) {
         this.classMap.set(clazz.type.toLowerCase(), clazz);
@@ -231,7 +231,7 @@ class PodeElement {
         }
 
         // build data, or use new-icon data?
-        if (typeof(data) === 'string') {
+        if (typeof (data) === 'string') {
             data = {
                 ID: `${this.id}_icon`,
                 Name: data
@@ -281,11 +281,11 @@ class PodeElement {
             case 'style':
                 switch (action) {
                     case 'add':
-                        this.addStyle(data.Key, data.Value, sender, {...data, ...opts});
+                        this.addStyle(data.Key, data.Value, sender, { ...data, ...opts });
                         break;
 
                     case 'remove':
-                        this.removeStyle(data.Key, sender, {...data, ...opts});
+                        this.removeStyle(data.Key, sender, { ...data, ...opts });
                         break;
                 }
                 break;
@@ -293,19 +293,19 @@ class PodeElement {
             case 'class':
                 switch (action) {
                     case 'add':
-                        this.addClass(data.Value, sender, {...data, ...opts});
+                        this.addClass(data.Value, sender, { ...data, ...opts });
                         break;
 
                     case 'remove':
-                        this.removeClass(data.Value, sender, {...data, ...opts});
+                        this.removeClass(data.Value, sender, { ...data, ...opts });
                         break;
 
                     case 'rename':
-                        this.replaceClass(data.From, data.To, sender, {...data, ...opts});
+                        this.replaceClass(data.From, data.To, sender, { ...data, ...opts });
                         break;
 
                     case 'switch':
-                        this.toggleClass(data.Value, data.State, sender, {...data, ...opts})
+                        this.toggleClass(data.Value, data.State, sender, { ...data, ...opts })
                         break;
                 }
                 break;
@@ -313,7 +313,7 @@ class PodeElement {
             case 'validation':
                 switch (action) {
                     case 'show':
-                        this.showValidation(data.Message, sender, {...data, ...opts});
+                        this.showValidation(data.Message, sender, { ...data, ...opts });
                         break;
                 }
                 break;
@@ -321,11 +321,11 @@ class PodeElement {
             case 'attribute':
                 switch (action) {
                     case 'add':
-                        this.addAttribute(data.Key, data.Value, sender, {...data, ...opts})
+                        this.addAttribute(data.Key, data.Value, sender, { ...data, ...opts })
                         break;
 
                     case 'remove':
-                        this.removeAttribute(data.Key, sender, {...data, ...opts});
+                        this.removeAttribute(data.Key, sender, { ...data, ...opts });
                         break;
                 }
                 break;
@@ -926,7 +926,7 @@ class PodeElement {
     }
 
     toggleClass(clazz, state, sender, opts) {
-        if (typeof(state) === 'string') {
+        if (typeof (state) === 'string') {
             state = ({
                 toggle: null,
                 add: true,
@@ -1010,7 +1010,7 @@ class PodeElement {
     update(data, sender, opts) {
         // update icon
         if (this.icon && data.Icon) {
-            if (typeof(data.Icon) === 'string') {
+            if (typeof (data.Icon) === 'string') {
                 this.icon.replace(data.Icon);
             }
             else {
@@ -1109,7 +1109,7 @@ class PodeCyclingElement extends PodeContentElement {
             }
 
             this.cycling.action = setInterval(() => {
-                this.move({Direction: 'next'}, this);
+                this.move({ Direction: 'next' }, this);
             }, this.cycling.interval);
         }
     }
@@ -1292,7 +1292,7 @@ class PodeFormElement extends PodeContentElement {
 
                     html = `<${lblTag}
                         for='${this.id}'
-                        class='col-sm-2 col-form-label ${this.label.asLegend ? 'float-sm-left pt-0' : '' }'>
+                        class='col-sm-2 col-form-label ${this.label.asLegend ? 'float-sm-left pt-0' : ''}'>
                             ${data.DisplayName}
                     </${lblTag}>
                     ${html}`;
@@ -1870,7 +1870,7 @@ class PodeButton extends PodeFormElement {
 
     constructor(data, sender, opts) {
         super(data, sender, opts);
-        this.iconOnly =  data.IconOnly;
+        this.iconOnly = data.IconOnly;
         this.validation = false;
         this.label.enabled = false;
     }
@@ -2256,7 +2256,7 @@ class PodeCard extends PodeContentElement {
     bind(data, sender, opts) {
         super.bind(data, sender, opts);
 
-        this.listen(this.element.find('.pode-card-collapse'), 'click' , function(e, target) {
+        this.listen(this.element.find('.pode-card-collapse'), 'click', function(e, target) {
             toggleIcon(target, 'eye-outline', 'eye-off-outline', 'Hide', 'Show');
             target.closest('.card').find('.card-body').slideToggle();
             unfocus(target);
@@ -3324,7 +3324,7 @@ class PodeTextbox extends PodeFormElement {
                     ? JSON.stringify(data.Value)
                     : JSON.stringify(data.Value, null, 4);
             }
-        
+
             this.element.val(data.Value);
         }
 
@@ -3493,7 +3493,7 @@ class PodeCodeBlock extends PodeTextualElement {
     bind(data, sender, opts) {
         super.bind(data, sender, opts);
         var obj = this;
-        
+
         this.listen(this.element.find('.pode-code-copy'), 'click', function(e, target) {
             obj.tooltip(false, target);
             var value = obj.element.find('code').text().trim();
@@ -4119,12 +4119,12 @@ class PodeCodeEditor extends PodeContentElement {
         var obj = this;
 
         var src = $('script[role="monaco"]').attr('src');
-        require.config({ paths: { 'vs': src.substring(0, src.lastIndexOf('/')) }});
+        require.config({ paths: { 'vs': src.substring(0, src.lastIndexOf('/')) } });
 
         // create the editors
         require(["vs/editor/editor.main"], function() {
             if (!obj.theme) {
-                switch(getPodeTheme()) {
+                switch (getPodeTheme()) {
                     case 'dark':
                         obj.theme = 'vs-dark';
                         break;
@@ -4715,7 +4715,7 @@ class PodeSelect extends PodeFormElement {
 
             options += `<option
                 value='${opt}'
-                ${selectedValue.includes(opt) ? 'selected' : '' }>
+                ${selectedValue.includes(opt) ? 'selected' : ''}>
                     ${data.DisplayOptions[index]}
             </option>`;
         });
@@ -4765,7 +4765,7 @@ class PodeSelect extends PodeFormElement {
             data.Options.forEach((opt, index) => {
                 this.element.append(`<option
                     value="${opt}"
-                    ${data.SelectedValue.includes(opt) ? 'selected' : '' }>
+                    ${data.SelectedValue.includes(opt) ? 'selected' : ''}>
                         ${data.DisplayOptions[index]}
                 </option>`);
             });

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -5,7 +5,14 @@
         AppPath = $data.AppPath
     })
 
-    <body id="normal-page" pode-page-id="$($data.Page.ID)" pode-theme="$($data.Theme)" pode-app-path="$($data.AppPath)" $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
+    <body
+        id="normal-page"
+        pode-page-id="$($data.Page.ID)"
+        pode-theme="$($data.Theme)"
+        $(if ($data.Sessions.Enabled) { "pode-session-tabs='$($data.Sessions.Tabs)'" })
+        pode-app-path="$($data.AppPath)"
+        $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
+
         $(
             if (!$data.Page.NoNavigation) {
                 Use-PodeWebPartialView -Path 'shared/navbar' -Data @{

--- a/src/Templates/Views/login.pode
+++ b/src/Templates/Views/login.pode
@@ -5,7 +5,15 @@
         AppPath = $data.AppPath
     })
 
-    <body id="login-page" pode-page-id="$($data.Page.ID)" pode-theme="$($data.Theme)" pode-app-path="$($data.AppPath)" style="background-image: url('$($data.Background.Image)'); background-repeat: no-repeat; background-size: cover" $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
+    <body
+        id="login-page"
+        pode-page-id="$($data.Page.ID)"
+        pode-theme="$($data.Theme)"
+        $(if ($data.Sessions.Enabled) { "pode-session-tabs='$($data.Sessions.Tabs)'" })
+        pode-app-path="$($data.AppPath)"
+        style="background-image: url('$($data.Background.Image)'); background-repeat: no-repeat; background-size: cover"
+        $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
+
         <div aria-live="polite" aria-atomic="true" style="min-height: 200px;" class="sticky">
             <div id="toast-area">
             </div>


### PR DESCRIPTION
### Description of the Change
Adds built-in support for Pode.Web to automatically handle the Tab `-Scope` on `Enable-PodeSessionMiddleware`.

This will be done by using the `window.sessionStorage` on the frontend, and supplying the `X-PODE-SESSION-TAB-ID` header via AJAX calls.

### Related Issue
Resolves #406 
