### PR TITLE
Bump bootstrap to v4.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jquery": "3.7.1",
     "jquery-ui-dist": "1.13.2",
     "popper.js": "1.16.1",
-    "bootstrap": "4.6.1",
+    "bootstrap": "4.6.2",
     "bs-stepper": "1.7.0",
     "@mdi/font": "7.4.47",
     "chart.js": "4.4.2",


### PR DESCRIPTION
### Description of the Change
Bump bootstrap to v4.6.2

### Related Issue
Resolves #564 
