### PR TITLE
Update parameters in Actions to move from "XState" to actual switch parameters; Adds support for Update-PodeWebTextbox to clear the textbox by passing an empty string; Adds Update/Clear Actions for Credential, DateTime, and MinMax elements

### DIFF
--- a/docs/Getting-Started/Migrating/08-to-10.md
+++ b/docs/Getting-Started/Migrating/08-to-10.md
@@ -119,6 +119,12 @@ The `Set-PodeWebComponentStyle` and `Remove-PodeWebComponentStyle` action functi
 
 The `-Property` parameter on both has also been renamed to `-Key`.
 
+### State Parameters
+
+All of the `-XState` parameters in all Action functions have been migrated to proper switch parameters - which now mirror the Element creation functions appropriately.
+
+For example, the `-SizeState` parameter on `Update-PodeWebButton` has been removed and is now the `-FullWidth` switch - matching the parameter on `New-PodeWebButton`. Omitting the switch on `Update-PodeWebButton` will not update `-FullWidth`; to enable full width buttons supply `-FullWidth`; and to disable full width supply `-FullWidth:$false`.
+
 ## NoForm and NoLabels
 
 In Pode.Web v1.X the new element rendering is more aware if an input element is being rendered within a Form, or not. Because of this the `-NoForm` and `-NoLabels` parameters are now all redundant, and have been removed from the following functions:
@@ -182,7 +188,7 @@ The `-Component` parameter on `Register-PodeWebEvent` and `Register-PodeWebMedia
 
 ## ReadOnly and Disabled
 
-In some places the ReadOnly/Disabled parameters were being used as if they were the same thing - these have been split out into two different parameters. Because of this split, the `-ReadOnly` parameter on `New-PodeWebSelect` is now `-Disabled`, and its counterpart of `Update-PodeWebSelect` has had its `-ReadOnlyState` parameter renamed to `-DisabledState`.
+In some places the ReadOnly/Disabled parameters were being used as if they were the same thing - these have been split out into two different parameters. Because of this split, the `-ReadOnly` parameter on `New-PodeWebSelect` is now `-Disabled`, and its counterpart of `Update-PodeWebSelect` has had its `-ReadOnly` parameter renamed to `-Disabled` as well.
 
 ## Icons
 
@@ -261,7 +267,7 @@ Now though, the `-ShowReset` switch has been removed and a new `-ButtonType` par
 * Submit
 * Reset
 
-with "Submit" being the default value if nothing is supplied. Following are some examples:
+With "Submit" being the default value if nothing is supplied. Following are some examples:
 
 ```powershell
 # default submit button:

--- a/docs/Tutorials/Actions/Audio.md
+++ b/docs/Tutorials/Actions/Audio.md
@@ -73,3 +73,5 @@ New-PodeWebContainer -Content @(
     )
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Badge.md
+++ b/docs/Tutorials/Actions/Badge.md
@@ -17,3 +17,5 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Button.md
+++ b/docs/Tutorials/Actions/Button.md
@@ -63,7 +63,7 @@ New-PodeWebCard -Content @(
     }
 
     New-PodeWebButton -Name 'Example' -ScriptBlock {
-        Update-PodeWebButton -Name 'Solid' -Colour Yellow -ColourState Outline
+        Update-PodeWebButton -Name 'Solid' -Colour Yellow -Outline
     }
 )
 ```
@@ -82,4 +82,4 @@ New-PodeWebCard -Content @(
 )
 ```
 
-The `-ColourState` and `-SizeState` have default values of `Unchanged`. They map to `-Outline` and `-FullWidth` of a button's switches, so they can be toggled in a stateful manner.
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Charts.md
+++ b/docs/Tutorials/Actions/Charts.md
@@ -25,6 +25,8 @@ New-PodeWebContainer -NoBackground -Content @(
 )
 ```
 
+Various other properties can be updated as well.
+
 ## ConvertTo
 
 The [`ConvertTo-PodeWebChartData`](../../../Functions/Actions/ConvertTo-PodeWebChartData) simplifies using the raw format, by letting you convert data at the end of a pipeline. The function takes a `-LabelProperty` which is the name of a property in the input that should be used for the X-axis, and then a `-DatasetProperty` with is property names for Y-axis values.

--- a/docs/Tutorials/Actions/Checkbox.md
+++ b/docs/Tutorials/Actions/Checkbox.md
@@ -50,3 +50,5 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/CodeEditor.md
+++ b/docs/Tutorials/Actions/CodeEditor.md
@@ -29,3 +29,5 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Credential.md
+++ b/docs/Tutorials/Actions/Credential.md
@@ -1,0 +1,38 @@
+# Credential
+
+This page details the actions available to Credential Textboxes.
+
+## Update
+
+To update the username and/or password values of a Credential on the page, you can use [`Update-PodeWebCredential`](../../../Functions/Actions/Update-PodeWebCredential). The `-UsernameValue` and `-PasswordValue` parameters should be a string:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebCredential -Name 'Credentials'
+
+    New-PodeWebButton -Name 'Update' -ScriptBlock {
+        Update-PodeWebCredential -Name 'Credentials' -UsernameValue 'new_username' -Password 'new_password'
+    }
+)
+```
+
+You can omit the `-UsernameValue`/`-PasswordValue` and update other properties of the Credential, such as `-ReadOnly`, etc.
+
+!!! note
+    You can clear a Credential by supplying an empty string to either `-UsernameValue` or `-PasswordValue`.
+
+Various other properties can be updated as well.
+
+## Clear
+
+You can clear the content of a Credential by using [`Clear-PodeWebCredential`](../../../Functions/Actions/Clear-PodeWebCredential), and both the username and password fields will be cleared:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebCredential -Name 'Credentials'
+
+    New-PodeWebButton -Name 'Clear' -ScriptBlock {
+        Clear-PodeWebCredential -Name 'Credentials'
+    }
+)
+```

--- a/docs/Tutorials/Actions/DateTime.md
+++ b/docs/Tutorials/Actions/DateTime.md
@@ -1,0 +1,38 @@
+# DateTime
+
+This page details the actions available to DateTime Textboxes.
+
+## Update
+
+To update the date and/or time values of a DateTime on the page, you can use [`Update-PodeWebDateTime`](../../../Functions/Actions/Update-PodeWebDateTime). The `-DateValue` and `-TimeValue` parameters should be a string:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebDateTime -Name 'DateTime'
+
+    New-PodeWebButton -Name 'Update' -ScriptBlock {
+        Update-PodeWebDateTime -Name 'DateTime' -DateValue '2024-01-01' -TimeValue '00:00'
+    }
+)
+```
+
+You can omit the `-DateValue`/`-TimeValue` and update other properties of the DateTime, such as `-ReadOnly`, etc.
+
+!!! note
+    You can clear a DateTime by supplying an empty string to either `-DateValue` or `-TimeValue`.
+
+Various other properties can be updated as well.
+
+## Clear
+
+You can clear the content of a DateTime by using [`Clear-PodeWebDateTime`](../../../Functions/Actions/Clear-PodeWebDateTime), and both the date and time fields will be cleared:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebDateTime -Name 'DateTime'
+
+    New-PodeWebButton -Name 'Clear' -ScriptBlock {
+        Clear-PodeWebDateTime -Name 'DateTime'
+    }
+)
+```

--- a/docs/Tutorials/Actions/ElementGroup.md
+++ b/docs/Tutorials/Actions/ElementGroup.md
@@ -51,3 +51,5 @@ New-PodeWebElementGroup -Id 'ele_grp' -SubmitButtonId 'submit1' -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/FileStream.md
+++ b/docs/Tutorials/Actions/FileStream.md
@@ -74,3 +74,5 @@ New-PodeWebContainer -NoBackground -Content @(
     New-PodeWebFileStream -Name 'Example' -Url '/logs/error.log'
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Header.md
+++ b/docs/Tutorials/Actions/Header.md
@@ -18,5 +18,7 @@ New-PodeWebContainer -NoBackground -Content @(
 )
 ```
 
+Various other properties can be updated as well.
+
 !!! note
     A `-Size` of `0` will leave the Header size unchanged - this is the default.

--- a/docs/Tutorials/Actions/IFrame.md
+++ b/docs/Tutorials/Actions/IFrame.md
@@ -33,3 +33,5 @@ Add-PodeWebPage -Name 'Example' -Content $con1, $con2
     )
 }
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Icon.md
+++ b/docs/Tutorials/Actions/Icon.md
@@ -16,6 +16,8 @@ New-PodeWebContainer -Content @(
 )
 ```
 
+Various other properties can be updated as well.
+
 ## Switch
 
 To switch the state of an Icon between the Base/Toggle presets, or specifically to either the Base, Toggle or Hover presets via the `-State` parameter, you can use [`Switch-PodeWebIcon`](../../../Functions/Actions/Switch-PodeWebIcon):

--- a/docs/Tutorials/Actions/Image.md
+++ b/docs/Tutorials/Actions/Image.md
@@ -16,3 +16,5 @@ New-PodeWebContainer -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Link.md
+++ b/docs/Tutorials/Actions/Link.md
@@ -45,3 +45,5 @@ New-PodeWebCard -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/MinMax.md
+++ b/docs/Tutorials/Actions/MinMax.md
@@ -1,0 +1,35 @@
+# MinMax
+
+This page details the actions available to MinMax Textboxes.
+
+## Update
+
+To update the min and/or max values of a MinMax on the page, you can use [`Update-PodeWebMinMax`](../../../Functions/Actions/Update-PodeWebMinMax). The `-MinValue` and `-MaxValue` parameters should be a valid double number type:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebMinMax -Name 'MinMax'
+
+    New-PodeWebButton -Name 'Update' -ScriptBlock {
+        Update-PodeWebMinMax -Name 'MinMax' -MinValue 10 -MaxValue 85
+    }
+)
+```
+
+You can omit the `-MinValue`/`-MaxValue` and update other properties of the MinMax, such as `-ReadOnly`, etc.
+
+Various other properties can be updated as well.
+
+## Clear
+
+You can clear the content of a MinMax by using [`Clear-PodeWebMinMax`](../../../Functions/Actions/Clear-PodeWebMinMax), and both the min and max fields will be cleared:
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebMinMax -Name 'MinMax'
+
+    New-PodeWebButton -Name 'Clear' -ScriptBlock {
+        Clear-PodeWebMinMax -Name 'MinMax'
+    }
+)
+```

--- a/docs/Tutorials/Actions/ProgressBar.md
+++ b/docs/Tutorials/Actions/ProgressBar.md
@@ -32,3 +32,5 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Raw.md
+++ b/docs/Tutorials/Actions/Raw.md
@@ -16,3 +16,5 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Select.md
+++ b/docs/Tutorials/Actions/Select.md
@@ -73,3 +73,5 @@ New-PodeWebContainer -NoBackground -Content @(
 ```
 
 You can also optionally supply `-DisplayOptions` to alter the values displayed in the Select element, as well as also supply as `-SelectedValue`.
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Table.md
+++ b/docs/Tutorials/Actions/Table.md
@@ -23,6 +23,8 @@ New-PodeWebContainer -NoBackground -Content @(
 )
 ```
 
+Various other properties can be updated as well.
+
 ## Update Row
 
 To update a single row in the table you can use [`Update-PodeWebTableRow`](../../../Functions/Actions/Update-PodeWebTableRow). You need to supply the table's ID/Name, and then either the index of the row, or the value of that row's `-DataColumn`. The `-Data` is a HashTable/PSCustomObject containing the properties/columns that you want to update:

--- a/docs/Tutorials/Actions/Text.md
+++ b/docs/Tutorials/Actions/Text.md
@@ -32,3 +32,5 @@ New-PodeWebContainer -NoBackground -Content @(
     }
 )
 ```
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Actions/Textbox.md
+++ b/docs/Tutorials/Actions/Textbox.md
@@ -16,6 +16,13 @@ New-PodeWebContainer -NoBackground -Content @(
 )
 ```
 
+You can omit the `-Value` and update other properties of the Textbox, such as `-ReadOnly`, etc.
+
+!!! note
+    You can clear the Textbox by supplying an empty string to `-Value`.
+
+Various other properties can be updated as well.
+
 ## Clear
 
 You can clear the content of a textbox by using [`Clear-PodeWebTextbox`](../../../Functions/Actions/Clear-PodeWebTextbox):

--- a/docs/Tutorials/Actions/Theme.md
+++ b/docs/Tutorials/Actions/Theme.md
@@ -19,6 +19,8 @@ New-PodeWebContainer -NoBackground -Content @(
 )
 ```
 
+Various other properties can be updated as well.
+
 ## Reset
 
 To reset a user's theme back to the default, you can use [`Reset-PodeWebTheme`](../../../Functions/Actions/Reset-PodeWebTheme):

--- a/docs/Tutorials/Actions/Tiles.md
+++ b/docs/Tutorials/Actions/Tiles.md
@@ -20,6 +20,8 @@ New-PodeWebContainer -NoBackground -Content @(
 )
 ```
 
+Various other properties can be updated as well.
+
 ## Sync
 
 To force a Tile to refresh its data you can use [`Sync-PodeWebTile`](../../../Functions/Actions/Sync-PodeWebTile):

--- a/docs/Tutorials/Actions/Video.md
+++ b/docs/Tutorials/Actions/Video.md
@@ -73,3 +73,5 @@ New-PodeWebContainer -Content @(
     )
 )
 ```
+
+Various other properties can be updated as well.

--- a/examples/input_multi_element.ps1
+++ b/examples/input_multi_element.ps1
@@ -1,0 +1,58 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psd1 -Force
+
+Start-PodeServer -Threads 2 {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8091 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Initialize-PodeWebTemplates -Title 'Inputs' -Theme Dark
+
+    Add-PodeWebPage -Name 'Home' -Path '/' -Title 'Testing Inputs' -HomePage -ScriptBlock {
+        # add credentials example
+        New-PodeWebForm -Name 'Credentials' -ButtonType Submit, Reset -AsCard -ScriptBlock {
+            $WebEvent.Data |
+                New-PodeWebTextbox -Name 'CredsOutput' -Multiline -Preformat -AsJson |
+                Out-PodeWebElement
+        } -Content @(
+            New-PodeWebCredential -Name 'Credentials'
+            New-PodeWebButton -Name 'Update Creds' -ScriptBlock {
+                Update-PodeWebCredential -Name 'Credentials' -UsernameValue 'new_username' -PasswordValue 'new_password'
+            }
+            New-PodeWebButton -Name 'Clear Creds' -ScriptBlock {
+                Clear-PodeWebCredential -Name 'Credentials'
+            }
+        )
+
+        # add datetime example
+        New-PodeWebForm -Name 'DateTime' -ButtonType Submit, Reset -AsCard -ScriptBlock {
+            $WebEvent.Data |
+                New-PodeWebTextbox -Name 'DateTimeOutput' -Multiline -Preformat -AsJson |
+                Out-PodeWebElement
+        } -Content @(
+            New-PodeWebDateTime -Name 'DateTime' -DateValue '2023-12-23' -TimeValue '13:37'
+            New-PodeWebButton -Name 'Update DateTime' -ScriptBlock {
+                Update-PodeWebDateTime -Name 'DateTime' -DateValue '2024-01-01' -TimeValue '00:00' -ReadOnly
+            }
+            New-PodeWebButton -Name 'Clear DateTime' -ScriptBlock {
+                Clear-PodeWebDateTime -Name 'DateTime'
+            }
+        )
+
+        # add minmax example
+        New-PodeWebForm -Name 'MinMax' -ButtonType Submit, Reset -AsCard -ScriptBlock {
+            $WebEvent.Data |
+                New-PodeWebTextbox -Name 'MinMaxOutput' -Multiline -Preformat -AsJson |
+                Out-PodeWebElement
+        } -Content @(
+            New-PodeWebMinMax -Name 'CPU' -AppendIcon 'percent' -MinValue 0 -MaxValue 100
+            New-PodeWebButton -Name 'Update MinMax' -ScriptBlock {
+                Update-PodeWebMinMax -Name 'CPU' -MinValue 10 -MaxValue 90
+            }
+            New-PodeWebButton -Name 'Clear MinMax' -ScriptBlock {
+                Clear-PodeWebMinMax -Name 'CPU'
+            }
+        )
+    }
+}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1116,6 +1116,7 @@ function Set-PodeWebSecurity {
 function Test-PodeWebParameter {
     param(
         [Parameter(Mandatory = $true)]
+        [System.Collections.Generic.Dictionary[string, object]]
         $Parameters,
 
         [Parameter(Mandatory = $true)]

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -396,10 +396,191 @@ function Clear-PodeWebChart {
     }
 }
 
+function Update-PodeWebCredential {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter()]
+        [string]
+        $UsernameValue,
+
+        [Parameter()]
+        [string]
+        $PasswordValue,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id,
+
+        [switch]
+        $ReadOnly,
+
+        [switch]
+        $Disabled
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Update'
+        ObjectType = 'Credential'
+        Values     = @{
+            Username = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'UsernameValue' -Value $UsernameValue)
+            Password = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'PasswordValue' -Value $PasswordValue)
+        }
+        ID         = $Id
+        Name       = $Name
+        ReadOnly   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'ReadOnly' -Value $ReadOnly.IsPresent)
+        Disabled   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Disabled' -Value $Disabled.IsPresent)
+    }
+}
+
+function Clear-PodeWebCredential {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Clear'
+        ObjectType = 'Credential'
+        ID         = $Id
+        Name       = $Name
+    }
+}
+
+function Update-PodeWebDateTime {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter()]
+        [string]
+        $DateValue,
+
+        [Parameter()]
+        [string]
+        $TimeValue,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id,
+
+        [switch]
+        $ReadOnly,
+
+        [switch]
+        $Disabled
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Update'
+        ObjectType = 'DateTime'
+        Values     = @{
+            Date = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'DateValue' -Value $DateValue)
+            Time = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'TimeValue' -Value $TimeValue)
+        }
+        ID         = $Id
+        Name       = $Name
+        ReadOnly   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'ReadOnly' -Value $ReadOnly.IsPresent)
+        Disabled   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Disabled' -Value $Disabled.IsPresent)
+    }
+}
+
+function Clear-PodeWebDateTime {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Clear'
+        ObjectType = 'DateTime'
+        ID         = $Id
+        Name       = $Name
+    }
+}
+
+function Update-PodeWebMinMax {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter()]
+        [double]
+        $MinValue,
+
+        [Parameter()]
+        [double]
+        $MaxValue,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id,
+
+        [switch]
+        $ReadOnly,
+
+        [switch]
+        $Disabled
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Update'
+        ObjectType = 'MinMax'
+        Values     = @{
+            Min = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'MinValue' -Value $MinValue)
+            Max = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'MaxValue' -Value $MaxValue)
+        }
+        ID         = $Id
+        Name       = $Name
+        ReadOnly   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'ReadOnly' -Value $ReadOnly.IsPresent)
+        Disabled   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Disabled' -Value $Disabled.IsPresent)
+    }
+}
+
+function Clear-PodeWebMinMax {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Clear'
+        ObjectType = 'MinMax'
+        ID         = $Id
+        Name       = $Name
+    }
+}
+
 function Update-PodeWebTextbox {
     [CmdletBinding(DefaultParameterSetName = 'Name')]
     param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline = $true)]
+        [ValidateNotNull()]
         [Alias('Data')]
         $Value,
 
@@ -419,15 +600,11 @@ function Update-PodeWebTextbox {
         [switch]
         $JsonInline,
 
-        [Parameter()]
-        [ValidateSet('Unchanged', 'Disabled', 'Enabled')]
-        [string]
-        $ReadOnlyState = 'Unchanged',
+        [switch]
+        $ReadOnly,
 
-        [Parameter()]
-        [ValidateSet('Unchanged', 'Disabled', 'Enabled')]
-        [string]
-        $DisabledState = 'Unchanged'
+        [switch]
+        $Disabled
     )
 
     begin {
@@ -444,15 +621,15 @@ function Update-PodeWebTextbox {
         }
 
         Send-PodeWebAction -Value @{
-            Operation     = 'Update'
-            ObjectType    = 'Textbox'
-            Value         = $items
-            ID            = $Id
-            Name          = $Name
-            AsJson        = $AsJson.IsPresent
-            JsonInline    = $JsonInline.IsPresent
-            ReadOnlyState = $ReadOnlyState
-            DisabledState = $DisabledState
+            Operation  = 'Update'
+            ObjectType = 'Textbox'
+            Value      = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Value' -Value $items)
+            ID         = $Id
+            Name       = $Name
+            AsJson     = $AsJson.IsPresent
+            JsonInline = $JsonInline.IsPresent
+            ReadOnly   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'ReadOnly' -Value $ReadOnly.IsPresent)
+            Disabled   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Disabled' -Value $Disabled.IsPresent)
         }
     }
 }
@@ -651,10 +828,8 @@ function Update-PodeWebSelect {
         [string[]]
         $SelectedValue,
 
-        [Parameter()]
-        [ValidateSet('Unchanged', 'Disabled', 'Enabled')]
-        [string]
-        $DisabledState = 'Unchanged'
+        [switch]
+        $Disabled
     )
 
     begin {
@@ -674,7 +849,7 @@ function Update-PodeWebSelect {
             Options        = $items
             DisplayOptions = @(Protect-PodeWebValues -Value $DisplayOptions -Default $items -EqualCount)
             SelectedValue  = @(Protect-PodeWebValues -Value $SelectedValue -Encode)
-            DisabledState  = $DisabledState
+            Disabled       = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Disabled' -Value $Disabled.IsPresent)
         }
     }
 }
@@ -760,12 +935,9 @@ function Update-PodeWebCheckbox {
         [int]
         $OptionId = 0,
 
-        [Parameter()]
-        [ValidateSet('Unchanged', 'Disabled', 'Enabled')]
-        [string]
-        $State = 'Unchanged',
+        [switch]
+        $Disabled,
 
-        [Parameter()]
         [switch]
         $Checked
     )
@@ -776,8 +948,8 @@ function Update-PodeWebCheckbox {
         ID         = $Id
         Name       = $Name
         OptionId   = $OptionId
-        State      = $State.ToLowerInvariant()
-        Checked    = $Checked.IsPresent
+        Disabled   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Disabled' -Value $Disabled.IsPresent)
+        Checked    = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Checked' -Value $Checked.IsPresent)
     }
 }
 
@@ -2657,19 +2829,9 @@ function Update-PodeWebButton {
         $Colour = '',
 
         [Parameter()]
-        [ValidateSet('Unchanged', 'Outline', 'Solid')]
-        [string]
-        $ColourState = 'Unchanged',
-
-        [Parameter()]
         [ValidateSet('', 'Normal', 'Small', 'Large')]
         [string]
         $Size = '',
-
-        [Parameter()]
-        [ValidateSet('Unchanged', 'Normal', 'Full')]
-        [string]
-        $SizeState = 'Unchanged',
 
         [Parameter()]
         [string]
@@ -2679,9 +2841,14 @@ function Update-PodeWebButton {
         [string]
         $DataValue,
 
-        [Parameter()]
-        [ValidateSet('Unchanged', 'SameTab', 'NewTab')]
-        $TabState = 'Unchanged'
+        [switch]
+        $Outline,
+
+        [switch]
+        $FullWidth,
+
+        [switch]
+        $NewTab
     )
 
     Send-PodeWebAction -Value @{
@@ -2690,15 +2857,15 @@ function Update-PodeWebButton {
         ID          = $Id
         Name        = $Name
         Colour      = $Colour
-        ColourState = $ColourState.ToLowerInvariant()
+        Outline     = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Outline' -Value $Outline.IsPresent)
         Size        = $Size
-        SizeState   = $SizeState.ToLowerInvariant()
+        FullWidth   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'FullWidth' -Value $FullWidth.IsPresent)
         DisplayName = [System.Net.WebUtility]::HtmlEncode($DisplayName)
         ClickName   = [System.Net.WebUtility]::HtmlEncode($ClickName)
         Icon        = (Protect-PodeWebIconType -Icon $Icon -Element 'Button')
         Url         = $Url
         DataValue   = $DataValue
-        TabState    = $TabState.ToLowerInvariant()
+        NewTab      = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'NewTab' -Value $NewTab.IsPresent)
     }
 }
 
@@ -3004,10 +3171,8 @@ function Update-PodeWebLink {
         [string]
         $Value,
 
-        [Parameter()]
-        [ValidateSet('Unchanged', 'SameTab', 'NewTab')]
-        [string]
-        $TabState = 'Unchanged'
+        [switch]
+        $NewTab
     )
 
     Send-PodeWebAction -Value @{
@@ -3016,6 +3181,6 @@ function Update-PodeWebLink {
         ID         = $Id
         Url        = (Add-PodeWebAppPath -Url $Url)
         Value      = [System.Net.WebUtility]::HtmlEncode($Value)
-        TabState   = $TabState.ToLowerInvariant()
+        NewTab     = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'NewTab' -Value $NewTab.IsPresent)
     }
 }

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1160,6 +1160,14 @@ function New-PodeWebCredential {
         [string[]]
         $Type = @('Username', 'Password'),
 
+        [Parameter()]
+        [string]
+        $UsernameValue,
+
+        [Parameter()]
+        [string]
+        $PasswordValue,
+
         [switch]
         $ReadOnly,
 
@@ -1198,6 +1206,10 @@ function New-PodeWebCredential {
         }
         Type          = @($Type)
         Required      = $Required.IsPresent
+        Values        = @{
+            Date = (Protect-PodeWebValue -Value $UsernameValue -Default '' -Encode)
+            Time = (Protect-PodeWebValue -Value $PasswordValue -Default '' -Encode)
+        }
     }
 }
 

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -319,6 +319,18 @@ class PodeElement {
         this.children.push(element);
     }
 
+    findChild(id, name) {
+        if (id) {
+            return this.children.find((c) => c.id == id);
+        }
+
+        if (name) {
+            return this.children.find((c) => c.name == name);
+        }
+
+        return null;
+    }
+
     setIcon(data, padRight, padTop, opts) {
         // empty if not icon
         if (!data) {
@@ -608,13 +620,11 @@ class PodeElement {
             }
         }
 
-        // render content, load and bind this element
+        // render content and import element/container
         this.element = this.get();
         this.container = this.getContainer();
         this.setBaseAttributes();
         this.renderContentArea(data);
-        this.load(data, sender, opts);
-        this.bind(data, sender, opts);
         this.created = true;
 
         // finalise non-created children
@@ -631,6 +641,10 @@ class PodeElement {
                 c.finalise(null, null, null, true, null);
             });
         }
+
+        // load and bind this element
+        this.load(data, sender, opts);
+        this.bind(data, sender, opts);
     }
 
     setBaseAttributes() {
@@ -1069,6 +1083,15 @@ class PodeElement {
         this.children.forEach((child) => { child.disable(data, sender, opts); });
     }
 
+    setDisabled(data, disabled, sender, opts) {
+        if (disabled) {
+            this.disable(data, sender, opts);
+        }
+        else {
+            this.enable(data, sender, opts);
+        }
+    }
+
     show(data, sender, opts) {
         (this.container ?? this.element).show();
         this.visible = true;
@@ -1250,6 +1273,10 @@ class PodeElement {
     }
 
     update(data, sender, opts) {
+        if (data == null) {
+            return;
+        }
+
         // update icon
         if (this.icon && data.Icon) {
             if (typeof (data.Icon) === 'string') {
@@ -1638,50 +1665,26 @@ class PodeFormElement extends PodeContentElement {
 
     update(data, sender, opts) {
         super.update(data, sender, opts);
+        if (data == null) {
+            return;
+        }
 
-        // disable / enable control
-        if (data.DisabledState) {
-            switch (data.DisabledState.toLowerCase()) {
-                case 'enabled':
-                    this.disabled = false;
-                    this.enable(data, sender, opts);
-                    break;
-
-                case 'disabled':
-                    this.disabled = true;
-                    this.disable(data, sender, opts);
-                    break;
-            }
+        // disable / enable state
+        if (data.Disabled != null) {
+            this.disabled = data.Disabled;
+            this.setDisabled(data, this.disabled, sender, opts);
         }
 
         // readonly state
-        if (data.ReadOnlyState) {
-            switch (data.ReadOnlyState.toLowerCase()) {
-                case 'enabled':
-                    this.readonly = true;
-                    this.setReadonly(true);
-                    break;
-
-                case 'disabled':
-                    this.readonly = false;
-                    this.setReadonly(false);
-                    break;
-            }
+        if (data.ReadOnly != null) {
+            this.readonly = data.ReadOnly;
+            this.setReadonly(data.ReadOnly);
         }
 
         // required state
-        if (data.RequiredState) {
-            switch (data.RequiredState.toLowerCase()) {
-                case 'enabled':
-                    this.required = true;
-                    this.setRequired(true);
-                    break;
-
-                case 'disabled':
-                    this.readonly = false;
-                    this.setRequired(false);
-                    break;
-            }
+        if (data.Required != null) {
+            this.required = data.Required;
+            this.setRequired(data.Required);
         }
     }
 }
@@ -1719,6 +1722,9 @@ class PodeFormMultiElement extends PodeFormElement {
                 ${html}
         </div>`;
     }
+
+    //TODO: custom disable / readonly / required for children
+    //TODO: how do we get child elements post-creation?
 }
 
 class PodeMediaElement extends PodeContentElement {
@@ -1934,8 +1940,8 @@ class PodeLink extends PodeTextualElement {
         }
 
         // update target
-        if (data.TabState != 'unchanged') {
-            this.element.attr('target', data.TabState == 'newtab' ? '_blank' : '_self');
+        if (data.NewTab != null) {
+            this.element.attr('target', data.NewTab ? '_blank' : '_self');
         }
     }
 }
@@ -2358,11 +2364,11 @@ class PodeButton extends PodeFormElement {
         }
 
         // change colour
-        if (!this.iconOnly && (data.Colour || data.ColourState != 'unchanged')) {
+        if (!this.iconOnly && (data.Colour || data.Outline != null)) {
             this.removeClass(this.mapButtonColourTypeToClass());
 
-            if (data.ColourState != 'unchanged') {
-                this.isOutline = (data.ColourState == 'outline');
+            if (data.Outline != null) {
+                this.isOutline = data.Outline;
             }
 
             if (data.Colour) {
@@ -2373,14 +2379,9 @@ class PodeButton extends PodeFormElement {
         }
 
         // change size
-        if (!this.iconOnly && (data.Size || data.SizeState != 'unchanged')) {
-            if (data.SizeState != 'unchanged') {
-                if (data.SizeState == 'normal') {
-                    this.removeClass('btn-block');
-                }
-                else {
-                    this.addClass('btn-block');
-                }
+        if (!this.iconOnly && (data.Size || data.FullWidth != null)) {
+            if (data.FullWidth != null) {
+                this.toggleClass('btn-block', data.FullWidth, null, this);
             }
 
             if (data.Size) {
@@ -2400,8 +2401,8 @@ class PodeButton extends PodeFormElement {
         }
 
         // change tab state
-        if (!this.dynamic && data.TabState != 'unchanged') {
-            this.element.attr('target', data.TabState == 'newtab' ? '_blank' : '_self');
+        if (!this.dynamic && data.NewTab != null) {
+            this.element.attr('target', data.NewTab ? '_blank' : '_self');
         }
     }
 
@@ -3717,7 +3718,11 @@ class PodeTextbox extends PodeFormElement {
 
     load(data, sender, opts) {
         super.load(data, sender, opts);
-        this.update(data, sender, opts);
+
+        if (data != null) {
+            this.update(data, sender, opts);
+        }
+
         var obj = this;
 
         if (this.autoComplete) {
@@ -3731,10 +3736,13 @@ class PodeTextbox extends PodeFormElement {
 
     update(data, sender, opts) {
         super.update(data, sender, opts);
+        if (data == null) {
+            return;
+        }
 
         // update value
-        if (data.Value) {
-            if (data.AsJson) {
+        if (data.Value != null) {
+            if (data.AsJson && data.Value != '') {
                 data.Value = data.JsonInline || !this.multiline
                     ? JSON.stringify(data.Value)
                     : JSON.stringify(data.Value, null, 4);
@@ -5542,18 +5550,9 @@ class PodeCheckbox extends PodeFormElement {
             return;
         }
 
-        // check TODO: Checked should have an "Unchanged" state
-        checkbox.attr('checked', data.Checked);
-
-        // enable/disable TODO: this isn't "DisabledState"
-        switch ((data.State ?? '').toLowerCase()) {
-            case 'enabled':
-                this.enable(data, sender, opts);
-                break;
-
-            case 'disabled':
-                this.disable(data, sender, opts);
-                break;
+        // check or uncheck
+        if (data.Checked != null) {
+            checkbox.prop('checked', data.Checked);
         }
     }
 
@@ -5678,6 +5677,49 @@ class PodeDateTime extends PodeFormMultiElement {
 
         return super.new(data, sender, opts);
     }
+
+    getDateElement() {
+        return this.findChild(`${this.id}_date`);
+    }
+
+    getTimeElement() {
+        return this.findChild(`${this.id}_time`);
+    }
+
+    load(data, sender, opts) {
+        super.load(data, sender, opts);
+        this.update(data, sender, opts);
+    }
+
+    update(data, sender, opts) {
+        super.update(data, sender, opts);
+
+        if (data.Values.Date != null) {
+            var dateElement = this.getDateElement();
+            if (dateElement) {
+                dateElement.update({ Value: data.Values.Date }, sender, opts);
+            }
+        }
+
+        if (data.Values.Time != null) {
+            var timeElement = this.getTimeElement();
+            if (timeElement) {
+                timeElement.update({ Value: data.Values.Time }, sender, opts);
+            }
+        }
+    }
+
+    clear(data, sender, opts) {
+        var dateElement = this.getDateElement();
+        if (dateElement) {
+            dateElement.clear(data, sender, opts);
+        }
+
+        var timeElement = this.getTimeElement();
+        if (timeElement) {
+            timeElement.clear(data, sender, opts);
+        }
+    }
 }
 PodeElementFactory.setClass(PodeDateTime);
 
@@ -5697,7 +5739,8 @@ class PodeCredential extends PodeFormMultiElement {
                 ReadOnly: this.readonly,
                 Required: this.required,
                 DynamicLabel: true,
-                DisplayName: data.Placeholders.Username
+                DisplayName: data.Placeholders.Username,
+                Value: data.Values.Username
             }, {
                 help: { enabled: true, id: this.id }
             }));
@@ -5711,13 +5754,57 @@ class PodeCredential extends PodeFormMultiElement {
                 ReadOnly: this.readonly,
                 Required: this.required,
                 DynamicLabel: true,
-                DisplayName: data.Placeholders.Password
+                DisplayName: data.Placeholders.Password,
+                Value: data.Values.Password
             }, {
                 help: { enabled: true, id: this.id }
             }));
         }
 
         return super.new(data, sender, opts);
+    }
+
+    getUsernameElement() {
+        return this.findChild(`${this.id}_username`);
+    }
+
+    getPasswordElement() {
+        return this.findChild(`${this.id}_password`);
+    }
+
+    load(data, sender, opts) {
+        super.load(data, sender, opts);
+        this.update(data, sender, opts);
+    }
+
+    update(data, sender, opts) {
+        super.update(data, sender, opts);
+
+        if (data.Values.Username != null) {
+            var usernameElement = this.getUsernameElement();
+            if (usernameElement) {
+                usernameElement.update({ Value: data.Values.Username }, sender, opts);
+            }
+        }
+
+        if (data.Values.Password != null) {
+            var passwordElement = this.getPasswordElement();
+            if (passwordElement) {
+                passwordElement.update({ Value: data.Values.Password }, sender, opts);
+            }
+        }
+    }
+
+    clear(data, sender, opts) {
+        var usernameElement = this.getUsernameElement();
+        if (usernameElement) {
+            usernameElement.clear(data, sender, opts);
+        }
+
+        var passwordElement = this.getPasswordElement();
+        if (passwordElement) {
+            passwordElement.clear(data, sender, opts);
+        }
     }
 }
 PodeElementFactory.setClass(PodeCredential);
@@ -5765,6 +5852,49 @@ class PodeMinMax extends PodeFormMultiElement {
         }
 
         return super.new(data, sender, opts);
+    }
+
+    getMinElement() {
+        return this.findChild(`${this.id}_min`);
+    }
+
+    getMaxElement() {
+        return this.findChild(`${this.id}_max`);
+    }
+
+    load(data, sender, opts) {
+        super.load(data, sender, opts);
+        this.update(data, sender, opts);
+    }
+
+    update(data, sender, opts) {
+        super.update(data, sender, opts);
+
+        if (data.Values.Min != null) {
+            var minElement = this.getMinElement();
+            if (minElement) {
+                minElement.update({ Value: data.Values.Min }, sender, opts);
+            }
+        }
+
+        if (data.Values.Max != null) {
+            var maxElement = this.getMaxElement();
+            if (maxElement) {
+                maxElement.update({ Value: data.Values.Max }, sender, opts);
+            }
+        }
+    }
+
+    clear(data, sender, opts) {
+        var minElement = this.getMinElement();
+        if (minElement) {
+            minElement.clear(data, sender, opts);
+        }
+
+        var maxElement = this.getMaxElement();
+        if (maxElement) {
+            maxElement.clear(data, sender, opts);
+        }
     }
 }
 PodeElementFactory.setClass(PodeMinMax);

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -1489,6 +1489,7 @@ div.form-floating>.form-control::placeholder {
     color: none !important;
 }
 
+.form-floating>label,
 .form-floating>.form-control:focus~label,
 .form-floating .form-control:focus~label::after,
 .form-floating>.form-control:not(:placeholder-shown)~label,


### PR DESCRIPTION
### Description of the Change
* Action functions which had parameters like `-ReadOnlyState` are now simply switches - if they are supplied they do nothing, and you can supply `-ReadOnly` to enable or `-ReadOnly:$false` to disable.
* Similar logic has been applied to `-Value` on `Update-PodeWebTextbox`. If it's not supplied it does nothing, but this also now enables passing an empty string which can "clear" the textbox.
* Update and Clear Action functions have been added for Credential, DateTime, and MinMax elements.

### Related Issue
Resolves #415, #475, #477
