### PR TITLE
Adds support for customising which buttons are visible on Forms and Modals

### DIFF
--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -211,3 +211,56 @@ The themes for `New-PodeWebCodeEditor` have been changed:
 | vs       | Light        |
 | vs-dark  | Dark         |
 | hc-black | HighContrast |
+
+## Form Buttons
+
+In previous versions of Pode.Web the "Submit" button was always visible, and you could optionally show a "Reset" button using the `-ShowReset` switch on `New-PodeWebForm`.
+
+Now though, the `-ShowReset` switch has been removed and a new `-ButtonType` parameter has been added. This parameter accepts one or more of the following values:
+
+* None
+* Submit
+* Reset
+
+with "Submit" being the default value if nothing is supplied. Following are some examples:
+
+```powershell
+# default submit button:
+New-PodeWebForm -Name 'Example' -Content @() -ScriptBlock {}
+
+# if you want a Form with a Submit and Reset button:
+New-PodeWebForm -Name 'Example' -ButtonType Submit, Reset -Content @() -ScriptBlock {}
+
+# if you want a Form with just a Reset button:
+New-PodeWebForm -Name 'Example' -ButtonType Submit, Reset -Content @() -ScriptBlock {}
+
+# if you want a Form with no buttons:
+New-PodeWebForm -Name 'Example' -ButtonType None -Content @() -ScriptBlock {}
+```
+
+## Modal Buttons
+
+Similar to Forms above: in previous versions "Close" button was always visible, and the "Submit" button was always visible if you supplied a `-ScriptBlock`. If you had a `-ScriptBlock` but didn't want the "Submit" button then this wasn't possible.
+
+Now though, there is a new `-ButtonType` parameter on `New-PodeWebModal` which accepts one or more of the following values:
+
+* None
+* Submit
+* Reset
+* Close
+
+with "Close" being the default with no `-ScriptBlock`, and "Submit" & "Close" being the default if you supplied a `-ScriptBlock`, and you don't supply a value for `-ButtonType`. Following are some examples:
+
+```powershell
+# default close and no scriptblock
+New-PodeWebModal -Name 'Example' -Content @()
+
+# default close/submit and scriptblock
+New-PodeWebModal -Name 'Example' -AsForm -Content @() -ScriptBlock {}
+
+# scriptblock with only submit and reset
+New-PodeWebModal -Name 'Example' -ButtonType Submit, Reset -AsForm -Content @() -ScriptBlock {}
+
+# scriptblock with no buttons
+New-PodeWebModal -Name 'Example' -ButtonType None -AsForm -Content @() -ScriptBlock {}
+```

--- a/docs/Tutorials/Elements/Form.md
+++ b/docs/Tutorials/Elements/Form.md
@@ -68,6 +68,28 @@ The default method for forms is `Post`, and the action is the internal route cre
 
 You can change these values by using the `-Method` and `-Action` parameters. The method can only be `Get` or `Post`, and the action must be a valid URL.
 
-## Reset
+## Buttons
 
-You can reset all form inputs by either using the [`Reset-PodeWebForm`](../../../Functions/Actions/Reset-PodeWebForm) action, or by using `-ShowReset` switch on [`New-PodeWebForm`](../../../Functions/Elements/New-PodeWebForm) to display an optional reset button.
+You can customise which buttons are visible at the bottom of the Form by using the `-ButtonType` parameter on [`New-PodeWebForm`](../../../Functions/Elements/New-PodeWebForm).
+
+By default, this parameter has the value "Submit", but you can supply one or more of the following values to change this:
+
+* None
+* Submit
+* Reset
+
+Following are some examples:
+
+```powershell
+# default submit button:
+New-PodeWebForm -Name 'Example' -Content @() -ScriptBlock {}
+
+# if you want a Form with a Submit and Reset button:
+New-PodeWebForm -Name 'Example' -ButtonType Submit, Reset -Content @() -ScriptBlock {}
+
+# if you want a Form with just a Reset button:
+New-PodeWebForm -Name 'Example' -ButtonType Submit, Reset -Content @() -ScriptBlock {}
+
+# if you want a Form with no buttons:
+New-PodeWebForm -Name 'Example' -ButtonType None -Content @() -ScriptBlock {}
+```

--- a/docs/Tutorials/Elements/Modal.md
+++ b/docs/Tutorials/Elements/Modal.md
@@ -118,3 +118,31 @@ New-PodeWebModal -Name 'Stop Service' -Content @() -ArgumentList 'Value1', 2, $f
     # $value3 = $false
 }
 ```
+
+## Buttons
+
+You can customise which buttons are visible at the bottom of the Modal by using the `-ButtonType` parameter on [`New-PodeWebModal`](../../../Functions/Elements/New-PodeWebModal).
+
+By default, this parameter has the value "Close" if no `-ScriptBlock` is supplied, or the value "Submit" & "Close" if a `-ScriptBlock` is supplied, but you can supply one or more of the following values to change this:
+
+* None
+* Submit
+* Reset
+* Close
+
+Following are some examples:
+
+```powershell
+# default close and no scriptblock
+New-PodeWebModal -Name 'Example' -Content @()
+
+# default close/submit and scriptblock
+New-PodeWebModal -Name 'Example' -AsForm -Content @() -ScriptBlock {}
+
+# scriptblock with only submit and reset
+New-PodeWebModal -Name 'Example' -ButtonType Submit, Reset -AsForm -Content @() -ScriptBlock {}
+
+# scriptblock with no buttons
+New-PodeWebModal -Name 'Example' -ButtonType None -AsForm -Content @() -ScriptBlock {}
+```
+

--- a/examples/basic.ps1
+++ b/examples/basic.ps1
@@ -21,7 +21,7 @@ Start-PodeServer {
     Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Content $section -Title 'Awesome Homepage'
 
     # add a page to search process (output as json in an appended textbox)
-    $form = New-PodeWebForm -Name 'Search' -ShowReset -SubmitText 'Search' -ResetText 'Clear' -AsCard -ScriptBlock {
+    $form = New-PodeWebForm -Name 'Search' -ButtonType Submit, Reset -SubmitText 'Search' -ResetText 'Clear' -AsCard -ScriptBlock {
         $procs = @(Get-Process -Name $WebEvent.Data.Name -ErrorAction Ignore |
                 Select-Object Name, ID, WorkingSet, CPU)
 

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -10,7 +10,7 @@ Start-PodeServer -Threads 2 {
     Use-PodeWebTemplates -Title 'Inputs' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
-    $form = New-PodeWebForm -Name 'Test' -ShowReset -AsCard -ScriptBlock {
+    $form = New-PodeWebForm -Name 'Test' -ButtonType Submit, Reset -AsCard -ScriptBlock {
         $WebEvent.Data |
             New-PodeWebTextbox -Name 'TestOutput' -Multiline -Preformat -AsJson |
             Out-PodeWebElement

--- a/examples/scoped-variables.ps1
+++ b/examples/scoped-variables.ps1
@@ -23,7 +23,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
     # add a page to search process (output as json in an appended textbox)
     Add-PodeWebPage -Name Processes -Icon 'chart-box-outline' -ScriptBlock {
-        New-PodeWebForm -Name 'Search' -ShowReset -SubmitText 'Search' -ResetText 'Clear' -AsCard -ScriptBlock {
+        New-PodeWebForm -Name 'Search' -ButtonType Submit, Reset 'Search' -ResetText 'Clear' -AsCard -ScriptBlock {
             $procs = @(Get-Process -Name $WebEvent.Data.Name -ErrorAction Ignore |
                     Select-Object Name, ID, WorkingSet, CPU)
 

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2714,15 +2714,17 @@ function New-PodeWebForm {
         $ResetText = 'Reset',
 
         [Parameter()]
+        [ValidateSet('None', 'Submit', 'Reset')]
+        [string[]]
+        $ButtonType = 'Submit',
+
+        [Parameter()]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication,
 
         [switch]
-        $AsCard,
-
-        [switch]
-        $ShowReset
+        $AsCard
     )
 
     # ensure content are correct
@@ -2747,7 +2749,7 @@ function New-PodeWebForm {
         Action           = (Protect-PodeWebValue -Value $Action -Default $routePath)
         NoEvents         = $true
         NoAuthentication = $NoAuthentication.IsPresent
-        ShowReset        = $ShowReset.IsPresent
+        ButtonType       = $ButtonType.ToLowerInvariant()
         ResetText        = (Protect-PodeWebValue -Value $ResetText -Default 'Reset' -Encode)
         SubmitText       = (Protect-PodeWebValue -Value $SubmitText -Default 'Submit' -Encode)
     }
@@ -3768,6 +3770,11 @@ function New-PodeWebModal {
         $CloseText = 'Close',
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ResetText = 'Reset',
+
+        [Parameter()]
         [ValidateSet('Small', 'Medium', 'Large')]
         [string]
         $Size = 'Small',
@@ -3792,6 +3799,11 @@ function New-PodeWebModal {
         [Parameter()]
         [string]
         $Action,
+
+        [Parameter()]
+        [ValidateSet('None', 'Submit', 'Reset', 'Close')]
+        [string[]]
+        $ButtonType = @('Close', 'Submit'),
 
         [switch]
         $AsForm,
@@ -3843,6 +3855,10 @@ function New-PodeWebModal {
         }
     }
 
+    if ($null -eq $ScriptBlock) {
+        $ButtonType = @('Close')
+    }
+
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -3852,11 +3868,12 @@ function New-PodeWebModal {
         ID            = $Id
         Icon          = (Protect-PodeWebIconType -Icon $Icon -Element 'Modal')
         Content       = $Content
-        CloseText     = [System.Net.WebUtility]::HtmlEncode($CloseText)
-        SubmitText    = [System.Net.WebUtility]::HtmlEncode($SubmitText)
+        CloseText     = (Protect-PodeWebValue -Value $CloseText -Default 'Close' -Encode)
+        SubmitText    = (Protect-PodeWebValue -Value $SubmitText -Default 'Submit' -Encode)
+        ResetText     = (Protect-PodeWebValue -Value $ResetText -Default 'Reset' -Encode)
         Size          = $Size
         AsForm        = $AsForm.IsPresent
-        ShowSubmit    = ($null -ne $ScriptBlock)
+        ButtonType    = $ButtonType.ToLowerInvariant()
         Method        = $Method
         Action        = (Protect-PodeWebValue -Value $Action -Default $routePath)
         NoEvents      = $true

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -52,7 +52,7 @@ function loadContent() {
         return;
     }
 
-    sendAjaxReq(`${getPageUrl('content')}`, null, undefined, true, () => {
+    sendAjaxReq(getPageUrl('content'), null, undefined, true, () => {
         loadBreadcrumb();
         bindFormSubmits();
         contentLoaded = true;
@@ -67,7 +67,7 @@ function connectSse() {
     }
 
     // create sse connection
-    const sse = new EventSource(`${getPageUrl('sse-open')}`);
+    const sse = new EventSource(getPageUrl('sse-open'));
 
     // wire up open event, to store clientId and load content
     sse.addEventListener('pode.open', (e) => {
@@ -92,7 +92,7 @@ function connectSse() {
 
     // wire up beforeunload, to close connection server side
     window.addEventListener("beforeunload", function(e) {
-        sendAjaxReq(`${getPageUrl('sse-close')}`, null, undefined, false);
+        sendAjaxReq(getPageUrl('sse-close'), null, undefined, false);
         return null;
     });
 }
@@ -898,9 +898,7 @@ function bindPageHelp() {
     $('span.pode-page-help').off('click').on('click', function(e) {
         e.preventDefault();
         e.stopPropagation();
-
-        var url = $(e.target).attr('for');
-        sendAjaxReq(`${url}/help`, null, null, true);
+        sendAjaxReq(getPageUrl('help'), null, null, true);
     });
 }
 

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -179,7 +179,7 @@
                                     $data.Page.Title
                                 "</h1>"
                                 if ($data.Page.ShowHelp) {
-                                    "<span class='mdi mdi-help-circle-outline pode-page-help' for='$($data.Page.Url)' title='Help' data-toggle='tooltip'></span>"
+                                    "<span class='mdi mdi-help-circle-outline pode-page-help' title='Help' data-toggle='tooltip'></span>"
                                 }
                             "</div>"
                         }


### PR DESCRIPTION
### Description of the Change
* Adds a new `-ButtonType` parameter onto `New-PodeWebForm` and `New-PodeWebModal`, to allow full control over which buttons are visible.
* Removes `-ShowReset` on `New-PodeWebForm`.
* The default ButtonType for a Form is "Submit".
* The default ButtonType for a Modal is "Close" if no scritpblock is supplied, or "Submit" & "Close" if one is supplied.

### Examples
* Form
```powershell
# default submit button:
New-PodeWebForm -Name 'Example' -Content @() -ScriptBlock {}

# if you want a Form with a Submit and Reset button:
New-PodeWebForm -Name 'Example' -ButtonType Submit, Reset -Content @() -ScriptBlock {}

# if you want a Form with just a Reset button:
New-PodeWebForm -Name 'Example' -ButtonType Submit, Reset -Content @() -ScriptBlock {}

# if you want a Form with no buttons:
New-PodeWebForm -Name 'Example' -ButtonType None -Content @() -ScriptBlock {}
```

* Modal
```powershell
# default close and no scriptblock
New-PodeWebModal -Name 'Example' -Content @()

# default close/submit and scriptblock
New-PodeWebModal -Name 'Example' -AsForm -Content @() -ScriptBlock {}

# scriptblock with only submit and reset
New-PodeWebModal -Name 'Example' -ButtonType Submit, Reset -AsForm -Content @() -ScriptBlock {}

# scriptblock with no buttons
New-PodeWebModal -Name 'Example' -ButtonType None -AsForm -Content @() -ScriptBlock {}
```
