### PR TITLE
Bump MkDocs from 1.6.0 to 1.6.1; Bump MkDocs Material from 9.5.23 to 9.6.4; Bump Pode from 2.10.1 to 2.12.0

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -15,9 +15,9 @@ $src_path = './pode_modules'
 #>
 
 $Versions = @{
-    MkDocs      = '1.6.0'
-    MkDocsTheme = '9.5.23'
-    Mike        = '2.1.1'
+    MkDocs      = '1.6.1'
+    MkDocsTheme = '9.6.4'
+    Mike        = '2.1.3'
     PlatyPS     = '0.14.2'
 }
 
@@ -438,6 +438,11 @@ task DocsDeploy DocsDeps, DocsHelpBuild, {
     mike deploy --push --update-aliases $version $alias
 }
 
+# Synopsis: Build the documentation
+task DocsBuild DocsDeps, DocsHelpBuild, {
+    mkdocs build --quiet
+}
+
 # Synopsis: Build the Release Notes
 task ReleaseNotes {
     if ([string]::IsNullOrWhiteSpace($ReleaseNoteVersion)) {
@@ -459,15 +464,15 @@ task ReleaseNotes {
     $dependabot = @{}
 
     foreach ($pr in $prs) {
-        if ($pr.labels.name -icontains 'superseded') {
+        $labels = @($pr.labels.name)
+        if ($labels -icontains 'superseded' -or
+            $labels -icontains 'new-release' -or
+            $labels -icontains 'internal-code :hammer:' -or
+            $labels -icontains 'exclude-from-release-notes') {
             continue
         }
 
         $label = ($pr.labels[0].name -split ' ')[0]
-        if ($label -iin @('new-release', 'internal-code')) {
-            continue
-        }
-
         if ([string]::IsNullOrWhiteSpace($label)) {
             $label = 'misc'
         }

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,57 @@
+name: Pode.Web CI - Docs
+
+on:
+  push:
+    branches:
+    - '*'
+    - '!gh-pages'
+    paths:
+    - 'mkdocs.yml'
+    - 'mkdocs-overrides/**'
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.build.ps1'
+    - 'src/Pode.Web.psd1'
+  pull_request:
+    branches:
+    - '*'
+    paths:
+    - 'mkdocs.yml'
+    - 'mkdocs-overrides/**'
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.build.ps1'
+    - 'src/Pode.Web.psd1'
+
+env:
+  INVOKE_BUILD_VERSION: '5.12.0'
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Output PowerShell version
+      shell: pwsh
+      run: |
+        $PSVersionTable.PSVersion
+
+    - name: Install Invoke-Build
+      shell: pwsh
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+
+    - name: Build Documentation
+      shell: pwsh
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-Build DocsBuild

--- a/.github/workflows/ci-pwsh.yml
+++ b/.github/workflows/ci-pwsh.yml
@@ -1,13 +1,32 @@
-name: Pode.Web CI
+name: Pode.Web CI - Pwsh
 
 on:
   push:
     branches:
     - '*'
     - '!gh-pages'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - '.build.ps1'
+    - '.github/workflows/ci-pwsh.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
+    - 'package.json'
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - '.build.ps1'
+    - '.github/workflows/ci-pwsh.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
+    - 'package.json'
+
+env:
+  INVOKE_BUILD_VERSION: '5.12.0'
 
 jobs:
   build:
@@ -20,13 +39,18 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
+    - name: Output PowerShell version
+      shell: pwsh
+      run: |
+        $PSVersionTable.PSVersion
 
     - name: Install Invoke-Build
       shell: pwsh
       run: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Install-Module -Name InvokeBuild -RequiredVersion '5.5.1' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
 
     - name: Install Yarn Packages
       shell: pwsh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
     "editor.formatOnSave": true,
     "editor.formatOnType": false,
     "editor.minimap.enabled": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
     "powershell.codeFormatting.addWhitespaceAroundPipe": true,
     "powershell.codeFormatting.alignPropertyValuePairs": true,
     "powershell.codeFormatting.autoCorrectAliases": true,
@@ -31,5 +33,8 @@
     "javascript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
     "javascript.format.insertSpaceAfterKeywordsInControlFlowStatements": true,
     "javascript.format.insertSpaceBeforeAndAfterBinaryOperators": true,
-    "javascript.format.insertSpaceBeforeFunctionParenthesis": false
+    "javascript.format.insertSpaceBeforeFunctionParenthesis": false,
+    "[yaml]": {
+        "editor.tabSize": 2
+    }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.10.1
+FROM badgerati/pode:2.12.0
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) [2020-2022] [Matthew Kelly (Badgerati)]
+Copyright (c) [2020-2025] [Matthew Kelly (Badgerati)]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
 # <img src="https://github.com/Badgerati/Pode/blob/develop/images/icon.png?raw=true" width="25" /> Pode.Web
 
-> This is the develop branch for Pode.Web v1.0.0, which is currently dependant on Pode v2.10.1. If you want the latest released Pode.Web code (v0.8.3), please view the master branch instead.
+> This is the develop branch for Pode.Web v1.0.0, which is currently dependant on Pode v2.12.0. If you want the latest released Pode.Web code (v0.8.3), please view the master branch instead.
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/Badgerati/Pode.Web/master/LICENSE.txt)
 [![Documentation](https://img.shields.io/github/v/release/badgerati/pode.web?label=docs)](https://badgerati.github.io/Pode.Web)
@@ -25,7 +25,7 @@
 - [🔥 Quick Example](#-quick-example)
 - [🌎 Roadmap](#-roadmap)
 
-This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.10.1+).
+This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.12.0+).
 
 It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge is required!
 

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.10.1-alpine
+FROM badgerati/pode:2.12.0-alpine
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.10.1-arm32
+FROM badgerati/pode:2.12.0-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -6,7 +6,7 @@ Pode.Web is a PowerShell module that works along side [Pode](https://github.com/
 
 Before installing Pode.Web, the minimum requirements must be met:
 
-* [Pode](https://github.com/Badgerati/Pode) v2.10.1+
+* [Pode](https://github.com/Badgerati/Pode) v2.12.0+
 
 Which also includes Pode's minimum requirements:
 * OS:
@@ -34,7 +34,7 @@ Install-Module -Name Pode.Web
 [![Docker](https://img.shields.io/docker/stars/badgerati/pode.web.svg?label=Stars)](https://hub.docker.com/r/badgerati/pode.web/)
 [![Docker](https://img.shields.io/docker/pulls/badgerati/pode.web.svg?label=Pulls)](https://hub.docker.com/r/badgerati/pode.web/)
 
-Like Pode, Pode.Web also has Docker images available. The images use Pode v2.10.1 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
+Like Pode, Pode.Web also has Docker images available. The images use Pode v2.12.0 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
 
 * To pull down the latest Pode.Web image you can do:
 

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -2,7 +2,7 @@
 
 Pode.Web has a Docker image that you can use to host your server, for instructions on pulling these images you can [look here](../../Getting-Started/Installation).
 
-The images use Pode v2.10.1 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
+The images use Pode v2.12.0 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
 
 ## Images
 
@@ -11,7 +11,7 @@ The images use Pode v2.10.1 on either an Ubuntu Focal (default), Alpine, or ARM3
 
 ### Default
 
-The default Pode.Web image is an Ubuntu Focal image with Pode v2.10.1 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
+The default Pode.Web image is an Ubuntu Focal image with Pode v2.12.0 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 
 > 💝 A lot of my free time, evenings, and weekends goes into making Pode happen; please do consider sponsoring as it will really help! 😊
 
-This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.10.1+).
+This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.12.0+).
 
 It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge is required!
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,5 +56,7 @@ extra:
       link: https://github.com/badgerati/pode
     - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/badgerati
+    - icon: fontawesome/brands/bluesky
+      link: https://bsky.app/profile/badgerati.bsky.social
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/badgerati/pode.web

--- a/src/Pode.Web.psd1
+++ b/src/Pode.Web.psd1
@@ -20,7 +20,7 @@
     Author            = 'Matthew Kelly (Badgerati)'
 
     # Copyright statement for this module
-    Copyright         = 'Copyright (c) 2020-2024 Matthew Kelly (Badgerati), licensed under the MIT License.'
+    Copyright         = 'Copyright (c) 2020-2025 Matthew Kelly (Badgerati), licensed under the MIT License.'
 
     # Description of the functionality provided by this module
     Description       = 'Web template framework for the Pode PowerShell web server'
@@ -31,7 +31,7 @@
     RequiredModules   = @(
         @{
             ModuleName    = 'Pode'
-            ModuleVersion = '2.10.1'
+            ModuleVersion = '2.12.0'
             Guid          = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
         }
     )


### PR DESCRIPTION
### Description of the Change
Bumps several versions:

* MkDocs to 1.6.1
* MkDocs Material to 9.6.4
* Mike to 2.1.3
* Pode to 2.12.0
* Adds CI pipeline for Docs