### PR TITLE
Removes the Interval restriction on Timers, so values of 1+ seconds can be supplied

### DIFF
--- a/docs/Tutorials/Elements/Timer.md
+++ b/docs/Tutorials/Elements/Timer.md
@@ -1,12 +1,15 @@
 # Timer
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | No  |
 
-A timer is a non-visible element, it sets up a javascript timer in the background that periodically (60s) invokes logic. You can add a timer using [`New-PodeWebTimer`](../../../Functions/Elements/New-PodeWebTimer), and they're mostly used with the action function to alter the page.
+A timer is a non-visible element, it sets up a javascript timer in the background that periodically invokes logic on the server. You can add a timer using [`New-PodeWebTimer`](../../../Functions/Elements/New-PodeWebTimer).
 
-The below example sets up a timer that will update the badge's value and colour every 10 seconds:
+!!! warning
+    You can set the interval of a timer to run using the `-Interval` parameter, in seconds. The default is 60s, and you can set this to whatever you need: 120s, 30, 15s, etc.; you can also set this to lower values such as 5s and 1s, however, please note that the lower you set the value it might have an adverse affect on the performance of your website - depending on the logic being invoked.
+
+The below example sets up a timer that will update a badge's value and colour every 10 seconds:
 
 ```powershell
 New-PodeWebTimer -Interval 10 -ScriptBlock {

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -64,7 +64,7 @@ Start-PodeServer -StatusPageExceptions Show {
     Set-PodeWebNavDefault -Items $link1, $link2, $div1, $link3, $dd1
 
 
-    $timer1 = New-PodeWebTimer -Name 'Timer1' -Interval 10 -NoAuth -ScriptBlock {
+    $timer1 = New-PodeWebTimer -Name 'Timer1' -Interval 5 -NoAuth -ScriptBlock {
         $rand = Get-Random -Minimum 0 -Maximum 3
         $colour = (@('Green', 'Yellow', 'Cyan'))[$rand]
         Update-PodeWebBadge -Id 'bdg_test' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')) -Colour $colour

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2931,6 +2931,7 @@ function New-PodeWebTimer {
         $Id,
 
         [Parameter()]
+        [ValidateRange(1, [int]::MaxValue)]
         [int]
         $Interval = 60,
 

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -2955,11 +2955,6 @@ function New-PodeWebTimer {
     # generate timer id
     $Id = Get-PodeWebElementId -Tag Timer -Id $Id -Name $Name
 
-    # check for min interval
-    if ($Interval -lt 10) {
-        $Interval = 10
-    }
-
     # check for scoped vars
     $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -4051,9 +4051,11 @@ class PodeTimer extends PodeContentElement {
         super.bind(data, sender, opts);
         this.invoke();
 
-        setInterval(() => {
-            this.invoke();
-        }, this.interval);
+        if (this.interval > 0) {
+            setInterval(() => {
+                this.invoke();
+            }, this.interval);
+        }
     }
 
     invoke(data, sender, opts) {


### PR DESCRIPTION
### Description of the Change
* Removes the restriction on `New-PodeWebTimer -Interval`, so values of 1+ can be supplied, and not limited to 10+
* Adds a warning to the docs for Timers about lower interval values, and potential performance hits

### Related Issue
Resolves #623 

### Examples
```powershell
New-PodeWebTimer -Interval 2 -ScriptBlock {
    $rand = Get-Random -Minimum 0 -Maximum 3
    $colour = (@('Green', 'Yellow', 'Cyan'))[$rand]
    Update-PodeWebBadge -Id 'bdg_example' -Value ([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss')) -Colour $colour
}
```
