### PR TITLE
Adds a new ClickName parameter for Buttons, to toggle the value rendered on clicking; Adds Url, DataValue, Tab state, and ClickName to Update-PodeWebButton

### DIFF
--- a/docs/Tutorials/Actions/Button.md
+++ b/docs/Tutorials/Actions/Button.md
@@ -52,7 +52,7 @@ New-PodeWebCard -Content @(
 
 ## Update
 
-You can update a button's Icon, DisplayName, Colour, and Size using [`Update-PodeWebButton`](../../../Functions/Actions/Update-PodeWebButton).
+You can update a button's Icon, DisplayName, Colour, Url, Size, and various other properties using [`Update-PodeWebButton`](../../../Functions/Actions/Update-PodeWebButton).
 
 For example, to change a solid button to be yellow and outlined:
 

--- a/docs/Tutorials/Elements/Button.md
+++ b/docs/Tutorials/Elements/Button.md
@@ -38,6 +38,19 @@ New-PodeWebButton -Name 'Click Me' -ArgumentList 'Value1', 2, $false -ScriptBloc
 }
 ```
 
+### Display/Click Name
+
+For dynamic buttons, alongside `-DisplayName` to customise the rendered value, there is also a `-ClickName` parameter. This `-ClickName` parameter will be shown when the button is clicked, and for the duration in which the spinner is visible. Once the button's action has been completed, the original value is shown again - this will be either `-Name` or `-DisplayName`.
+
+For example, the following will display "Disable Link" originally but when clicked will show "Disabling..." for 2 seconds, and will then revert to "Disable Link" again.
+
+```powershell
+New-PodeWebButton -Name 'Disable Link' -ClickName 'Disabling...' -ScriptBlock {
+    Start-Sleep -Seconds 2
+    Disable-PodeWebLink -Id 'link'
+}
+```
+
 ## URL
 
 To have a button that simply redirects to another URL, all you have to do is supply `-Url`:

--- a/examples/links.ps1
+++ b/examples/links.ps1
@@ -23,10 +23,12 @@ Start-PodeServer -Browse {
                 New-PodeWebButton -Name 'Update to DuckDuckGo' -ScriptBlock {
                     Update-PodeWebLink -Id 'link' -Value 'DuckDuckGo' -Url 'https://www.duckduckgo.com'
                 }
-                New-PodeWebButton -Name 'Disable Link' -ScriptBlock {
+                New-PodeWebButton -Name 'Disable Link' -ClickName 'Disabling...' -ScriptBlock {
+                    Start-Sleep -Seconds 2
                     Disable-PodeWebLink -Id 'link'
                 }
-                New-PodeWebButton -Name 'Enable Link' -ScriptBlock {
+                New-PodeWebButton -Name 'Enable Link' -ClickName 'Enabling...' -ScriptBlock {
+                    Start-Sleep -Seconds 2
                     Enable-PodeWebLink -Id 'link'
                 }
             )

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -2541,6 +2541,10 @@ function Update-PodeWebButton {
         $DisplayName,
 
         [Parameter()]
+        [string]
+        $ClickName,
+
+        [Parameter()]
         [object]
         $Icon,
 
@@ -2562,7 +2566,19 @@ function Update-PodeWebButton {
         [Parameter()]
         [ValidateSet('Unchanged', 'Normal', 'Full')]
         [string]
-        $SizeState = 'Unchanged'
+        $SizeState = 'Unchanged',
+
+        [Parameter()]
+        [string]
+        $Url,
+
+        [Parameter()]
+        [string]
+        $DataValue,
+
+        [Parameter()]
+        [ValidateSet('Unchanged', 'SameTab', 'NewTab')]
+        $TabState = 'Unchanged'
     )
 
     $colourType = Convert-PodeWebColourToClass -Colour $Colour
@@ -2580,7 +2596,11 @@ function Update-PodeWebButton {
         SizeType    = $sizeType
         SizeState   = $SizeState.ToLowerInvariant()
         DisplayName = [System.Net.WebUtility]::HtmlEncode($DisplayName)
+        ClickName   = [System.Net.WebUtility]::HtmlEncode($ClickName)
         Icon        = (Protect-PodeWebIconType -Icon $Icon -Element 'Button')
+        Url         = $Url
+        DataValue   = $DataValue
+        TabState    = $TabState.ToLowerInvariant()
     }
 }
 

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1364,6 +1364,10 @@ function New-PodeWebButton {
 
         [Parameter()]
         [string]
+        $ClickName,
+
+        [Parameter()]
+        [string]
         $Id,
 
         [Parameter(ParameterSetName = 'ScriptBlock')]
@@ -1436,6 +1440,7 @@ function New-PodeWebButton {
         ObjectType       = 'Button'
         Name             = $Name
         DisplayName      = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
+        ClickName        = [System.Net.WebUtility]::HtmlEncode($ClickName)
         ID               = $Id
         DataValue        = $DataValue
         Icon             = (Protect-PodeWebIconType -Icon $Icon -Element 'Button')

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -2077,6 +2077,8 @@ class PodeButton extends PodeFormElement {
         this.validation = false;
         this.label.enabled = false;
         this.hasSpinner = true;
+        this.displayName = data.DisplayName ?? '';
+        this.clickName = data.ClickName ?? '';
     }
 
     new(data, sender, opts) {
@@ -2093,7 +2095,7 @@ class PodeButton extends PodeFormElement {
                     id='${this.id}'
                     name='${this.name}'
                     pode-data-value='${data.DataValue}'
-                    title='${data.DisplayName}'
+                    title='${this.displayName}'
                     data-toggle='tooltip'
                     pode-object='${this.getType()}'
                     pode-id='${this.uuid}'>
@@ -2107,7 +2109,7 @@ class PodeButton extends PodeFormElement {
                     id='${this.id}'
                     name='${this.name}'
                     pode-data-value='${data.DataValue}'
-                    title='${data.DisplayName}'
+                    title='${this.displayName}'
                     href='${data.Url}'
                     target='${data.NewTab ? '_blank' : '_self'}'
                     data-toggle='tooltip'
@@ -2135,7 +2137,7 @@ class PodeButton extends PodeFormElement {
                     pode-id='${this.uuid}'>
                         <span for='${this.uuid}' class='pode-spinner spinner-border spinner-border-sm' role='status' aria-hidden='true' style='display: none'></span>
                         ${icon}
-                        <span class='pode-text'>${data.DisplayName}</span>
+                        <span class='pode-text'>${this.displayName}</span>
                 </button>`;
             }
             else {
@@ -2151,7 +2153,7 @@ class PodeButton extends PodeFormElement {
                     pode-colour='${data.ColourType}'
                     pode-id='${this.uuid}'>
                         ${icon}
-                        <span class='pode-text'>${data.DisplayName}</span>
+                        <span class='pode-text'>${this.displayName}</span>
                 </a>`;
             }
         }
@@ -2192,8 +2194,29 @@ class PodeButton extends PodeFormElement {
                 inputs.data = addFormDataValue(inputs.data, 'Value', dataValue);
             }
 
+            // invoke url
             sendAjaxReq(sender.url, inputs.data, sender, true, null, null, inputs.opts, $(e.currentTarget));
         });
+    }
+
+    spinner(show) {
+        super.spinner(show);
+
+        // skip if no click name
+        if (!this.clickName) {
+            return;
+        }
+
+        // display name, or click name?
+        var name = show ? this.clickName : this.displayName;
+
+        // render name
+        if (this.iconOnly) {
+            this.setTitle(name);
+        }
+        else {
+            this.element.find('span.pode-text').text(decodeHTML(name));
+        }
     }
 
     update(data, sender, opts) {
@@ -2201,12 +2224,19 @@ class PodeButton extends PodeFormElement {
 
         // update display name
         if (data.DisplayName) {
+            this.displayName = data.DisplayName;
+
             if (this.iconOnly) {
-                this.setTitle(data.DisplayName);
+                this.setTitle(this.displayName);
             }
             else {
-                this.element.find('span.pode-text').text(decodeHTML(data.DisplayName));
+                this.element.find('span.pode-text').text(decodeHTML(this.displayName));
             }
+        }
+
+        // update click name
+        if (data.ClickName) {
+            this.clickName = data.ClickName;
         }
 
         // change colour
@@ -2244,6 +2274,21 @@ class PodeButton extends PodeFormElement {
             if (data.Size) {
                 this.replaceClass('btn-(sm|lg)', data.SizeType, null, { pattern: true });
             }
+        }
+
+        // change url
+        if (!this.dynamic && data.Url) {
+            this.element.attr('href', data.Url);
+        }
+
+        // change data value
+        if (data.DataValue) {
+            this.element.attr('pode-data-value', data.DataValue);
+        }
+
+        // change tab state
+        if (!this.dynamic && data.TabState != 'unchanged') {
+            this.element.attr('target', data.TabState == 'newtab' ? '_blank' : '_self');
         }
     }
 }


### PR DESCRIPTION
### Description of the Change
* Adds a new ClickName parameter for Buttons, to toggle the value rendered on clicking
* Adds Url, DataValue, Tab state, and ClickName to Update-PodeWebButton

### Related Issue
A link/reference to the GitHub issue.

### Examples
* ClickName
```powershell
New-PodeWebButton -Name 'Disable Link' -ClickName 'Disabling...' -ScriptBlock {
    Start-Sleep -Seconds 2
    Disable-PodeWebLink -Id 'link'
}
```

* Update URL
```powershell
New-PodeWebButton -Name 'Update Button' -ScriptBlock {
    Update-PodeWebButton -Name 'Example Button' -Url 'https://google.com'
}
```