### PR TITLE
Set the default connection type to HTTP; Close SSE connections client-side when enabled; Use-PodeWebTemplates renamed to Initialize-PodeWebTemplates, alias for the former exists; Renames -ResponseType to -ConnectionType

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -16,7 +16,7 @@ $src_path = './pode_modules'
 
 $Versions = @{
     MkDocs      = '1.6.1'
-    MkDocsTheme = '9.6.4'
+    MkDocsTheme = '9.7.1'
     Mike        = '2.1.3'
     PlatyPS     = '0.14.2'
 }
@@ -401,11 +401,11 @@ task DocsHelpBuild DocsDeps, {
         $content = (Get-Content -Path $_.FullName | ForEach-Object {
                 $line = $_
 
-                while ($line -imatch '\[`(?<name>[a-z]+\-podeweb[a-z]+)`\](?<char>([^(]|$))') {
+                while ($line -imatch '(?<func>\[`(?<name>[a-z]+\-podeweb[a-z]+)`\])([^(])') {
                     $updated = $true
+                    $func = $Matches['func']
                     $name = $Matches['name']
-                    $char = $Matches['char']
-                    $line = ($line -ireplace "\[``$($name)``\]([^(]|$)", "[``$($name)``]($('../' * $depth)Functions/$($map[$name])/$($name))$($char)")
+                    $line = $line.Replace($func, "$($func)($('../' * $depth)Functions/$($map[$name])/$($name))")
                 }
 
                 $line

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.ps1 text eol=crlf
+*.psm1 text eol=crlf
+*.psd1 text eol=crlf
+*.md text eol=crlf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.12.0
+FROM badgerati/pode:2.12.1
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
 # <img src="https://github.com/Badgerati/Pode/blob/develop/images/icon.png?raw=true" width="25" /> Pode.Web
 
-> This is the develop branch for Pode.Web v1.0.0, which is currently dependant on Pode v2.12.0. If you want the latest released Pode.Web code (v0.8.3), please view the master branch instead.
+> This is the develop branch for Pode.Web v1.0.0, which is currently dependant on Pode v2.12.1. If you want the latest released Pode.Web code (v0.8.3), please view the master branch instead.
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/Badgerati/Pode.Web/master/LICENSE.txt)
 [![Documentation](https://img.shields.io/github/v/release/badgerati/pode.web?label=docs)](https://badgerati.github.io/Pode.Web)
@@ -25,7 +25,7 @@
 - [🔥 Quick Example](#-quick-example)
 - [🌎 Roadmap](#-roadmap)
 
-This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.12.0+).
+This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.12.1+).
 
 It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge is required!
 
@@ -98,7 +98,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
 
     # set the use of the pode.web templates
-    Use-PodeWebTemplates -Title 'Example' -Theme Midnight
+    Initialize-PodeWebTemplates -Title 'Example' -Theme Midnight
 
     # add the page
     Add-PodeWebPage -Name Processes -Icon Activity -ScriptBlock {

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.12.0-alpine
+FROM badgerati/pode:2.12.1-alpine
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/pode:2.12.0-arm32
+FROM badgerati/pode:2.12.1-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode.Web
 COPY ./src/ /usr/local/share/powershell/Modules/Pode.Web

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -6,7 +6,7 @@ Pode.Web is a PowerShell module that works along side [Pode](https://github.com/
 
 Before installing Pode.Web, the minimum requirements must be met:
 
-* [Pode](https://github.com/Badgerati/Pode) v2.12.0+
+* [Pode](https://github.com/Badgerati/Pode) v2.12.1+
 
 Which also includes Pode's minimum requirements:
 * OS:
@@ -34,7 +34,7 @@ Install-Module -Name Pode.Web
 [![Docker](https://img.shields.io/docker/stars/badgerati/pode.web.svg?label=Stars)](https://hub.docker.com/r/badgerati/pode.web/)
 [![Docker](https://img.shields.io/docker/pulls/badgerati/pode.web.svg?label=Pulls)](https://hub.docker.com/r/badgerati/pode.web/)
 
-Like Pode, Pode.Web also has Docker images available. The images use Pode v2.12.0 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
+Like Pode, Pode.Web also has Docker images available. The images use Pode v2.12.1 on either an Ubuntu Focal image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
 
 * To pull down the latest Pode.Web image you can do:
 
@@ -112,7 +112,7 @@ Once installed, you then need to import the module at the top of your Pode serve
 Import-Module -Name Pode.Web
 
 Start-PodeServer {
-    Use-PodeWebTemplates -Title '<Title>'
+    Initialize-PodeWebTemplates -Title '<Title>'
 }
 ```
 

--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -6,6 +6,12 @@ In Pode.Web v1.X all elements are now rendered client-side using JavaScript, rat
 
 ## Module
 
+### Initialisation
+
+When you create a new Pode server, and you wish to use the Pode.Web module, you have to first call `Use-PodeWebTemplates`. Whilst an alias for this function still exists for now, the function itself has been renamed to `Initialize-PodeWebTemplates` - while not mandatory yet, it is recommended to migrate to the new name, and use in any new scripts.
+
+There is no date as to when `Use-PodeWebTemplates` will be removed, if at all in v1.X, but it will definitely be removed when a v2 is released.
+
 ### AutoImport Settings
 
 Due to changes and fixes within the core Pode module itself, around the AutoImport functionality for modules, if you have the following in your `server.psd1` file to disable AutoImport for Modules:
@@ -198,7 +204,7 @@ In Pode.Web v1.X it is possible to set custom paths on `Add-PodeWebPage`. Becaus
 
 The Home Page in Pode.Web is still a "special" kind of system page - used by Login page redirects and the header icon. Therefore, if you create a Home Page using `Add-PodeWebPage` it's recommended to flag it as such by supplying the new `-HomePage` switch.
 
-For example, if currently have a `Set-PodeWebHomePage` setup similar to the below:
+For example, if you currently have a `Set-PodeWebHomePage` setup similar to the below:
 
 ```powershell
 Set-PodeWebHomePage -Content $section -Title 'Awesome Homepage'
@@ -220,9 +226,9 @@ The `-Source` parameter on `New-PodeWebLink` has been renamed to `-Url`.
 
 ### Default Root Page
 
-Before v1.X, when `Use-PodeWebTemplates` was called it would set up an empty root (`/`) page for you as the Home Page - meaning you were always forced to have a "Home" page in the sidebar. In v1.X this is no longer the case, a default root Home page is no longer automatically configured.
+Before v1.X, when `Use-PodeWebTemplates` (now `Initialize-PodeWebTemplates`) was called it would set up an empty root (`/`) page for you as the Home Page - meaning you were always forced to have a "Home" page in the sidebar. In v1.X this is no longer the case, a default root Home page is no longer automatically configured.
 
-If you would like to have a default root page still set up, but simply redirect the user to the first available page, you can use the new `-RootRedirect` on `Use-PodeWebTemplates`. This switch will simply set up a behind-the-scenes root for redirection, and will not appear as a "Home" page on your sidebar.
+If you would like to have a default root page still set up, but simply redirect the user to the first available page, you can use the new `-RootRedirect` on `Initialize-PodeWebTemplates`. This switch will simply set up a behind-the-scenes root for redirection, and will not appear as a "Home" page on your sidebar.
 
 ## Pode.Web Static Content
 

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -2,7 +2,7 @@
 
 Pode.Web has a Docker image that you can use to host your server, for instructions on pulling these images you can [look here](../../Getting-Started/Installation).
 
-The images use Pode v2.12.0 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
+The images use Pode v2.12.1 on either an Ubuntu Focal (default), Alpine, or ARM32 image.
 
 ## Images
 
@@ -11,7 +11,7 @@ The images use Pode v2.12.0 on either an Ubuntu Focal (default), Alpine, or ARM3
 
 ### Default
 
-The default Pode.Web image is an Ubuntu Focal image with Pode v2.12.0 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
+The default Pode.Web image is an Ubuntu Focal image with Pode v2.12.1 and Pode.Web installed. An example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image

--- a/docs/Tutorials/Actions/Theme.md
+++ b/docs/Tutorials/Actions/Theme.md
@@ -7,7 +7,7 @@ This page details the actions available to the Theme of pages.
 To update the theme for a user you can use [`Update-PodeWebTheme`](../../../Functions/Actions/Update-PodeWebTheme). This will update the frontend cookie, and then reload the page to toggle the rendering theme:
 
 ```powershell
-Use-PodeWebTemplates -Title Test -Theme Dark
+Initialize-PodeWebTemplates -Title Test -Theme Dark
 
 New-PodeWebContainer -NoBackground -Content @(
     New-PodeWebButton -Name 'Dark Theme' -Icon 'moon-new' -Colour Dark -ScriptBlock {

--- a/docs/Tutorials/Basics.md
+++ b/docs/Tutorials/Basics.md
@@ -40,19 +40,19 @@ The default timeout in Pode is 30 seconds, so if you have elements/Routes you kn
 }
 ```
 
-## Use the Templates
+## Initialise the Templates
 
-Pode.Web contains extension functions that can be used within your [Pode](https://github.com/Badgerati/Pode) server. To initialise Pode.Web and start using its functions you'll first need to call [`Use-PodeWebTemplates`](../../Functions/Utilities/Use-PodeWebTemplates) as one of the first functions within your `Start-PodeServer` scriptblock. This will let you define the title of your website, the default theme, and the logo/favicon.
+Pode.Web contains extension functions that can be used within your [Pode](https://github.com/Badgerati/Pode) server. To initialise Pode.Web, and start using its functions, you'll first need to call [`Initialize-PodeWebTemplates`](../../Functions/Utilities/Initialize-PodeWebTemplates) as one of the first functions within your `Start-PodeServer` scriptblock. This will let you define the title of your website, the default theme, and the logo/favicon.
 
 !!! important
-    You **must** call [`Use-PodeWebTemplates`](../../Functions/Utilities/Use-PodeWebTemplates) before you can start using any other function within the Pode.Web module. Ideally, you should make this the first function call within `Start-PodeServer` after you have called `Add-PodeEndpoint`.
+    You **must** call [`Initialize-PodeWebTemplates`](../../Functions/Utilities/Initialize-PodeWebTemplates) before you can start using any other function within the Pode.Web module. Ideally, you should make this the first function call within `Start-PodeServer` after you have called `Add-PodeEndpoint`.
 
 ```powershell
 Import-Module -Name Pode.Web
 
 Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
-    Use-PodeWebTemplates -Title 'Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Example' -Theme Dark
 }
 ```
 
@@ -66,28 +66,43 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http -Name Admin
 
     # this will bind the site to the Admin endpoint
-    Use-PodeWebTemplates -Title 'Example' -Theme Dark -EndpointName Admin
+    Initialize-PodeWebTemplates -Title 'Example' -Theme Dark -EndpointName Admin
 }
 ```
 
-### Response Type
+### Connection Type
 
-By default Pode.Web will use SSE to send data back to any connected clients, this allows feedback from Pode.Web's actions to be done asynchronously - if you have a button click that does some lengthy processing, you can update a client on the current progress.
+#### HTTP
 
-However, if required, you can switch Pode.Web's response type back to HTTP via the `-ResponseType` parameter on [`Use-PodeWebTemplates`](../../Functions/Utilities/Use-PodeWebTemplates).
+By default Pode.Web will use HTTP connections to send data back to connected clients - this means the standard request/response pattern for HTTP connections will be used. If you have a Form on your page and a user submits it, and then you have multiple Actions - such as table/progress updates - within that Form's scriptblock, then these Actions will all occur after the scriptblock has completed.
+
+For a lot of peoples use-cases this pattern is sufficient: user clicks a button, your server does some work and then responds back with a single action.
+
+#### SSE
+
+If required, Pode.Web does have support for SSE connections - instead of the default of HTTP. This allows feedback from Pode.Web's Actions to be done asynchronously - if a user submits a button for a Form that does some lengthy processing, you can update a client on the current progress; multiple Actions respond in "real-time", not all at the end of processing the scriptblock like standard HTTP connections.
+
+To switch to SSE connections pass the `-ConnectionType` parameter on [`Initialize-PodeWebTemplates`](../../Functions/Utilities/Initialize-PodeWebTemplates):
 
 ```powershell
 Import-Module -Name Pode.Web
 
 Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
-    Use-PodeWebTemplates -Title 'Example' -ResponseType Http
+    Initialize-PodeWebTemplates -Title 'Example' -ConnectionType Sse
 }
 ```
 
+!!! warning
+    SSE connections are left open between the client and server, if too many are opened you will start to see CPU/performance issues.
+
+    Additionally, most browsers only allow 6 SSE connections open per window - not tab, per **window**. Pode.Web does close SSE connections on the client-side when you swap between pages and close tabs/windows, but if you have 6 tabs open you might start receiving errors from your browser, or seeing "hanging" issues.
+
+    Furthermore, when SSE connections are closed client-side - which will be common - they will remain "open" on the server for ~60 seconds before auto-cleanup removes stale connections on the server-side.
+
 ### Root Redirect
 
-You can have [`Use-PodeWebTemplates`](../../Functions/Utilities/Use-PodeWebTemplates) set up a default root (`/`) Route for you, which simply redirects the user to the first created Page of your site, by supplying the `-RootRedirect` switch.
+You can have [`Initialize-PodeWebTemplates`](../../Functions/Utilities/Initialize-PodeWebTemplates) set up a default root (`/`) Route for you, which simply redirects the user to the first created Page of your site, by supplying the `-RootRedirect` switch.
 
 This will let users navigate to `http://localhost:8080/` and be redirected to a page without seeing a 404 error.
 
@@ -122,13 +137,13 @@ The above would render a new page with a table, showing all the services on the 
 Pages added to your site will appear in the sidebar on the left of your pages. The sidebar has a filter box at the top by default, but this can be removed via `-NoPageFilter`:
 
 ```powershell
-Use-PodeWebTemplates -Title 'Example' -Theme Dark -NoPageFilter
+Initialize-PodeWebTemplates -Title 'Example' -Theme Dark -NoPageFilter
 ```
 
 You can also force the sidebar to be hidden by default via `-HideSidebar`:
 
 ```powershell
-Use-PodeWebTemplates -Title 'Example' -Theme Dark -HideSidebar
+Initialize-PodeWebTemplates -Title 'Example' -Theme Dark -HideSidebar
 ```
 
 ## Custom Scripts/Styles

--- a/docs/Tutorials/Pages.md
+++ b/docs/Tutorials/Pages.md
@@ -330,7 +330,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
 
     # set the use of templates
-    Use-PodeWebTemplates -Title 'Pester'
+    Initialize-PodeWebTemplates -Title 'Pester'
 
     # convert module to pages
     ConvertTo-PodeWebPage -Module Pester -GroupVerbs

--- a/docs/Tutorials/Security.md
+++ b/docs/Tutorials/Security.md
@@ -6,10 +6,10 @@ Pode.Web uses this feature to automatically set some default headers on requests
 
 ## Options
 
-To set which security type to use, you can optionally specify a type via the `-Security` parameter on [`Use-PodeWebTemplates`](../../Functions/Utilities/Use-PodeWebTemplates). The valid values are: None, Default, Simple, and Strict.
+To set which security type to use, you can optionally specify a type via the `-Security` parameter on [`Initialize-PodeWebTemplates`](../../Functions/Utilities/Initialize-PodeWebTemplates). The valid values are: None, Default, Simple, and Strict.
 
 ```powershell
-Use-PodeWebTemplates -Title 'Test' -Theme Dark -Security Simple
+Initialize-PodeWebTemplates -Title 'Test' -Theme Dark -Security Simple
 ```
 
 In the case of the Default, Simple and Strict types: Pode.Web uses the inbuilt security types within Pode (simple for default), and adds some extra essential default Content Security Policy rules to allow Pode.Web to function:
@@ -66,7 +66,7 @@ The same also applies to styles and scripts as well.
 
 ### HSTS
 
-If you need to enable HSTS for your site, you can do so vua supplying the `-UseHSTS` switch on [`Use-PodeWebTemplates`](../../Functions/Utilities/Use-PodeWebTemplates).
+If you need to enable HSTS for your site, you can do so vua supplying the `-UseHSTS` switch on [`Initialize-PodeWebTemplates`](../../Functions/Utilities/Initialize-PodeWebTemplates).
 
 ### Rating
 

--- a/docs/Tutorials/Themes.md
+++ b/docs/Tutorials/Themes.md
@@ -1,6 +1,6 @@
 # Themes
 
-Pode.Web comes with some inbuilt themes (including a dark theme!), plus the ability to build/use custom themes. Themes are set using [`Use-PodeWebTemplates`](../../Functions/Utilities/Use-PodeWebTemplates), or custom ones can be built using [`Add-PodeWebCustomTheme`](../../Functions/Utilities/Add-PodeWebCustomTheme).
+Pode.Web comes with some inbuilt themes (including a dark theme!), plus the ability to build/use custom themes. Themes are set using [`Initialize-PodeWebTemplates`](../../Functions/Utilities/Initialize-PodeWebTemplates), or custom ones can be built using [`Add-PodeWebCustomTheme`](../../Functions/Utilities/Add-PodeWebCustomTheme).
 
 ## Inbuilt
 
@@ -17,7 +17,7 @@ Pode.Web has 7 inbuilt themes:
 For example, to use the `Dark` theme:
 
 ```powershell
-Use-PodeWebTemplates -Title 'Example' -Theme Dark
+Initialize-PodeWebTemplates -Title 'Example' -Theme Dark
 ```
 
 Examples of how the inbuilt themes look are as follows:
@@ -54,7 +54,7 @@ This will allow you to build on top of, or customise, one of Pode.Web's inbuilt 
 One option for using a custom theme is to directly create a custom CSS file, and then have Pode.Web use that file by either literal or relative URL:
 
 ```powershell
-Use-PodeWebTemplates -Title 'Example' -Theme Custom
+Initialize-PodeWebTemplates -Title 'Example' -Theme Custom
 
 # literal url
 Add-PodeWebCustomTheme -Name 'Custom1' -Url 'https://example.com/custom-theme.css'
@@ -83,7 +83,7 @@ Instead of rolling a custom CSS file, Pode.Web comes with some functions that al
 Let's say you want to use the Dark theme as a base, and change the Page background to "darkred" and the font-family to "wingdings" (because why not!):
 
 ```powershell
-Use-PodeWebTemplates -Title 'Example' -Theme Custom
+Initialize-PodeWebTemplates -Title 'Example' -Theme Custom
 Add-PodeWebCustomTheme -Name 'Custom1' -Base Dark `
     -BackgroundColourConfig (New-PodeWebBackgroundColourConfig -Page 'darkred') `
     -FontFamily 'wingdings'
@@ -96,7 +96,7 @@ Only the parameters you supply will be applied and override the base theme - in 
 A fuller example, still using the Dark theme as a base, would be as follows. Here we supply nearly all possible configuration to build a custom darkred theme:
 
 ```powershell
-Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Custom
+Initialize-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Custom
 
 $bgColourConfig = @{
     Page      = '#000'

--- a/docs/Tutorials/UpdatingAsync.md
+++ b/docs/Tutorials/UpdatingAsync.md
@@ -3,7 +3,7 @@
 In Pode.Web you can update users asynchronously, whether it be updating the rows of a Table from a long-running Task to retrieve data, or sending a Toast to all connected users from a Timer, it can be done asynchronously by sending events back to the user(s).
 
 !!! important
-    This feature is dependent on using SSE, if you have `-ResponseType Http` configured on your `Use-PodeWebTemplates` call, then asynchronous updates won't work.
+    This feature is dependent on using SSE connections. If you don't supply `-ConnectionType` to `Initialize-PodeWebTemplates`, or you do but it's set to HTTP, then asynchronous updates **will not** work.
 
 ## Connections
 
@@ -101,7 +101,7 @@ Add-PodeTask -Name 'GetProcesses' -ScriptBlock {
 ```
 
 !!! tip
-    You can use a Task to call other actions as well and update other elements - not just Tables! ??
+    You can use a Task to call other actions as well and update other elements - not just Tables!
 
 ### Timers / Schedules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 
 > 💝 A lot of my free time, evenings, and weekends goes into making Pode happen; please do consider sponsoring as it will really help! 😊
 
-This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.12.0+).
+This is a web template framework for use with the [Pode](https://github.com/Badgerati/Pode) PowerShell web server (v2.12.1+).
 
 It allows you to build web pages purely with PowerShell - no HTML, CSS, or JavaScript knowledge is required!
 
@@ -45,7 +45,7 @@ Import-Module Pode.Web
 Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
 
-    Use-PodeWebTemplates -Title 'Example' -Theme Midnight
+    Initialize-PodeWebTemplates -Title 'Example' -Theme Midnight
 
     Add-PodeWebPage -Name 'Services' -Icon 'Settings' -ScriptBlock {
         New-PodeWebCard -Content @(

--- a/examples/accordion.ps1
+++ b/examples/accordion.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Accordion' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Accordion' -Theme Dark
 
     # set the home page controls
     $acc = New-PodeWebAccordion -Name 'Accordion1' -Cycle -Bellows @(

--- a/examples/alerts.ps1
+++ b/examples/alerts.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Alerts' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Alerts' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
     $card = New-PodeWebCard -Content @(

--- a/examples/async-updates.ps1
+++ b/examples/async-updates.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Async Updates' -Theme Dark -RootRedirect
+    Initialize-PodeWebTemplates -Title 'Async Updates' -Theme Dark -RootRedirect
 
     # add a home page page
     Add-PodeWebPage -Name 'Page 1' -Id 'page_1' -HomePage -ScriptBlock {

--- a/examples/audio.ps1
+++ b/examples/audio.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Audio' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Audio' -Theme Dark
 
     # set the home page controls
     Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Title 'Audio' -Content @(

--- a/examples/badges.ps1
+++ b/examples/badges.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Badges' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Badges' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
     $card = New-PodeWebCard -Content @(

--- a/examples/basic.ps1
+++ b/examples/basic.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Basic Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Basic Example' -Theme Dark
 
     # social
     Set-PodeWebSocial -Type GitHub -Url 'https://github.com/badgerati'

--- a/examples/buttons.ps1
+++ b/examples/buttons.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Buttons' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Buttons' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
     $card = New-PodeWebCard -Content @(

--- a/examples/catfacts.ps1
+++ b/examples/catfacts.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'CatFacts' -Theme Dark -RootRedirect
+    Initialize-PodeWebTemplates -Title 'CatFacts' -Theme Dark -RootRedirect
 
     $table = New-PodeWebTable -Name 'Static' -DataColumn ID -AsCard -Click -Paginate -ScriptBlock {
         # refresh button, to refresh the current row

--- a/examples/charts.ps1
+++ b/examples/charts.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Charts' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Charts' -Theme Dark
 
     $chartData = {
         $count = 1

--- a/examples/class_and_style.ps1
+++ b/examples/class_and_style.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Classy Styles' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Classy Styles' -Theme Dark
 
     # import the custom css/js
     Import-PodeWebStylesheet -Url '/my-styles.css'

--- a/examples/code-editor.ps1
+++ b/examples/code-editor.ps1
@@ -8,7 +8,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Code Editor' -Logo '/pode.web-static/images/icon.png' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Code Editor' -Logo '/pode.web-static/images/icon.png' -Theme Dark
 
 
     $codeEditor = New-PodeWebCodeEditor -Language Html -Name 'Code Editor' -AsCard -Value '<p style="color:white;">well</p>' -Upload {

--- a/examples/cores.ps1
+++ b/examples/cores.ps1
@@ -8,7 +8,7 @@ Start-PodeServer {
 
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Azure Core Usage' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Azure Core Usage' -Theme Dark
 
 
     # set the home page controls

--- a/examples/dynamic-pages.ps1
+++ b/examples/dynamic-pages.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Dynamic Pages' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Dynamic Pages' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
     Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Title 'Awesome Homepage' -Icon 'cat' -ScriptBlock {

--- a/examples/element-groups.ps1
+++ b/examples/element-groups.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Element Groups' -Theme Dark -RootRedirect
+    Initialize-PodeWebTemplates -Title 'Element Groups' -Theme Dark -RootRedirect
 
     # set the controls
     Add-PodeWebPage -Name 'Example' -HomePage -ScriptBlock {

--- a/examples/endpoints.ps1
+++ b/examples/endpoints.ps1
@@ -9,7 +9,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Basic Example' -Theme Dark -EndpointName '8090Endpoint', '8091Endpoint'
+    Initialize-PodeWebTemplates -Title 'Basic Example' -Theme Dark -EndpointName '8090Endpoint', '8091Endpoint'
 
     # set the home page controls (just a simple paragraph)
     $section = New-PodeWebCard -Name 'Welcome' -NoTitle -Content @(

--- a/examples/excel.ps1
+++ b/examples/excel.ps1
@@ -12,7 +12,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title Test -Logo '/pode.web-static/images/icon.png' -Theme Dark
+    Initialize-PodeWebTemplates -Title Test -Logo '/pode.web-static/images/icon.png' -Theme Dark
 
 
     # add a page to search and filter services (output in a new table element)

--- a/examples/file-stream.ps1
+++ b/examples/file-stream.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Streaming' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Streaming' -Theme Dark
 
     # set the home page controls
     $con = New-PodeWebContainer -Content @(

--- a/examples/full.ps1
+++ b/examples/full.ps1
@@ -6,9 +6,8 @@ Start-PodeServer -StatusPageExceptions Show {
     Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-
     # enable sessions and authentication
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
+    Enable-PodeSessionMiddleware -Duration (10 * 60) -Extend
 
     New-PodeAuthScheme -Form | Add-PodeAuth -Name Example -SuccessUseOrigin -ScriptBlock {
         param($username, $password)
@@ -31,7 +30,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # set the use of templates
-    Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark -ConnectionType SSE
 
     # add a custom darkred theme
     Add-PodeWebCustomTheme -Name DarkRed -Base Dark `
@@ -81,7 +80,7 @@ Start-PodeServer -StatusPageExceptions Show {
             New-PodeWebText -Value ' paragraphs' -Style Bold
         )
         New-PodeWebParagraph -Content @(
-            New-PodeWebText -Value 'Pronuncation example: '
+            New-PodeWebText -Value 'Pronunciation example: '
             New-PodeWebText -Value '漢' -Pronunciation 'ㄏㄢˋ'
         )
         New-PodeWebParagraph -Content @(
@@ -205,17 +204,17 @@ Start-PodeServer -StatusPageExceptions Show {
 
     $carousel = New-PodeWebCarousel -Slides @(
         New-PodeWebSlide -Title 'First Slide' -Message 'First slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 1' -Alignment Center
             )
         )
         New-PodeWebSlide -Title 'Second Slide' -Message 'Second slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 2' -Alignment Center
             )
         )
         New-PodeWebSlide -Title 'Third Slide' -Message 'Third slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 3' -Alignment Center
             )
         )

--- a/examples/full_custom_auth.ps1
+++ b/examples/full_custom_auth.ps1
@@ -8,7 +8,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # enable sessions and authentication
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
+    Enable-PodeSessionMiddleware -Duration (10 * 60) -Extend
 
     # define a new custom authentication scheme, which needs a client, username, and password
     $custom_scheme = New-PodeAuthScheme -Custom -ScriptBlock {
@@ -46,7 +46,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # set the use of templates
-    Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
 
     # set login page
     # -BackgroundImage '/images/galaxy.jpg'
@@ -206,17 +206,17 @@ Start-PodeServer -StatusPageExceptions Show {
 
     $carousel = New-PodeWebCarousel -Slides @(
         New-PodeWebSlide -Title 'First Slide' -Message 'First slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 1' -Alignment Center
             )
         )
         New-PodeWebSlide -Title 'Second Slide' -Message 'Second slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 2' -Alignment Center
             )
         )
         New-PodeWebSlide -Title 'Third Slide' -Message 'Third slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 3' -Alignment Center
             )
         )

--- a/examples/full_iis.ps1
+++ b/examples/full_iis.ps1
@@ -1,5 +1,4 @@
-#Import-Module Pode -MaximumVersion 2.99.99 -Force
-Import-Module ..\..\Pode\src\Pode.psm1 -Force
+Import-Module Pode -MaximumVersion 2.99.99 -Force
 Import-Module ..\src\Pode.Web.psm1 -Force
 
 Start-PodeServer -StatusPageExceptions Show {
@@ -9,11 +8,11 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # enable sessions and authentication
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
+    Enable-PodeSessionMiddleware -Duration (10 * 60) -Extend
     Add-PodeAuthIIS -Name Example
 
     # set the use of templates
-    Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
 
     # set auth to iis
     Set-PodeWebAuth -Authentication Example
@@ -164,17 +163,17 @@ Start-PodeServer -StatusPageExceptions Show {
 
     $carousel = New-PodeWebCarousel -Slides @(
         New-PodeWebSlide -Title 'First Slide' -Message 'First slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 1' -Alignment Center
             )
         )
         New-PodeWebSlide -Title 'Second Slide' -Message 'Second slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 2' -Alignment Center
             )
         )
         New-PodeWebSlide -Title 'Third Slide' -Message 'Third slide message' -Content @(
-            New-PodeWebContainer -Nobackground -Content @(
+            New-PodeWebContainer -NoBackground -Content @(
                 New-PodeWebText -Value 'Slide 3' -Alignment Center
             )
         )

--- a/examples/functions.ps1
+++ b/examples/functions.ps1
@@ -10,7 +10,7 @@ Start-PodeServer {
 
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Functions' -RootRedirect
+    Initialize-PodeWebTemplates -Title 'Functions' -RootRedirect
 
     Export-PodeModule -Name 'functions'
 

--- a/examples/icons.ps1
+++ b/examples/icons.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Icons' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Icons' -Theme Dark
 
     # set the home page controls
     $card1 = New-PodeWebCard -Content @(

--- a/examples/iframe.ps1
+++ b/examples/iframe.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'IFrame Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'IFrame Example' -Theme Dark
 
     $con1 = New-PodeWebContainer -Content @(
         1..3 |  ForEach-Object {

--- a/examples/input_events.ps1
+++ b/examples/input_events.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Input Events' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Input Events' -Theme Dark
 
 
     # select event

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Inputs' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Inputs' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
     $form = New-PodeWebForm -Name 'Test' -ButtonType Submit, Reset -AsCard -ScriptBlock {

--- a/examples/language.ps1
+++ b/examples/language.ps1
@@ -8,7 +8,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # set the use of templates
-    Use-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Test' -Logo '/pode.web-static/images/icon.png' -Theme Dark
 
     $chartData = {
         $count = 1

--- a/examples/links.ps1
+++ b/examples/links.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Browse {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Links Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Links Example' -Theme Dark
 
     # home page with link togglging
     Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Title 'Homepage' -ScriptBlock {

--- a/examples/login-azure-ad.ps1
+++ b/examples/login-azure-ad.ps1
@@ -6,7 +6,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
 
     # enable sessions and authentication
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
+    Enable-PodeSessionMiddleware -Duration (10 * 60) -Extend
 
     $clientId = '<client-id-from-portal>'
     $clientSecret = '<client-secret-from-portal>'
@@ -25,7 +25,7 @@ Start-PodeServer {
     }
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Login Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Login Example' -Theme Dark
     Set-PodeWebLoginPage -Authentication AzureAD
 
     # set the home page controls (just a simple paragraph)

--- a/examples/login-oauth2.ps1
+++ b/examples/login-oauth2.ps1
@@ -48,7 +48,7 @@ Start-PodeServer -Threads 2 {
     }
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Login Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Login Example' -Theme Dark
     Set-PodeWebLoginPage -Authentication MockOAuth2
 
     # set the home page controls (just a simple paragraph)

--- a/examples/login.ps1
+++ b/examples/login.ps1
@@ -6,7 +6,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
 
     # enable sessions and authentication
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
+    Enable-PodeSessionMiddleware -Duration (10 * 60) -Extend
 
     New-PodeAuthScheme -Form | Add-PodeAuth -Name Login -ScriptBlock {
         param($username, $password)
@@ -22,7 +22,7 @@ Start-PodeServer {
     }
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Login Example'
+    Initialize-PodeWebTemplates -Title 'Login Example'
     Set-PodeWebLoginPage -Authentication Login
 
     # set the home page controls (just a simple paragraph)

--- a/examples/modals.ps1
+++ b/examples/modals.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Browse {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Modals Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Modals Example' -Theme Dark
 
     # home page with link togglging
     Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Title 'Homepage' -ScriptBlock {

--- a/examples/module.ps1
+++ b/examples/module.ps1
@@ -8,7 +8,7 @@ Start-PodeServer {
 
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Pester' -RootRedirect
+    Initialize-PodeWebTemplates -Title 'Pester' -RootRedirect
 
 
     # convert module to pages

--- a/examples/multi-table.ps1
+++ b/examples/multi-table.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Basic Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Basic Example' -Theme Dark
 
     Add-PodeWebPage -Name Table -Icon 'chart-box-outline' -NoBackArrow -ScriptBlock {
         $value = $WebEvent.Query['value']

--- a/examples/paragraphs.ps1
+++ b/examples/paragraphs.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Paragraphs' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Paragraphs' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
     $card1 = New-PodeWebCard -Content @(

--- a/examples/processes.ps1
+++ b/examples/processes.ps1
@@ -7,13 +7,13 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # login/auth
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration (10 * 60) -Extend
+    Enable-PodeSessionMiddleware -Duration (10 * 60) -Extend
     New-PodeAuthScheme -Form | Add-PodeAuth -Name Example -ScriptBlock {
         param($username, $password)
 
         if ($username -eq 'morty' -and $password -eq 'pickle') {
             return @{
-                User = @{ ID ='M0R7Y302'; Name = 'Morty'; Type = 'Human' }
+                User = @{ ID = 'M0R7Y302'; Name = 'Morty'; Type = 'Human' }
             }
         }
 
@@ -21,7 +21,7 @@ Start-PodeServer {
     }
 
     # templates / login page
-    Use-PodeWebTemplates -Title Test -Theme Dark
+    Initialize-PodeWebTemplates -Title Test -Theme Dark -RootRedirect
     Set-PodeWebLoginPage -Authentication Example
 
     # processes - table for results, and a form to search
@@ -34,7 +34,7 @@ Start-PodeServer {
         New-PodeWebTextbox -Name 'Name'
     )
 
-    Add-PodeWebPage -Name Processes -Icon 'chart-box-outline' -Content $form, $table
+    Add-PodeWebPage -Name Processes -Icon 'chart-box-outline' -Content $form, $table -HomePage
 
     # processes - table for results, and a form to search, but table as action
     $form2 = New-PodeWebForm -Name 'Search2' -AsCard -ScriptBlock {

--- a/examples/progress-async.ps1
+++ b/examples/progress-async.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Progress Async' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Progress Async' -Theme Dark
 
     # set the controls
     Add-PodeWebPage -Name 'Example' -ScriptBlock {

--- a/examples/raw.ps1
+++ b/examples/raw.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Raw' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Raw' -Theme Dark
 
     # set the home page controls (just a simple paragraph)
     $card = New-PodeWebCard -Content @(

--- a/examples/scoped-variables.ps1
+++ b/examples/scoped-variables.ps1
@@ -9,7 +9,7 @@ Start-PodeServer -StatusPageExceptions Show {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Basic Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Basic Example' -Theme Dark
     $state:card_name = 'Hello, there!'
 
     # set the home page controls (just a simple paragraph)

--- a/examples/sessions-tabs.ps1
+++ b/examples/sessions-tabs.ps1
@@ -30,7 +30,7 @@ Start-PodeServer -StatusPageExceptions Show {
 
 
     # set the use of templates
-    Use-PodeWebTemplates -Title 'Sessions' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Sessions' -Theme Dark
 
     # set login page
     Set-PodeWebLoginPage -Authentication Example -PassThru

--- a/examples/steps.ps1
+++ b/examples/steps.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Steps Example' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Steps Example' -Theme Dark
 
 
     # set the home page controls (just a simple paragraph)

--- a/examples/tables.ps1
+++ b/examples/tables.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Tables' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Tables' -Theme Dark
 
     # set the home page controls
     $card1 = New-PodeWebTable `

--- a/examples/tiles.ps1
+++ b/examples/tiles.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Tiles' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Tiles' -Theme Dark
 
     $processData = {
         Get-Process |

--- a/examples/upload.ps1
+++ b/examples/upload.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'File Upload' -Theme Terminal
+    Initialize-PodeWebTemplates -Title 'File Upload' -Theme Terminal
 
     # set the home page controls (just a simple paragraph)
     $form = New-PodeWebForm -Name 'Test'  -AsCard -ScriptBlock {

--- a/examples/video.ps1
+++ b/examples/video.ps1
@@ -7,7 +7,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the use of templates, and set a login page
-    Use-PodeWebTemplates -Title 'Video' -Theme Dark
+    Initialize-PodeWebTemplates -Title 'Video' -Theme Dark
 
     # set the home page controls
     Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Title 'Video' -Content @(

--- a/src/Pode.Web.psd1
+++ b/src/Pode.Web.psd1
@@ -31,7 +31,7 @@
     RequiredModules   = @(
         @{
             ModuleName    = 'Pode'
-            ModuleVersion = '2.12.0'
+            ModuleVersion = '2.12.1'
             Guid          = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
         }
     )

--- a/src/Pode.Web.psm1
+++ b/src/Pode.Web.psm1
@@ -1,33 +1,57 @@
 # root path
 $root = Split-Path -Parent -Path $MyInvocation.MyCommand.Path
 
-# load binaries
-Add-Type -AssemblyName System.Web
-Add-Type -AssemblyName System.Net.Http
+try {
+    # load binaries
+    Add-Type -AssemblyName System.Web
+    Add-Type -AssemblyName System.Net.Http
 
-# stop ansi colours in ps7.2+
-if ($PSVersionTable.PSVersion -ge [version]'7.2.0') {
-    $PSStyle.OutputRendering = 'PlainText'
+    # stop ansi colours in ps7.2+
+    if ($PSVersionTable.PSVersion -ge [version]'7.2.0') {
+        $PSStyle.OutputRendering = 'PlainText'
+    }
+
+    # import everything if in a runspace
+    if ($PODE_SCOPE_RUNSPACE) {
+        $sysFuncs = Get-ChildItem Function:
+        $sysAliases = Get-ChildItem Alias:
+    }
+
+    # load private functions
+    Get-ChildItem "$($root)/Private/*.ps1" | Resolve-Path | ForEach-Object { . $_ }
+
+    # only import public functions/aliases if not in a runspace
+    if (!$PODE_SCOPE_RUNSPACE) {
+        $sysFuncs = Get-ChildItem Function:
+        $sysAliases = Get-ChildItem Alias:
+    }
+
+    # load public functions
+    Get-ChildItem "$($root)/Public/*.ps1" | Resolve-Path | ForEach-Object { . $_ }
+
+    # get functions/aliases from memory and compare to existing to find new functions added
+    $funcs = Get-ChildItem Function: | Where-Object { $sysFuncs -notcontains $_ }
+    $aliases = Get-ChildItem Alias: | Where-Object { $sysAliases -notcontains $_ }
+
+    # export the module's public functions/aliases
+    if ($funcs) {
+        if ($aliases) {
+            Export-ModuleMember -Function $funcs.Name -Alias $aliases.Name
+        }
+        else {
+            Export-ModuleMember -Function $funcs.Name
+        }
+    }
 }
-
-# import everything if in a runspace
-if ($PODE_SCOPE_RUNSPACE) {
-    $sysfuncs = Get-ChildItem Function:
+catch {
+    throw "Failed to load the Pode.Web module: $($_.Exception.Message)`n$($_.Exception.StackTrace)"
 }
-
-# load private functions
-Get-ChildItem "$($root)/Private/*.ps1" | Resolve-Path | ForEach-Object { . $_ }
-
-# only import public functions if not in a runspace
-if (!$PODE_SCOPE_RUNSPACE) {
-    $sysfuncs = Get-ChildItem Function:
+finally {
+    Remove-Variable -ErrorAction SilentlyContinue -Name @(
+        'root',
+        'sysFuncs',
+        'sysAliases',
+        'funcs',
+        'aliases'
+    )
 }
-
-# load public functions
-Get-ChildItem "$($root)/Public/*.ps1" | Resolve-Path | ForEach-Object { . $_ }
-
-# get functions from memory and compare to existing to find new functions added
-$funcs = Get-ChildItem Function: | Where-Object { $sysfuncs -notcontains $_ }
-
-# export the module's public functions
-Export-ModuleMember -Function ($funcs.Name)

--- a/src/Private/Actions.ps1
+++ b/src/Private/Actions.ps1
@@ -9,7 +9,7 @@ function Send-PodeWebAction {
     )
 
     # for http, just return
-    if (Test-PodeWebResponseType -Type Http) {
+    if (Test-PodeWebConnectionType -Type Http) {
         return $Value
     }
 
@@ -41,7 +41,7 @@ function Test-PodeWebActionsAsync {
     [OutputType([bool])]
     param()
 
-    return !(Test-PodeWebResponseType -Type Http)
+    return !(Test-PodeWebConnectionType -Type Http)
 }
 
 function Get-PodeWebSseClientId {

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -161,8 +161,8 @@ function Test-PodeWebThemeInbuilt {
         $Name
     )
 
-    $inbuildThemes = Get-PodeWebInbuiltThemes
-    return ($Name -iin $inbuildThemes)
+    $inbuiltThemes = Get-PodeWebInbuiltThemes
+    return ($Name -iin $inbuiltThemes)
 }
 
 function Get-PodeWebCustomThemeRoutePath {
@@ -1110,7 +1110,6 @@ function Set-PodeWebSecurity {
         -Style 'self', 'unsafe-inline' `
         -Scripts 'self', 'unsafe-inline', 'blob:' `
         -Image 'self', 'data'
-    #TODO: move "blob:" to -Worker in Pode v2.12.0
 }
 
 function Test-PodeWebParameter {
@@ -1226,7 +1225,7 @@ function Set-PodeWebMetadata {
     $WebEvent.Metadata.SenderId = Get-PodeHeader -Name 'X-PODE-WEB-SENDER-ID'
 }
 
-function Test-PodeWebResponseType {
+function Test-PodeWebConnectionType {
     param(
         [Parameter()]
         [ValidateSet('Http', 'Sse')]
@@ -1234,9 +1233,9 @@ function Test-PodeWebResponseType {
         $Type
     )
 
-    return ((Get-PodeWebState -Name 'resp-type') -ieq $Type)
+    return ((Get-PodeWebState -Name 'conn-type') -ieq $Type)
 }
 
-function Get-PodeWebResponseType {
-    return (Get-PodeWebState -Name 'resp-type')
+function Get-PodeWebConnectionType {
+    return (Get-PodeWebState -Name 'conn-type')
 }

--- a/src/Public/Pages.ps1
+++ b/src/Public/Pages.ps1
@@ -152,7 +152,7 @@ function Set-PodeWebLoginPage {
         IsOAuth2        = $isOAuth2
         GrantType       = $grantType
         IsSystem        = $true
-        ResponseType    = (Get-PodeWebResponseType)
+        ConnectionType  = (Get-PodeWebConnectionType)
     }
 
     # set auth system urls
@@ -217,11 +217,11 @@ function Set-PodeWebLoginPage {
         $global:PageData = $null
     }
 
-    # add sse open route
-    if (Test-PodeWebResponseType -Type Sse) {
+    # add sse open/close routes
+    if (Test-PodeWebConnectionType -Type Sse) {
         Add-PodeRoute -Method Get -Path "/pode.web-dynamic/pages/$($pageMeta.ID)/sse-open" -ArgumentList @{ ID = $Id } -EndpointName $EndpointName -ScriptBlock {
             param($Data)
-            ConvertTo-PodeSseConnection -Name 'Pode.Web.Actions' -Group $Data.ID
+            ConvertTo-PodeSseConnection -Name 'Pode.Web.Actions' -Group $Data.ID -Scope Global
         }
 
         # add sse close route
@@ -419,7 +419,7 @@ function Add-PodeWebPage {
             Groups = @($AccessGroups)
             Users  = @($AccessUsers)
         }
-        ResponseType     = (Get-PodeWebResponseType)
+        ConnectionType   = (Get-PodeWebConnectionType)
     }
 
     # does the page need auth?
@@ -541,8 +541,8 @@ function Add-PodeWebPage {
         $global:PageData = $null
     }
 
-    # add sse open route
-    if (Test-PodeWebResponseType -Type Sse) {
+    # add sse open/close routes
+    if (Test-PodeWebConnectionType -Type Sse) {
         Add-PodeRoute -Method Get -Path "/pode.web-dynamic/pages/$($pageMeta.ID)/sse-open" -Authentication $pageMeta.Authentication -ArgumentList @{ Data = $ArgumentList; ID = $Id } -IfExists $IfExists -EndpointName $EndpointName -ScriptBlock {
             param($Data)
             $global:PageData = (Get-PodeWebState -Name 'pages')[$Data.ID]
@@ -567,7 +567,7 @@ function Add-PodeWebPage {
             }
             else {
                 # open new sse connection
-                ConvertTo-PodeSseConnection -Name 'Pode.Web.Actions' -Group $Data.ID
+                ConvertTo-PodeSseConnection -Name 'Pode.Web.Actions' -Group $Data.ID -Scope Global
             }
 
             $global:PageData = $null
@@ -970,7 +970,7 @@ function ConvertTo-PodeWebPage {
                     }
 
                     try {
-                    (. $cmd @_args) |
+                        (. $cmd @_args) |
                             New-PodeWebTextbox -Name 'Output_Result' -Multiline -Preformat |
                             Out-PodeWebElement
                     }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -1,4 +1,4 @@
-function Use-PodeWebTemplates {
+function Initialize-PodeWebTemplates {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -28,9 +28,9 @@ function Use-PodeWebTemplates {
         $Security = 'Default',
 
         [Parameter()]
-        [ValidateSet('Sse', 'Http')]
+        [ValidateSet('Http', 'Sse')]
         [string]
-        $ResponseType = 'Sse',
+        $ConnectionType = 'Http',
 
         [Parameter()]
         [string]
@@ -84,7 +84,7 @@ function Use-PodeWebTemplates {
     Set-PodeWebState -Name 'endpoint-name' -Value $EndpointName
     Set-PodeWebState -Name 'custom-css' -Value @()
     Set-PodeWebState -Name 'custom-js' -Value @()
-    Set-PodeWebState -Name 'resp-type' -Value $ResponseType.ToLowerInvariant()
+    Set-PodeWebState -Name 'conn-type' -Value $ConnectionType.ToLowerInvariant()
 
     # themes
     Set-PodeWebState -Name 'theme' -Value $Theme.ToLowerInvariant()
@@ -105,7 +105,7 @@ function Use-PodeWebTemplates {
     Set-PodeWebSecurity -Security $Security -UseHsts:$UseHsts
 
     # initialise SSE connections
-    if (Test-PodeWebResponseType -Type Sse) {
+    if (Test-PodeWebConnectionType -Type Sse) {
         if ([string]::IsNullOrEmpty($SseSecret)) {
             $SseSecret = Get-PodeServerDefaultSecret
         }
@@ -127,6 +127,10 @@ function Use-PodeWebTemplates {
             Set-PodeResponseStatus -Code 421
         }
     }
+}
+
+if (!(Test-Path Alias:Use-PodeWebTemplates)) {
+    New-Alias Use-PodeWebTemplates -Value Initialize-PodeWebTemplates
 }
 
 function Import-PodeWebStylesheet {

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -43,8 +43,8 @@ $(() => {
     // sessions
     setSessionTabId();
 
-    // setup sse connection
-    connectSse();
+    // setup client connection
+    setupClientConnection();
 });
 
 function loadContent() {
@@ -59,13 +59,28 @@ function loadContent() {
     });
 }
 
-function connectSse() {
-    // http responses?
-    if (!testConnectOverSse()) {
-        loadContent();
-        return;
-    }
+function setupClientConnection() {
+    var type = $('body').attr('pode-conn-type');
 
+    switch (type) {
+        case 'http':
+            setupHttpConnection();
+            break;
+
+        case 'sse':
+            setupSseConnection();
+            break;
+
+        default:
+            throw `Unknown response type '${type}'`;
+    }
+}
+
+function setupHttpConnection() {
+    loadContent();
+}
+
+function setupSseConnection() {
     // create sse connection
     const sse = new EventSource(getPageUrl('sse-open'));
 
@@ -77,28 +92,31 @@ function connectSse() {
 
     // wire up close event, to close sse connection
     sse.addEventListener('pode.close', (e) => {
+        sse.close();
         SSE_CLIENT_ID = null;
     });
 
     // wire up event for actions
     sse.addEventListener('pode.web.action', (e) => {
+        if (sse.readyState === EventSource.CLOSED) {
+            return;
+        }
+
         invokeActions(JSON.parse(e.data));
     });
 
     // error event
     sse.onerror = (e) => {
+        sse.close();
         console.log(e);
     };
 
     // wire up beforeunload, to close connection server side
     window.addEventListener("beforeunload", function(e) {
-        sendAjaxReq(getPageUrl('sse-close'), null, undefined, false);
+        sse.close();
+        SSE_CLIENT_ID = null;
         return null;
     });
-}
-
-function testConnectOverSse() {
-    return ($('body').attr('pode-resp-type') === 'sse');
 }
 
 function testCookie(name) {

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -115,10 +115,13 @@ class PodeElementFactory {
         }
         else {
             obj = this.findObject(name, action, data, sender, opts);
-            if (action === 'new' && obj.created) {
-                action = 'update';
+            if (obj != null) {
+                if (action === 'new' && obj.created) {
+                    action = 'update';
+                }
+
+                html = obj.refresh(action).apply(action, data, sender, opts);
             }
-            html = obj.refresh(action).apply(action, data, sender, opts);
         }
 
         // invoke after element action event
@@ -4775,6 +4778,11 @@ class PodeChart extends PodeRefreshableElement {
         // remove the chart if exists
         if (this.chart) {
             this.chart.destroy();
+        }
+
+        // skip if no element
+        if (!this.element) {
+            return
         }
 
         // get the chart's canvas and type

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -491,7 +491,9 @@ input[type=range]:hover,
 div.form-switch label.form-check-label:hover,
 div.form-check label.form-check-label:hover,
 select.form-select:hover,
-input[type=file]:hover {
+input[type=file]:hover,
+input[type=checkbox]:hover,
+input[type=radio]:hover {
     cursor: pointer;
 }
 
@@ -1094,6 +1096,11 @@ a.nav-link .mdi:before {
 
 .breadcrumb a:hover span {
     text-decoration: underline;
+}
+
+.breadcrumb-item.active,
+.breadcrumb-item.active::before {
+    color: var(--podeweb-primary-text-color);
 }
 
 .alert .mdi::before {

--- a/src/Templates/Views/index.pode
+++ b/src/Templates/Views/index.pode
@@ -11,7 +11,7 @@
         pode-theme="$($data.Theme)"
         $(if ($data.Sessions.Enabled) { "pode-session-tabs='$($data.Sessions.Tabs)'" })
         $(if ($data.AppPath) { "pode-app-path='$($data.AppPath)'" })
-        pode-resp-type="$($data.Page.ResponseType)"
+        pode-conn-type="$($data.Page.ConnectionType)"
         $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
 
         $(

--- a/src/Templates/Views/login.pode
+++ b/src/Templates/Views/login.pode
@@ -11,7 +11,7 @@
         pode-theme="$($data.Theme)"
         $(if ($data.Sessions.Enabled) { "pode-session-tabs='$($data.Sessions.Tabs)'" })
         $(if ($data.AppPath) { "pode-app-path='$($data.AppPath)'" })
-        pode-resp-type="$($data.Page.ResponseType)"
+        pode-conn-type="$($data.Page.ConnectionType)"
         style="background-image: url('$($data.Background.Image)'); background-repeat: no-repeat; background-size: cover"
         $(ConvertTo-PodeWebEvents -Events $data.Page.Events)>
 


### PR DESCRIPTION
### Description of the Change
For the vast majority of use-cases a standard HTTP connection will suffice, so I've set the default connection type to remain as HTTP. SSE is still present, but you need to supply `-ConnectionType SSE` to `Initialize-PodeWebTemplates` to enable.

The stability of SSE connections has been improved on the Pode side, with auto-cleanup server-side. Additionally, Pode.Web will now close an SSE connection client-side when the page is closed.

On a side note , I've renamed `Use-PodeWebTemplates` to be `Initialize-PodeWebTemplates`. This makes far more sense for what the function it actually doing. The `Use-PodeWebTemplates` still exists as an alias, but the init one will be recommended going forward.

### Related Issue
Resolves #660 
