### PR TITLE
Update 1.0.0 migration docs to reference AutoImport functionality

### DIFF
--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -4,6 +4,39 @@ This is a brief guide on migrating from Pode.Web v0.8.X to v1.X.
 
 In Pode.Web v1.X all elements are now rendered client-side using JavaScript, rather than server-side using `.pode` view files. There are still some base view files for HTML boilerplate, but everything else has been migrated. This will help take some load away from the server, and allow element rendering to be more dynamic and "on-the-fly". (ie: a table can now contain any element, not just 5 randomly pre-selected elements).
 
+## Module
+
+### AutoImport Settings
+
+Due to changes and fixes within the core Pode module itself around the AutoImport functionality, if you have the following in your `server.psd1` file to disable AutoImport for Modules:
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Modules = @{
+                Enable = $false
+            }
+        }
+    }
+}
+```
+
+You'll need to change this to the following; this will enable Module AutoImports, but it will restrict it to allowed modules added via `Export-PodeModule` - Pode.Web automatically calls this for you.
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Modules = @{
+                Enable     = $true
+                ExportOnly = $true
+            }
+        }
+    }
+}
+```
+
 ## Actions
 
 ### Outputs

--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -8,7 +8,7 @@ In Pode.Web v1.X all elements are now rendered client-side using JavaScript, rat
 
 ### AutoImport Settings
 
-Due to changes and fixes within the core Pode module itself around the AutoImport functionality, if you have the following in your `server.psd1` file to disable AutoImport for Modules:
+Due to changes and fixes within the core Pode module itself, around the AutoImport functionality for modules, if you have the following in your `server.psd1` file to disable AutoImport for Modules:
 
 ```powershell
 @{
@@ -22,7 +22,7 @@ Due to changes and fixes within the core Pode module itself around the AutoImpor
 }
 ```
 
-You'll need to change this to the following; this will enable Module AutoImports, but it will restrict it to allowed modules added via `Export-PodeModule` - Pode.Web automatically calls this for you.
+Then you'll need to change this to the following configuration. This will enable Module AutoImports, but it will restrict it to only allow modules added via `Export-PodeModule` to be auto-imported - Pode.Web automatically calls this for you, so Pode can appropriately import the Pode.Web module.
 
 ```powershell
 @{

--- a/examples/server.psd1
+++ b/examples/server.psd1
@@ -1,16 +1,16 @@
 @{
     Server = @{
-        Request = @{
+        Request    = @{
             Timeout = 600
         }
         AutoImport = @{
             Modules = @{
-                Enable = $true
+                Enable     = $true
                 ExportOnly = $true
             }
         }
     }
-    Web = @{
+    Web    = @{
         Static = @{
             Cache = @{
                 Enable = $true


### PR DESCRIPTION
### Description of the Change
Updates the 1.0.0 migration docs, to reference that anybody who has Module AutoImport disabled in their `server.psd1` will need to enable it - but, to also have ExportOnly enabled as well.

Due to a fix made in Pode which ignored the AutoImport settings, it meant that anyone who disabled the feature didn't allow for Pode to auto-import the Pode.Web module - resulting in errors such as `can't find Get-PodeWebState`.

### Related Issue
Resolves #582 