### PR TITLE
Added support for Events to trigger JavaScript functions; Enabled support to supply multiple of the same event type for an element; Enabled Events support for additional elements, including Buttons and File Upload; Fixed a bug with Range value textbox not triggering Change events; Added custom "step" support for Range elements; Added Update and Step Actions for Range elements

### DIFF
--- a/docs/Tutorials/Actions/Range.md
+++ b/docs/Tutorials/Actions/Range.md
@@ -1,0 +1,43 @@
+# Range
+
+This page details the actions available to Range elements.
+
+## Step
+
+To increment, or decrement, a Range element by its current "step" value you can use [`Step-PodeWebRange`](../../../Functions/Actions/Step-PodeWebRange):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebRange -Name 'CPU' -Step 8 -Min 0 -Max 32
+
+    New-PodeWebButton -Name 'Increase' -ScriptBlock {
+        Step-PodeWebRange -Name 'CPU' -Direction Increase
+    }
+    New-PodeWebButton -Name 'Decrease' -ScriptBlock {
+        Step-PodeWebRange -Name 'CPU' -Direction Decrease
+    }
+)
+```
+
+## Update
+
+To update the value, min, max, or step of a Range element you can use [`Update-PodeWebRange`](../../../Functions/Actions/Update-PodeWebRange):
+
+```powershell
+New-PodeWebContainer -NoBackground -Content @(
+    New-PodeWebRange -Name 'Example'
+
+    New-PodeWebButton -Name 'Update Range' -ScriptBlock {
+        $value = Get-Random -Minimum 0 -Maximum 100
+        Update-PodeWebRange -Name 'Example' -Value $value
+    }
+)
+```
+
+!!! tip
+    The values supplied are treated as raw values by default, for example if you supply `-Value 1` the the value will always be set to 1. However, if you supply `-AsDelta` then instead the value will be increased by 1 instead. Same applies to Min, Max, and Step.
+
+!!! note
+    If you have a custom step supplied, such as `-Step 2.5`, and you supply `-Value 1 -AsDelta`, then the value will not increase as Pode will round to the nearest step - in this case down to 0. However, in this example, using `-Value 2 -AsDelta` will increase as it will round up to 2.5.
+
+Various other properties can be updated as well.

--- a/docs/Tutorials/Elements/Button.md
+++ b/docs/Tutorials/Elements/Button.md
@@ -2,7 +2,7 @@
 
 | Support |     |
 | ------- | --- |
-| Events  | No  |
+| Events  | Yes |
 
 To display a button on your page you use [`New-PodeWebButton`](../../../Functions/Elements/New-PodeWebButton); a button can either be dynamic and run custom logic via a `-ScriptBlock`, or it can redirect a user to a `-Url`.
 
@@ -67,6 +67,17 @@ To open the URL in a new tab, supply the `-NewTab` switch:
 
 ```powershell
 New-PodeWebButton -Name 'Repository' -Icon Link -Url 'https://github.com/Badgerati/Pode.Web' -NewTab
+```
+
+## Custom Events
+
+The Button element does support [`Register-PodeWebEvent`](../../../Functions/Events/Register-PodeWebEvent) and the `Click` event type. There is the `-ScriptBlock` parameter on [`New-PodeWebButton`](../../../Functions/Elements/New-PodeWebButton), but you can supply `-NoClick` instead which will render a dummy button with no event handlers - allowing you to supply custom, including client-side, event handlers via [`Register-PodeWebEvent`](../../../Functions/Events/Register-PodeWebEvent) instead:
+
+```powershell
+New-PodeWebButton -Name 'Custom Events' -NoClick |
+    Register-PodeWebEvent -Type Click -ScriptBlock {
+        Show-PodeWebToast -Message 'The button click event was triggered!'
+    }
 ```
 
 ## Outlined

--- a/docs/Tutorials/Elements/Code.md
+++ b/docs/Tutorials/Elements/Code.md
@@ -1,8 +1,8 @@
 # Code
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 The code element will render pre-formatted text as `<code>value</code>`. To create a code element you use [`New-PodeWebCode`](../../../Functions/Elements/New-PodeWebCode):
 

--- a/docs/Tutorials/Elements/CodeBlock.md
+++ b/docs/Tutorials/Elements/CodeBlock.md
@@ -1,8 +1,8 @@
 # Code Block
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 The code block element will render pre-formatted text as `<pre>value</pre>`. To create a code block element you use [`New-PodeWebCodeBlock`](../../../Functions/Elements/New-PodeWebCodeBlock), and you can specify the highlighting language via `-Language` - the default is plain text.
 

--- a/docs/Tutorials/Elements/FileUpload.md
+++ b/docs/Tutorials/Elements/FileUpload.md
@@ -1,8 +1,8 @@
 # File Upload
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 The File Upload element is a form input element, and can be created using [`New-PodeWebFileUpload`](../../../Functions/Elements/New-PodeWebFileUpload). It allows users to upload files from your page forms:
 

--- a/docs/Tutorials/Elements/Header.md
+++ b/docs/Tutorials/Elements/Header.md
@@ -1,8 +1,8 @@
 # Header
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 You can render header titles to your page by using [`New-PodeWebHeader`](../../../Functions/Elements/New-PodeWebHeader). This will show a title in various header sizes (`h1` - `h6`):
 

--- a/docs/Tutorials/Elements/Line.md
+++ b/docs/Tutorials/Elements/Line.md
@@ -2,7 +2,7 @@
 
 | Support |     |
 | ------- | --- |
-| Events  | No  |
+| Events  | Yes |
 
 This will render a line (`<hr/>`) to your page, using [`New-PodeWebLine`](../../../Functions/Elements/New-PodeWebLine):
 

--- a/docs/Tutorials/Elements/Paragraph.md
+++ b/docs/Tutorials/Elements/Paragraph.md
@@ -2,7 +2,7 @@
 
 | Support |     |
 | ------- | --- |
-| Events  | No  |
+| Events  | Yes |
 
 You can display a `-Value`, or other `-Content`, within a paragraph block using [`New-PodeWebParagraph`](../../../Functions/Elements/New-PodeWebParagraph). This lets you separate blocks of text/elements neatly on a page:
 

--- a/docs/Tutorials/Elements/Quote.md
+++ b/docs/Tutorials/Elements/Quote.md
@@ -1,8 +1,8 @@
 # Quote
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 You can render a quote to your page by using [`New-PodeWebQuote`](../../../Functions/Elements/New-PodeWebQuote). This will show a quoted message (`-Value`), with optional `-Source`, to your page:
 

--- a/docs/Tutorials/Elements/Range.md
+++ b/docs/Tutorials/Elements/Range.md
@@ -1,8 +1,8 @@
 # Range
 
-| Support | |
-| ------- |-|
-| Events | Yes |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 The Range element is a form input element, and can be added using [`New-PodeWebRange`](../../../Functions/Elements/New-PodeWebRange). This will add a range slider to your form, with default min/max values of 0-100, but these can be altered via `-Min` and `-Max`. You can set a default `-Value`, and show the currently selected value via `-ShowValue`:
 
@@ -23,3 +23,7 @@ Which looks like below:
 ## Display Name
 
 By default the label displays the `-Name` of the element. You can change the value displayed by also supplying an optional `-DisplayName` value; this value is purely visual, when the user submits the form the value of the element is still retrieved using the `-Name` from `$WebEvent.Data`.
+
+## Steps
+
+By default the Range element will increment, and decrement, in steps of 1. You can customise this, to say 2.5, by supplying the `-Step` parameter.

--- a/docs/Tutorials/Elements/Spinner.md
+++ b/docs/Tutorials/Elements/Spinner.md
@@ -1,8 +1,8 @@
 # Spinner
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 The spinner element will render a progress spinner to your page. To create a spinner element you use [`New-PodeWebSpinner`](../../../Functions/Elements/New-PodeWebSpinner), you can also change the spinner colour via `-Colour` which can be a known name (red/green/etc) or a hex value (#333333).
 

--- a/docs/Tutorials/Elements/Text.md
+++ b/docs/Tutorials/Elements/Text.md
@@ -1,8 +1,8 @@
 # Text
 
-| Support | |
-| ------- |-|
-| Events | No |
+| Support |     |
+| ------- | --- |
+| Events  | Yes |
 
 You can render different types of text/typography to your page by using [`New-PodeWebText`](../../../Functions/Elements/New-PodeWebText). You can specify the `-Value` to display, and then a custom `-Style` to render the text; such as Normal, Bold, Italic, etc. (default is Normal):
 

--- a/docs/Tutorials/Events.md
+++ b/docs/Tutorials/Events.md
@@ -1,29 +1,32 @@
 # Events
 
-In JavaScript you have general events that can trigger, such as `onchange` or `onfocus`. You can bind scriptblocks to these events for different elements by using [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent).
+In JavaScript you have general events that can trigger, such as `onchange` or `onfocus`. You can bind either server-side scriptblocks, or client-side JavaScript functions, to these events for different elements by using [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent).
 
-For now only Elements support registering events, and not all elements support events (check an elements page to see if it supports events!).
+For now only Elements support registering events, and not all elements support events (check an element's page to see if it supports events!).
 
-The following general events are supported:
+The following events are supported:
 
-| Name | Description |
-| ---- | ----------- |
-| Change | Fires when the value of the element changes |
-| Focus | Fires when the element gains focus |
-| FocusOut | Fires when the element loses focus |
-| Click | Fires when the element is clicked |
-| MouseOver | Fires when the mouse moves over the element |
-| MouseOut | Fires when the mouse moves out of the element |
-| KeyDown | Fires when a key is pressed down on the element |
-| KeyUp | Fires when a key is lifted up on a element |
+| Name      | Description                                     |
+| --------- | ----------------------------------------------- |
+| Change    | Fires when the value of the element changes     |
+| Focus     | Fires when the element gains focus              |
+| FocusOut  | Fires when the element loses focus              |
+| Click     | Fires when the element is clicked               |
+| MouseOver | Fires when the mouse moves over the element     |
+| MouseOut  | Fires when the mouse moves out of the element   |
+| KeyDown   | Fires when a key is pressed down on the element |
+| KeyUp     | Fires when a key is lifted up on a element      |
+
 
 Similar to say a Button's click scriptblock, these events can run whatever logic you like, including returning actions for Pode.Web to action against on the frontend.
 
-You can bind the same action to multiple event types by supplying multiple types to [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent)'s `-Type` parameter. The current event that has triggered the logic can be sourced via `$EventType` within the `-ScriptBlock`.
+You can bind the same logic to multiple event types by supplying multiple types to [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent)'s `-Type` parameter. Additionally, you can supply the same event multiple times, and the logic when the event is triggered will be run in the order they are defined.
 
 ## Example
 
-Let's say you want to have a Select element, but not in a form. When the Select's current value is changed, you want to run a script to show a message; to achieve this you can pipe the object returned by [`New-PodeWebSelect`](../../Functions/Elements/New-PodeWebSelect) into [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent):
+Let's say you want to have a Select element, but not in a form. When the Select's current value is changed you want to run a script to show a message. to achieve this you can pipe the object returned by [`New-PodeWebSelect`](../../Functions/Elements/New-PodeWebSelect) into [`Register-PodeWebEvent`](../../Functions/Events/Register-PodeWebEvent):
+
+### Server-Side
 
 ```powershell
 New-PodeWebSelect -Name 'Role' -Options @('Choose...', 'User', 'Admin', 'Operations') |
@@ -32,7 +35,38 @@ New-PodeWebSelect -Name 'Role' -Options @('Choose...', 'User', 'Admin', 'Operati
     }
 ```
 
-If the element the event triggers for is a form input element, the value will be serialised and available in `$WebEvent.Data`.
+If the element the event triggers for is a form input element, the value will be serialised and available in `$WebEvent.Data`. The current event that has triggered the logic can be sourced via `$EventType` within the ScriptBlock.
+
+### Client-Side
+
+```powershell
+New-PodeWebSelect -Name 'Role' -Options @('Choose...', 'User', 'Admin', 'Operations') |
+    Register-PodeWebEvent -Type Change -JSFunction 'invokeCustomEvent'
+```
+
+The above will trigger a JavaScript function on the frontend, which will need to be imported via [`Import-PodeWebJavaScript`](../../Functions/Utilities/Import-PodeWebJavaScript). For example, assume the following `custom.js` file in your `/public` folder:
+
+```powershell
+Import-PodeWebJavaScript -Url '/custom.js'
+```
+
+with content containing the `invokeCustomEvent` function:
+
+```javascript
+function invokeCustomEvent(evt, target, sender, eventType, opts) {
+    console.log(`Custom event triggered: ${eventType} on ${target.attr('name')}`);
+}
+```
+
+The arguments supplied to the function are:
+
+| Argument  | Description                                               |
+| --------- | --------------------------------------------------------- |
+| evt       | The JavaScript event object                               |
+| target    | A jQuery object for the element which triggered the event |
+| sender    | A Pode JavaScript object which triggered the event        |
+| eventType | The event type name - such a "load", "click", etc.        |
+| opts      | Any additional options for the event, such as eventId     |
 
 ## Element Specific
 

--- a/examples/icons.ps1
+++ b/examples/icons.ps1
@@ -28,10 +28,13 @@ Start-PodeServer -Threads 2 {
     $card3 = New-PodeWebCard -Content @(
         New-PodeWebTable -Name Example -ScriptBlock {
             return @{
-                Icon = (New-PodeWebIcon -Name 'refresh' -Spin -Colour Yellow |
-                        Register-PodeWebEvent -Type Click -ScriptBlock {
-                            Show-PodeWebToast -Message 'Spinning icon clicked!'
-                        })
+                Icon = New-PodeWebIcon -Name 'refresh' -Spin -Colour Yellow -HoverIcon (New-PodeWebIconPreset -Name 'cat') |
+                    Register-PodeWebEvent -Type Click -ScriptBlock {
+                        Show-PodeWebToast -Message 'Spinning icon clicked!'
+                    } |
+                    Register-PodeWebEvent -Type MouseOver -ScriptBlock {
+                        Show-PodeWebToast -Message 'Spinning icon moused over!'
+                    }
             }
         }
     )

--- a/examples/inputs.ps1
+++ b/examples/inputs.ps1
@@ -8,6 +8,7 @@ Start-PodeServer -Threads 2 {
 
     # set the use of templates, and set a login page
     Initialize-PodeWebTemplates -Title 'Inputs' -Theme Dark
+    Import-PodeWebJavaScript -Url '/client-events.js'
 
     # set the home page controls (just a simple paragraph)
     $form = New-PodeWebForm -Name 'Test' -ButtonType Submit, Reset -AsCard -ScriptBlock {
@@ -23,6 +24,10 @@ Start-PodeServer -Threads 2 {
             } |
             Register-PodeWebEvent -Type KeyUp -ScriptBlock {
                 Show-PodeWebToast -Message "The element has a keyup: $($WebEvent.Data['Name'])"
+            } |
+            Register-PodeWebEvent -Type MouseOver -JSFunction 'customEvent' |
+            Register-PodeWebEvent -Type MouseOver -ScriptBlock {
+                Show-PodeWebToast -Message 'The element has the mouse over!'
             }
 
         New-PodeWebTextbox -Name 'Password' -Type Password -PrependIcon 'Lock' -Placeholder 'Enter your password' -HideName -Required

--- a/examples/inputs_no_form.ps1
+++ b/examples/inputs_no_form.ps1
@@ -1,0 +1,67 @@
+Import-Module Pode -MaximumVersion 2.99.99 -Force
+Import-Module ..\src\Pode.Web.psd1 -Force
+
+Start-PodeServer -Threads 2 {
+    # add a simple endpoint
+    Add-PodeEndpoint -Address localhost -Port 8091 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the use of templates, and set a login page
+    Initialize-PodeWebTemplates -Title 'Inputs' -Theme Dark
+    Import-PodeWebJavaScript -Url '/client-events.js'
+
+    # add home page
+    Add-PodeWebPage -Name 'Home' -Path '/' -Title 'Testing Inputs' -HomePage -ScriptBlock {
+        New-PodeWebCard -Name 'Inputs' -Content @(
+            New-PodeWebTextbox -Name 'Name' -AppendIcon Account |
+                Register-PodeWebEvent -Type KeyDown -ScriptBlock {
+                    Show-PodeWebToast -Message "The element has a keydown: $($WebEvent.Data['Name'])"
+                } |
+                Register-PodeWebEvent -Type KeyUp -ScriptBlock {
+                    Show-PodeWebToast -Message "The element has a keyup: $($WebEvent.Data['Name'])"
+                } |
+                Register-PodeWebEvent -Type MouseOver -JSFunction 'customEvent' |
+                Register-PodeWebEvent -Type MouseOver -ScriptBlock {
+                    Show-PodeWebToast -Message 'The element has the mouse over!'
+                }
+
+            New-PodeWebFileUpload -Name 'Upload' |
+                Register-PodeWebEvent -Type Change -ScriptBlock {
+                    $file = $WebEvent.Data['Upload']
+
+                    if ([string]::IsNullOrEmpty($file)) {
+                        Show-PodeWebToast -Message 'No files were uploaded'
+                        return
+                    }
+
+                    Show-PodeWebToast -Message "File uploaded: $($file)"
+                }
+
+            New-PodeWebButton -Name 'Custom Click' -ClickName "I've Been Clicked" -Colour Blue -NoClick |
+                Register-PodeWebEvent -Type Click -ScriptBlock {
+                    Start-Sleep -Seconds 3
+                    Show-PodeWebToast -Message 'The button click event was triggered!'
+                }
+
+            New-PodeWebRange -Name 'Range' -Step 2.5 -ShowValue |
+                Register-PodeWebEvent -Type Change -ScriptBlock {
+                    $value = $WebEvent.Data['Range']
+                    Show-PodeWebToast -Message "Range changed to: $($value)"
+                }
+            New-PodeWebButtonGroup -Buttons @(
+                New-PodeWebButton -Name 'Subtract' -DisplayName '-1' -Colour Red -ScriptBlock {
+                    Update-PodeWebRange -Name 'Range' -Value -1 -AsDelta
+                }
+                New-PodeWebButton -Name 'Add' -DisplayName '+1' -Colour Green -ScriptBlock {
+                    Update-PodeWebRange -Name 'Range' -Value 1 -AsDelta
+                }
+                New-PodeWebButton -Name 'Down' -Colour Red -ScriptBlock {
+                    Step-PodeWebRange -Name 'Range' -Direction Decrease
+                }
+                New-PodeWebButton -Name 'Up' -Colour Green -ScriptBlock {
+                    Step-PodeWebRange -Name 'Range' -Direction Increase
+                }
+            )
+        )
+    }
+}

--- a/examples/public/client-events.js
+++ b/examples/public/client-events.js
@@ -1,0 +1,3 @@
+function customEvent(evt, target, sender, eventType, opts) {
+    console.log(`Custom event triggered: ${eventType} on ${target.attr('pode-id')}`);
+}

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -1,5 +1,5 @@
 function Register-PodeWebElementEventInternal {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
@@ -10,11 +10,15 @@ function Register-PodeWebElementEventInternal {
         [string]
         $Type,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ScriptBlock')]
         [scriptblock]
         $ScriptBlock,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true, ParameterSetName = 'JSFunction')]
+        [string]
+        $JSFunction,
+
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [object[]]
         $ArgumentList,
 
@@ -22,11 +26,13 @@ function Register-PodeWebElementEventInternal {
         [System.Management.Automation.SessionState]
         $PSSession,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication
     )
+
+    $Type = $Type.ToLowerInvariant()
 
     # does element support events?
     if ($Element.NoEvents -or ($Element.ComponentType -ine 'element')) {
@@ -38,51 +44,61 @@ function Register-PodeWebElementEventInternal {
         $Element.Events = @()
     }
 
-    # ensure not already defined
-    if ($Element.Events -icontains $Type) {
-        throw "$($Element.ObjectType) $($Element.ComponentType) with ID '$($Element.ID)' already has the $($Type) event defined"
+    # add event type
+    $eventObj = @{
+        Type         = $Type
+        ID           = $Element.Events.Length + 1
+        IsClientSide = $PSCmdlet.ParameterSetName -ieq 'JSFunction'
     }
 
-    # add event type
-    $Element.Events += $Type.ToLowerInvariant()
+    # setup params for client-side events
+    if ($eventObj.IsClientSide) {
+        $eventObj.JSFunction = $JSFunction
+    }
 
-    # setup the route
-    $routePath = "/pode.web-dynamic/elements/$($Element.ObjectType.ToLowerInvariant())/$($Element.ID)/events/$($Type.ToLowerInvariant())"
-    if (!(Test-PodeWebRoute -Path $routePath)) {
-        # check for scoped vars
-        $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSSession
-        $eventLogic = @{
-            ScriptBlock    = $ScriptBlock
-            UsingVariables = $usingVars
-        }
+    # setup the route for server-side events
+    if (!$eventObj.IsClientSide) {
+        $routePath = "/pode.web-dynamic/elements/$($Element.ObjectType.ToLowerInvariant())/$($Element.ID)/events/$($Type.ToLowerInvariant())/$($eventObj.ID)"
 
-        $auth = $null
-        if (!$NoAuthentication -and !$Element.NoAuthentication -and !$PageData.NoAuthentication) {
-            $auth = (Get-PodeWebState -Name 'auth')
-        }
-
-        $argList = @(
-            @{ Data = $ArgumentList },
-            $Element,
-            $Type,
-            $eventLogic
-        )
-
-        Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $Element.EndpointName -ScriptBlock {
-            param($Data, $Element, $Type, $Logic)
-            $global:ElementData = $Element
-            $global:EventType = $Type
-            Set-PodeWebMetadata
-
-            $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
-
-            if (($null -ne $result) -and !$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
-                Write-PodeJsonResponse -Value $result
+        if (!(Test-PodeWebRoute -Path $routePath)) {
+            # check for scoped vars
+            $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSSession
+            $eventLogic = @{
+                ScriptBlock    = $ScriptBlock
+                UsingVariables = $usingVars
             }
 
-            $global:ElementData = $null
+            $auth = $null
+            if (!$NoAuthentication -and !$Element.NoAuthentication -and !$PageData.NoAuthentication) {
+                $auth = (Get-PodeWebState -Name 'auth')
+            }
+
+            $argList = @(
+                @{ Data = $ArgumentList },
+                $Element,
+                $Type,
+                $eventLogic
+            )
+
+            Add-PodeRoute -Method Post -Path $routePath -Authentication $auth -ArgumentList $argList -EndpointName $Element.EndpointName -ScriptBlock {
+                param($Data, $Element, $Type, $Logic)
+                $global:ElementData = $Element
+                $global:EventType = $Type
+                Set-PodeWebMetadata
+
+                $result = Invoke-PodeWebScriptBlock -Logic $Logic -Arguments $Data.Data
+
+                if (($null -ne $result) -and !$WebEvent.Response.Headers.ContainsKey('Content-Disposition')) {
+                    Write-PodeJsonResponse -Value $result
+                }
+
+                $global:ElementData = $null
+            }
         }
     }
+
+    # add event to element
+    $Element.Events += $eventObj
 }
 
 function Register-PodeWebPageEventInternal {

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -446,7 +446,7 @@ function Set-PodeWebState {
         $Value
     )
 
-    Set-PodeState -Name "pode.web.$($Name)" -Value $Value -Scope 'pode.web' | Out-Null
+    $null = Set-PodeState -Name "pode.web.$($Name)" -Value $Value -Scope 'pode.web'
 }
 
 function Get-PodeWebState {
@@ -957,7 +957,7 @@ function ConvertTo-PodeWebEvents {
     }
 
     foreach ($evt in $Events) {
-        $js_events += " on$($evt)=`"invokeEvent('$($evt)', this);`""
+        $js_events += " on$($evt)=`"invokePageEvent('$($evt)', this);`""
     }
 
     return $js_events

--- a/src/Public/Actions.ps1
+++ b/src/Public/Actions.ps1
@@ -3184,3 +3184,78 @@ function Update-PodeWebLink {
         NewTab     = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'NewTab' -Value $NewTab.IsPresent)
     }
 }
+
+function Update-PodeWebRange {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [int]
+        $Value,
+
+        [Parameter()]
+        [int]
+        $Min,
+
+        [Parameter()]
+        [int]
+        $Max,
+
+        [Parameter()]
+        [ValidateRange(0.1, [double]::MaxValue)]
+        [double]
+        $Step,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id,
+
+        [switch]
+        $Disabled,
+
+        [switch]
+        $AsDelta
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Update'
+        ObjectType = 'Range'
+        Value      = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Value' -Value $Value)
+        Min        = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Min' -Value $Min)
+        Max        = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Max' -Value $Max)
+        Step       = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Step' -Value $Step)
+        ID         = $Id
+        Name       = $Name
+        Disabled   = (Test-PodeWebParameter -Parameters $PSBoundParameters -Name 'Disabled' -Value $Disabled.IsPresent)
+        AsDelta    = $AsDelta.IsPresent
+    }
+}
+
+function Step-PodeWebRange {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Id')]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Increase', 'Decrease')]
+        [string]
+        $Direction
+    )
+
+    Send-PodeWebAction -Value @{
+        Operation  = 'Step'
+        ObjectType = 'Range'
+        ID         = $Id
+        Name       = $Name
+        Direction  = $Direction.ToLowerInvariant()
+    }
+}

--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -248,7 +248,6 @@ function New-PodeWebFileUpload {
         HideName      = $HideName.IsPresent
         ID            = $Id
         Accept        = ($Accept -join ',')
-        NoEvents      = $true
         Required      = $Required.IsPresent
         Multiple      = $Multiple.IsPresent
     }
@@ -290,7 +289,6 @@ function New-PodeWebParagraph {
         Value         = [System.Net.WebUtility]::HtmlEncode($Value)
         Content       = $Content
         Alignment     = $Alignment.ToLowerInvariant()
-        NoEvents      = $true
     }
 }
 
@@ -332,7 +330,6 @@ function New-PodeWebCodeBlock {
         Value         = [System.Net.WebUtility]::HtmlEncode($Value)
         Language      = $Language.ToLowerInvariant()
         Scrollable    = $Scrollable.IsPresent
-        NoEvents      = $true
     }
 }
 
@@ -356,7 +353,6 @@ function New-PodeWebCode {
         ObjectType    = 'Code'
         ID            = $Id
         Value         = [System.Net.WebUtility]::HtmlEncode($Value)
-        NoEvents      = $true
     }
 }
 
@@ -684,6 +680,11 @@ function New-PodeWebRange {
         [int]
         $Max = 100,
 
+        [Parameter()]
+        [ValidateRange(0.1, [double]::MaxValue)]
+        [double]
+        $Step = 1.0,
+
         [switch]
         $Disabled,
 
@@ -697,8 +698,19 @@ function New-PodeWebRange {
         $HideName
     )
 
+    # ensure min less than max, and max greater than min
+    if ($Min -ge $Max) {
+        throw 'The Min value must be less than the Max value for a Range element'
+    }
+
+    if ($Max -le $Min) {
+        throw 'The Max value must be greater than the Min value for a Range element'
+    }
+
+    # generate an ID
     $Id = Get-PodeWebElementId -Tag Range -Id $Id -Name $Name
 
+    # clamp value
     if ($Value -lt $Min) {
         $Value = $Min
     }
@@ -707,6 +719,12 @@ function New-PodeWebRange {
         $Value = $Max
     }
 
+    # clamp step
+    if ($Step -gt ($Max - $Min)) {
+        $Step = $Max - $Min
+    }
+
+    # build element
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -718,6 +736,7 @@ function New-PodeWebRange {
         Value         = $Value
         Min           = $Min
         Max           = $Max
+        Step          = $Step
         Disabled      = $Disabled.IsPresent
         ShowValue     = $ShowValue.IsPresent
         Required      = $Required.IsPresent
@@ -884,7 +903,6 @@ function New-PodeWebHeader {
         Value         = [System.Net.WebUtility]::HtmlEncode($Value)
         Secondary     = [System.Net.WebUtility]::HtmlEncode($Secondary)
         Icon          = (Protect-PodeWebIconType -Icon $Icon -Element 'Header')
-        NoEvents      = $true
     }
 }
 
@@ -919,7 +937,6 @@ function New-PodeWebQuote {
         Alignment     = $Alignment.ToLowerInvariant()
         Value         = [System.Net.WebUtility]::HtmlEncode($Value)
         Source        = [System.Net.WebUtility]::HtmlEncode($Source)
-        NoEvents      = $true
     }
 }
 
@@ -1060,7 +1077,6 @@ function New-PodeWebText {
         Style         = $Style
         InParagraph   = $InParagraph.IsPresent
         Alignment     = $Alignment.ToLowerInvariant()
-        NoEvents      = $true
     }
 }
 
@@ -1077,7 +1093,6 @@ function New-PodeWebLine {
         ComponentType = 'Element'
         ObjectType    = 'Line'
         ID            = (Get-PodeWebElementId -Tag Line -Id $Id)
-        NoEvents      = $true
     }
 }
 
@@ -1553,7 +1568,11 @@ function New-PodeWebButton {
         $Disabled,
 
         [switch]
-        $FullWidth
+        $FullWidth,
+
+        [Parameter(ParameterSetName = 'NoClick')]
+        [switch]
+        $NoClick
     )
 
     $Id = Get-PodeWebElementId -Tag Btn -Id $Id -Name $Name
@@ -1570,6 +1589,7 @@ function New-PodeWebButton {
         Icon             = (Protect-PodeWebIconType -Icon $Icon -Element 'Button')
         Url              = (Add-PodeWebAppPath -Url $Url)
         IsDynamic        = ($null -ne $ScriptBlock)
+        NoClick          = $NoClick.IsPresent
         IconOnly         = $IconOnly.IsPresent
         Colour           = $Colour
         Outline          = $Outline.IsPresent
@@ -1577,13 +1597,12 @@ function New-PodeWebButton {
         FullWidth        = $FullWidth.IsPresent
         NewLine          = $NewLine.IsPresent
         NewTab           = $NewTab.IsPresent
-        NoEvents         = $true
         NoAuthentication = $NoAuthentication.IsPresent
         Disabled         = $Disabled.IsPresent
     }
 
     $routePath = "/pode.web-dynamic/elements/button/$($Id)/click"
-    if (($null -ne $ScriptBlock) -and !(Test-PodeWebRoute -Path $routePath)) {
+    if (($null -ne $ScriptBlock) -and !$NoClick -and !(Test-PodeWebRoute -Path $routePath)) {
         # check for scoped vars
         $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
         $elementLogic = @{
@@ -1834,7 +1853,6 @@ function New-PodeWebSpinner {
         ID            = (Get-PodeWebElementId -Tag Spinner -Id $Id)
         Colour        = $Colour
         Title         = $Title
-        NoEvents      = $true
     }
 }
 

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -1,5 +1,5 @@
 function Register-PodeWebEvent {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidateNotNull()]
@@ -11,35 +11,57 @@ function Register-PodeWebEvent {
         [string[]]
         $Type,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ScriptBlock')]
         [scriptblock]
         $ScriptBlock,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true, ParameterSetName = 'JSFunction')]
+        [string]
+        $JSFunction,
+
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [object[]]
         $ArgumentList,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication
     )
 
+    # ensure component is and Element
+    if (!(Test-PodeWebContent -Content $Element -ComponentType Element)) {
+        throw "General events can only be registered on Elements, '$($Element.ComponentType)' given"
+    }
+
+    # params for internal call
+    $params = @{
+        Element   = $Element
+        PSSession = $PSCmdlet.SessionState
+    }
+
+    switch ($PSCmdlet.ParameterSetName) {
+        'ScriptBlock' {
+            $params.ScriptBlock = $ScriptBlock
+            $params.ArgumentList = $ArgumentList
+            $params.NoAuthentication = $NoAuthentication.IsPresent
+        }
+        'JSFunction' {
+            $params.JSFunction = $JSFunction
+        }
+    }
+
+    # register event
     foreach ($t in $Type) {
-        Register-PodeWebElementEventInternal `
-            -Element $Element `
-            -Type $t `
-            -ScriptBlock $ScriptBlock `
-            -ArgumentList $ArgumentList `
-            -PSSession $PSCmdlet.SessionState `
-            -NoAuthentication:$NoAuthentication | Out-Null
+        $params.Type = $t
+        $null = Register-PodeWebElementEventInternal @params
     }
 
     return $Element
 }
 
 function Register-PodeWebMediaEvent {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidateNotNull()]
@@ -51,15 +73,19 @@ function Register-PodeWebMediaEvent {
         [string[]]
         $Type,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ScriptBlock')]
         [scriptblock]
         $ScriptBlock,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true, ParameterSetName = 'JSFunction')]
+        [string]
+        $JSFunction,
+
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [object[]]
         $ArgumentList,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [Alias('NoAuth')]
         [switch]
         $NoAuthentication
@@ -67,18 +93,30 @@ function Register-PodeWebMediaEvent {
 
     # ensure component is Audio or Video only
     if (!(Test-PodeWebContent -Content $Element -ComponentType Element -ObjectType Audio, Video)) {
-        throw 'Media events can only be registered on Audio/Video elements'
+        throw "Media events can only be registered on Audio/Video elements, '$($Element.ObjectType)' given"
+    }
+
+    # params for internal call
+    $params = @{
+        Element   = $Element
+        PSSession = $PSCmdlet.SessionState
+    }
+
+    switch ($PSCmdlet.ParameterSetName) {
+        'ScriptBlock' {
+            $params.ScriptBlock = $ScriptBlock
+            $params.ArgumentList = $ArgumentList
+            $params.NoAuthentication = $NoAuthentication.IsPresent
+        }
+        'JSFunction' {
+            $params.JSFunction = $JSFunction
+        }
     }
 
     # register event
     foreach ($t in $Type) {
-        Register-PodeWebElementEventInternal `
-            -Element $Element `
-            -Type $t `
-            -ScriptBlock $ScriptBlock `
-            -ArgumentList $ArgumentList `
-            -PSSession $PSCmdlet.SessionState `
-            -NoAuthentication:$NoAuthentication | Out-Null
+        $params.Type = $t
+        $null = Register-PodeWebElementEventInternal @params
     }
 
     return $Element
@@ -116,18 +154,18 @@ function Register-PodeWebPageEvent {
 
     # ensure page is a page
     if (!(Test-PodeWebContent -Content $Page -ComponentType Page)) {
-        throw 'Page events can only be registered onto pages'
+        throw "Page events can only be registered onto pages, '$($Page.ComponentType)' given"
     }
 
     # register event
     foreach ($t in $Type) {
-        Register-PodeWebPageEventInternal `
+        $null = Register-PodeWebPageEventInternal `
             -Page $Page `
             -Type $t `
             -ScriptBlock $ScriptBlock `
             -ArgumentList $ArgumentList `
             -PSSession $PSCmdlet.SessionState `
-            -NoAuthentication:$NoAuthentication | Out-Null
+            -NoAuthentication:$NoAuthentication
     }
 
     if ($PassThru) {

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1384,15 +1384,12 @@ function getPageTitle() {
     return $('#pode-page-title h1').text().trim();
 }
 
-function invokeEvent(type, element) {
-    element = $(element);
+function invokePageEvent(eventType, target) {
+    sendAjaxReq(getPageUrl(`events/${eventType}`), null, null, true);
+}
 
-    if (getTagName(element) == null) {
-        sendAjaxReq(getPageUrl(`events/${type}`), null, null, true);
-    }
-    else {
-        PodeElementFactory.triggerObject(element.attr('pode-id'), type);
-    }
+function invokeServerEvent(evt, target, sender, eventType, opts) {
+    PodeElementFactory.triggerObject(target.attr('pode-id'), eventType, opts);
 }
 
 function generateUuid() {

--- a/src/Templates/Public/scripts/templates.js
+++ b/src/Templates/Public/scripts/templates.js
@@ -178,8 +178,8 @@ class PodeElementFactory {
         return this.referenceMap.get(id);
     }
 
-    static triggerObject(id, evt) {
-        return this.getObject(id).trigger(evt, true);
+    static triggerObject(id, evt, opts) {
+        return this.getObject(id).trigger(evt, true, opts);
     }
 
     static setTheme(theme) {
@@ -228,6 +228,9 @@ class PodeElement {
         this.width = data.Width ?? '';
         this.height = data.Height ?? '';
         this.themeable = false;
+        this.focused = false;
+        this.previouslyFocused = false;
+        this.focusable = false;
 
         this.content = {
             0: 'Content'
@@ -587,6 +590,10 @@ class PodeElement {
             case 'switch':
                 this.switch(data, sender, opts);
                 break;
+
+            case 'step':
+                this.steps(data, sender, opts);
+                break;
         }
 
         if (this.ephemeral) {
@@ -780,7 +787,7 @@ class PodeElement {
 
         if (checkGroup) {
             var group = element.closest('.pode-element-group');
-            if (group) {
+            if (group && group.length > 0) {
                 element = group;
             }
         }
@@ -792,7 +799,19 @@ class PodeElement {
             processData: false
         };
 
-        if (element.find('input[type=file]').length > 0) {
+        // if the element is an input, textarea or select, serialize directly
+        if (element.is('input, textarea, select')) {
+            if (element.is('input[type=file]')) {
+                data = newFormData(element);
+            }
+            else {
+                opts = {};
+                data = element.serialize();
+            }
+        }
+
+        // otherwise we're in a container; if it has a file input use FormData
+        else if (element.find('input[type=file]').length > 0) {
             data = newFormData(element.find('input, textarea, select'));
         }
         else {
@@ -812,45 +831,47 @@ class PodeElement {
         };
     }
 
-    events(evts) {
-        if (!evts) {
-            return '';
-        }
-
-        var strEvents = '';
-
-        convertToArray(evts).forEach((evt) => {
-            strEvents += `on${evt}="invokeEvent('${evt}', this);"`;
-        });
-
-        return strEvents;
-    }
-
-    trigger(evt, asAjax) {
+    trigger(evt, asAjax, opts) {
         if (asAjax) {
+            if (!opts || !opts.eventId) {
+                throw 'Event ID is required for AJAX event server-side triggers';
+            }
+
             var inputs = this.serialize(null, true);
             inputs.opts.keepFocus = true;
-            sendAjaxReq(`${this.url}/events/${evt}`, inputs.data, this, true, null, null, inputs.opts);
+            sendAjaxReq(`${this.url}/events/${evt}/${opts.eventId}`, inputs.data, this, true, null, null, inputs.opts);
         }
         else {
             this.element.trigger(evt);
         }
     }
 
-    listen(element, evt, func, noPreventDefault) {
+    listen(element, evt, func, noPreventDefault, opts) {
         element = element ?? this.element;
         if (!element) {
             return;
         }
 
         var obj = this;
-        element.off(evt).on(evt, function(e) {
-            if (!noPreventDefault) {
+        element.on(evt, function(e) {
+            var skip = false;
+
+            // check focus state
+            if (obj.focusable && (evt == 'focus' || evt == 'focusout') && obj.previouslyFocused === obj.focused) {
+                skip = true;
+                console.log(`focus: ${obj.focused}, skip event ${evt}`);
+            }
+
+            // stop propagation/prevent default
+            if (!noPreventDefault || skip) {
                 e.preventDefault();
                 e.stopPropagation();
             }
 
-            func(e, $(this), obj);
+            // invoke function
+            if (!skip) {
+                func(e, $(this), obj, evt, opts);
+            }
         });
     }
 
@@ -1272,6 +1293,10 @@ class PodeElement {
         throw `${this.getType()} "switch" method not implemented`;
     }
 
+    steps(data, sender, opts) {
+        throw `${this.getType()} "steps" method not implemented`;
+    }
+
     update(data, sender, opts) {
         if (data == null) {
             return;
@@ -1293,7 +1318,66 @@ class PodeElement {
             return;
         }
 
+        // bind custom events
+        this.bindCustomEvents(data, sender, opts);
+
+        // bind tooltips
         this.element.find('[data-bs-toggle="tooltip"]').tooltip();
+    }
+
+    bindCustomEvents(data, sender, opts) {
+        // skip if no events
+        if (!this.element || !data || !data.Events) {
+            return;
+        }
+
+        // skip if events are off
+        var eventsStatus = this.element.attr('pode-events-status');
+        if (eventsStatus == 'off') {
+            return;
+        }
+
+        // get this object
+        var obj = this;
+
+        // get delegate element if exists
+        var ele = this.element;
+        var delegateEle = $(`[pode-events-for='${this.uuid}']`);
+        if (delegateEle && delegateEle.length > 0) {
+            ele = delegateEle;
+        }
+
+        // unbind existing events
+        ele.off();
+
+        // bind event handlers, and track focus state to prevent erroneous focusout event
+        var focusHandled = false;
+
+        convertToArray(data.Events).forEach((evt) => {
+            // need to handle focus/focusout only once
+            if (!focusHandled && this.focusable && (evt.Type === 'focus' || evt.Type === 'focusout')) {
+                focusHandled = true;
+
+                ele.on('focus', function() {
+                    obj.previouslyFocused = obj.focused;
+                    obj.focused = true;
+                });
+
+                ele.on('focusout', function() {
+                    obj.previouslyFocused = obj.focused;
+                    obj.focused = false;
+                });
+            }
+
+            // determine function name for server/client side
+            var funcName = 'invokeServerEvent';
+            if (evt.IsClientSide) {
+                funcName = evt.JSFunction;
+            }
+
+            // bind event
+            obj.listen(ele, evt.Type, window[funcName], true, { eventId: evt.ID });
+        });
     }
 
     load(data, sender, opts) {
@@ -1536,6 +1620,7 @@ class PodeFormElement extends PodeContentElement {
             icon: (data.Append.Icon ?? '').toLowerCase()
         };
         this.inForm = false;
+        this.focusable = true;
     }
 
     isInForm(sender) {
@@ -1618,7 +1703,7 @@ class PodeFormElement extends PodeContentElement {
                     var formGroup = !this.inForm ? 'd-inline-block' : `form-group row mb-3`;
                     var divTag = this.asFieldset ? 'fieldset' : 'div';
                     var idProps = this.asFieldset ? `id='${this.id}' pode-object='${this.getType()}' pode-id='${this.uuid}'` : '';
-                    var events = this.asFieldset ? this.events(data.Events) : '';
+                    var events = this.asFieldset ? `pode-events-status='off'` : '';
                     var width = this.inForm || !this.width ? '' : `width:${this.width}`;
 
                     html = `<${divTag}
@@ -1717,8 +1802,7 @@ class PodeFormMultiElement extends PodeFormElement {
             name='${this.name}'
             class='row'
             pode-object='${this.getType()}'
-            pode-id='${this.uuid}'
-            ${this.events(data.Events)}>
+            pode-id='${this.uuid}'>
                 ${html}
         </div>`;
     }
@@ -1788,8 +1872,7 @@ class PodeBadge extends PodeTextualElement {
             id='${this.id}'
             class='badge text-bg-${PodeElement.mapColourToClass(data.Colour)} pode-text'
             pode-object='${this.getType()}'
-            pode-id='${this.uuid}'
-            ${this.events(data.Events)}>
+            pode-id='${this.uuid}'>
                 ${data.Value}
         </span>`;
     }
@@ -1925,8 +2008,7 @@ class PodeLink extends PodeTextualElement {
             class="pode-text"
             target='${data.NewTab ? '_blank' : '_self'}'
             pode-object='${this.getType()}'
-            pode-id='${this.uuid}'
-            ${this.events(data.Events)}>
+            pode-id='${this.uuid}'>
                 ${data.Value}
         </a>`;
     }
@@ -1995,12 +2077,13 @@ class PodeIcon extends PodeContentElement {
             style='${colour}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
-            ${title}
-            ${this.events(data.Events)}>
+            ${title}>
         </span>`;
     }
 
     bind(data, sender, opts) {
+        super.bind(data, sender, opts);
+
         // icon or parent?
         var obj = this;
         if (this.parent && this.parent.icon && this.parent.icon.uuid === this.uuid) {
@@ -2195,6 +2278,7 @@ class PodeButton extends PodeFormElement {
 
     constructor(data, sender, opts) {
         super(data, sender, opts);
+        this.noClick = data.NoClick ?? false;
         this.iconOnly = data.IconOnly;
         this.validation = false;
         this.label.enabled = false;
@@ -2213,7 +2297,7 @@ class PodeButton extends PodeFormElement {
         var html = '';
 
         if (this.iconOnly) {
-            if (this.dynamic) {
+            if (this.dynamic || this.noClick) {
                 html = `<button
                     type='button'
                     class='btn btn-icon-only pode-button'
@@ -2249,7 +2333,7 @@ class PodeButton extends PodeFormElement {
             var size = this.mapButtonSizeToClass();
             var sizeState = data.FullWidth ? 'btn-block' : '';
 
-            if (this.dynamic) {
+            if (this.dynamic || this.noClick) {
                 html = `<button
                     type='button'
                     class='btn ${colour} ${size} ${sizeState} pode-button'
@@ -2304,7 +2388,7 @@ class PodeButton extends PodeFormElement {
                 }
 
                 // find a form, if no group found
-                if (!group || group.length == 0) {
+                else {
                     var form = sender.element.closest('form');
                     if (form && form.length > 0) {
                         inputs = sender.serialize(form);
@@ -2708,8 +2792,7 @@ class PodeAlert extends PodeTextualElement {
             pode-object="${this.getType()}"
             pode-id='${this.uuid}'
             role="alert"
-            data-bs-theme="${getCssColorScheme()}"
-            ${this.events(data.Events)}>
+            data-bs-theme="${getCssColorScheme()}">
                 <h6 class='pode-alert-header'>
                     <span class="mdi mdi-${iconType}"></span>
                     <strong>${data.DisplayName}</strong>
@@ -3666,7 +3749,6 @@ class PodeTextbox extends PodeFormElement {
         var autofocus = this.autofocus ? 'autofocus' : '';
         var maxLength = data.MaxLength ? `maxlength='${data.MaxLength}'` : '';
         var width = `width:${this.width};`;
-        var events = this.events(data.Events);
 
         var placeholder = data.Placeholder
             ? `placeholder='${encodeAttribute(data.Placeholder)}'`
@@ -3684,7 +3766,6 @@ class PodeTextbox extends PodeFormElement {
                 style='${width}'
                 ${placeholder}
                 ${autofocus}
-                ${events}
                 ${maxLength}></textarea>`;
         }
 
@@ -3703,7 +3784,6 @@ class PodeTextbox extends PodeFormElement {
                 style='${width}'
                 ${placeholder}
                 ${autofocus}
-                ${events}
                 ${maxLength}>`;
         }
 
@@ -3822,8 +3902,7 @@ class PodeAudio extends PodeMediaElement {
             ${data.AutoPlay ? 'autoplay' : ''}
             ${data.AutoBuffer ? 'autobuffer' : ''}
             ${data.Loop ? 'loop' : ''}
-            ${data.Muted ? 'muted' : ''}
-            ${this.events(data.Events)}>
+            ${data.Muted ? 'muted' : ''}>
                 ${sources}
                 ${tracks}
                 ${data.NotSupportedText}
@@ -3866,8 +3945,7 @@ class PodeVideo extends PodeMediaElement {
             ${data.AutoBuffer ? 'autobuffer' : ''}
             ${data.Loop ? 'loop' : ''}
             ${data.Muted ? 'muted' : ''}
-            ${thumbnail})
-            ${this.events(data.Events)}>
+            ${thumbnail}>
                 ${sources}
                 ${tracks}
                 ${data.NotSupportedText}
@@ -4101,8 +4179,7 @@ class PodeImage extends PodeContentElement {
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
             data-bs-placement='bottom'
-            ${title}
-            ${this.events(data.Events)}>`;
+            ${title}>`;
     }
 
     update(data, sender, opts) {
@@ -4553,8 +4630,7 @@ class PodeCodeEditor extends PodeContentElement {
             name="${this.name}"
             class="pode-code-editor"
             pode-object="${this.getType()}"
-            pode-id="${this.uuid}"
-            ${this.events(data.Events)}>
+            pode-id="${this.uuid}">
                 ${upload}
                 <div class="code-editor" for="${this.id}"></div>
         </div>`;
@@ -5051,6 +5127,7 @@ class PodeModal extends PodeContentElement {
     }
 
     bind(data, sender, opts) {
+        super.bind(data, sender, opts);
         var obj = this;
 
         if (this.buttons.reset) {
@@ -5274,8 +5351,7 @@ class PodeSelect extends PodeFormElement {
             name='${this.name}'
             pode-object='${this.getType()}'
             pode-id='${this.uuid}'
-            ${multiple}
-            ${this.events(data.Events)}>
+            ${multiple}>
                 ${options}
         </select>`;
     }
@@ -5332,6 +5408,9 @@ class PodeRange extends PodeFormElement {
     constructor(data, sender, opts) {
         super(data, sender, opts);
         this.showValue = data.ShowValue ?? false;
+        this.min = data.Min ?? 0;
+        this.max = data.Max ?? 100;
+        this.step = data.Step ?? 1.0;
     }
 
     new(data, sender, opts) {
@@ -5341,9 +5420,10 @@ class PodeRange extends PodeFormElement {
             class='form-control pode-range-value'
             for='${this.id}'
             value='${data.Value}'
-            min='${data.Min}'
-            max='${data.Max}'>
-        <label class=''>/${data.Max}</label>`;
+            min='${this.min}'
+            max='${this.max}'
+            step='${this.step}'>
+        <span class='pode-range-max'>/${this.max}</span>`;
 
         return `<span class='range-wrapper' for='${this.id}' pode-container-for='${this.uuid}'>
             <input
@@ -5354,14 +5434,15 @@ class PodeRange extends PodeFormElement {
                 pode-object='${this.getType()}'
                 pode-id='${this.uuid}'
                 value='${data.Value}'
-                min='${data.Min}'
-                max='${data.Max}'
-                ${this.events(data.Events)}>
+                min='${this.min}'
+                max='${this.max}'
+                step='${this.step}'>
             ${rangeValue}
         </span>`;
     }
 
     bind(data, sender, opts) {
+        super.bind(data, sender, opts);
         var obj = this;
 
         if (this.showValue) {
@@ -5373,8 +5454,85 @@ class PodeRange extends PodeFormElement {
 
             this.listen(valElement, 'change', function(e, target) {
                 obj.element.val(valElement.val());
+                obj.trigger('change');
             }, true);
         }
+    }
+
+    update(data, sender, opts) {
+        super.update(data, sender, opts);
+
+        // update min if supplied
+        if (data.Min != null) {
+            var value = data.Min;
+            if (data.AsDelta) {
+                value = this.min + data.Min;
+            }
+
+            this.element.attr('min', value);
+            if (this.showValue) {
+                this.getNumberInput().attr('min', value);
+            }
+
+            this.min = value;
+        }
+
+        // update max if supplied
+        if (data.Max != null) {
+            var value = data.Max;
+            if (data.AsDelta) {
+                value = this.max + data.Max;
+            }
+
+            this.element.attr('max', value);
+            if (this.showValue) {
+                this.getNumberInput().attr('max', value);
+            }
+
+            this.max = value;
+        }
+
+        // update step if supplied
+        if (data.Step != null) {
+            var value = data.Step;
+            if (data.AsDelta) {
+                value = this.step + data.Step;
+            }
+
+            // ensure step is not greater than (max - min)
+            if (value > (this.max - this.min)) {
+                value = this.max - this.min;
+            }
+
+            this.element.attr('step', value);
+            if (this.showValue) {
+                this.getNumberInput().attr('step', value);
+            }
+
+            this.step = value;
+        }
+
+        // update value if supplied - but ensure the value is an increment of step
+        if (data.Value != null) {
+            var value = data.Value;
+            if (data.AsDelta) {
+                value = this.getValue() + data.Value;
+            }
+
+            // ensure value is an increment of step
+            if (((value - this.min) % this.step) !== 0) {
+                value = this.min + (Math.round((value - this.min) / this.step) * this.step);
+            }
+
+            // skip if value is out of range
+            this.updateValue(value);
+        }
+    }
+
+    steps(data, sender, opts) {
+        var currentValue = this.getValue();
+        var value = data.Direction == 'increase' ? currentValue + this.step : currentValue - this.step;
+        this.updateValue(value);
     }
 
     disable(data, sender, opts) {
@@ -5387,8 +5545,44 @@ class PodeRange extends PodeFormElement {
         enable(this.getNumberInput());
     }
 
+    updateValue(value) {
+        // ensure value is a number
+        if (value == null || isNaN(value)) {
+            return;
+        }
+
+        // clamp value to min/max
+        if (value < this.min) {
+            value = this.min;
+        }
+        else if (value > this.max) {
+            value = this.max;
+        }
+
+        // skip if no change
+        var currentValue = this.getValue();
+        if (value === currentValue) {
+            return;
+        }
+
+        // set value
+        this.element.val(value);
+        if (this.showValue) {
+            this.getNumberInput().val(value);
+        }
+
+        // trigger change
+        this.trigger('change');
+    }
+
+    getValue() {
+        return parseFloat(this.element.val());
+    }
+
     getNumberInput() {
-        return !this.showValue ? null : this.element.closest('.range-wrapper').find(`input[type="number"][for="${this.id}"]`);
+        return !this.showValue
+            ? null
+            : this.element.closest('.range-wrapper').find(`input[type="number"][for="${this.id}"]`);
     }
 }
 PodeElementFactory.setClass(PodeRange);
@@ -5420,8 +5614,7 @@ class PodeProgress extends PodeContentElement {
                     aria-valuemin='${data.Min ?? 0}'
                     aria-valuemax='${data.Max ?? 100}'
                     pode-object='${this.getType()}'
-                    pode-id='${this.uuid}'
-                    ${this.events(data.Events)}>
+                    pode-id='${this.uuid}'>
                 </div>
         </div>`;
 
@@ -5444,6 +5637,7 @@ class PodeProgress extends PodeContentElement {
     }
 
     bind(data, sender, opts) {
+        super.bind(data, sender, opts);
         var obj = this;
 
         if (this.showValue) {
@@ -5957,7 +6151,8 @@ class PodeFileStream extends PodeContentElement {
                             class="form-control"
                             rows="$($data.Height)"
                             readonly
-                            ${this.events(data.Events)}></textarea>
+                            pode-events-for='${this.uuid}'>
+                        </textarea>
                     </pre>
                 </div>
         </div>`;
@@ -6192,6 +6387,7 @@ class PodeStep extends PodeContentElement {
     }
 
     bind(data, sender, opts) {
+        super.bind(data, sender, opts);
         var obj = this;
 
         // auto submit on enter key
@@ -6395,6 +6591,7 @@ class PodeNavLink extends PodeNavElement {
     }
 
     bind(data, sender, opts) {
+        super.bind(data, sender, opts);
         var obj = this;
 
         if (this.dynamic) {

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -496,11 +496,16 @@ div.pode-grid {
 input[type="range"].pode-range-value {
     display: inline;
     width: 87% !important;
+    vertical-align: middle;
 }
 
 input[type="number"].pode-range-value {
     display: inline;
     width: 6% !important;
+}
+
+span.pode-range-max {
+    vertical-align: middle;
 }
 
 input[type=date]::-webkit-calendar-picker-indicator:hover,


### PR DESCRIPTION
### Description of the Change
Updates a lot of events functionality, and Range features:

* Added support for Events to trigger JavaScript functions
* Enabled support to supply multiple of the same event type for an element
* Enabled Events support for additional elements: Spinners, Lines, Text, Quotes, Headers, Code, Code Blocks, Paragraphs, File Uploads, and Buttons
* Fixed a bug with Range value textbox not triggering Change events
* Added custom "step" support for Range elements
* Added Update and Step Actions for Range elements

For buttons, there is now a `-NoClick` switch which will render a "dummy" button - no URL or ScriptBlock. Instead, you can pipe the button into `Register-PodeWebEvent` and build your own custom handlers.

For the supplying of multiple of the same event types, this means you can now call `Register-PodeWebEvent` and supply multiple click, or change, or mouseover events to the same element - and they will be invoked in the other the events were defined. You can even mix-and-match server-side/client-side events.

### Related Issue
* Resolves #463 
* Resolves #494 
* Resolves #492 
* Resolves #683 
