### PR TITLE
Added support to state where custom JavaScript files are imported - Head or Body; Added additional parameters for importing custom JavaScript/CSS, such as Integrity, Async, etc.

### DIFF
--- a/docs/Tutorials/Basics.md
+++ b/docs/Tutorials/Basics.md
@@ -149,3 +149,5 @@ Initialize-PodeWebTemplates -Title 'Example' -Theme Dark -HideSidebar
 ## Custom Scripts/Styles
 
 You can reference custom JavaScript and CSS files to use via [`Import-PodeWebJavaScript`](../../Functions/Utilities/Import-PodeWebJavaScript) and [`Import-PodeWebStylesheet`](../../Functions/Utilities/Import-PodeWebStylesheet). Both take a relative/literal `-Url` to the file.
+
+For each, you can also supply additional parameters to help define how the JavaScript or CSS file should be retrieved, such as: async; crossorigin; integrity; etc.

--- a/examples/inputs_no_form.ps1
+++ b/examples/inputs_no_form.ps1
@@ -8,7 +8,7 @@ Start-PodeServer -Threads 2 {
 
     # set the use of templates, and set a login page
     Initialize-PodeWebTemplates -Title 'Inputs' -Theme Dark
-    Import-PodeWebJavaScript -Url '/client-events.js'
+    Import-PodeWebJavaScript -Url '/client-events.js' -Location Head -Async
 
     # add home page
     Add-PodeWebPage -Name 'Home' -Path '/' -Title 'Testing Inputs' -HomePage -ScriptBlock {

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -144,10 +144,44 @@ function Import-PodeWebStylesheet {
     param(
         [Parameter(Mandatory = $true)]
         [string]
-        $Url
+        $Url,
+
+        [Parameter()]
+        [ValidateSet('Render')]
+        [string[]]
+        $Blocking,
+
+        [Parameter()]
+        [ValidateSet('Anonymous', 'Use-Credentials')]
+        [string]
+        $CrossOrigin,
+
+        [Parameter()]
+        [ValidateSet('Auto', 'High', 'Low')]
+        [string]
+        $FetchPriority = 'Auto',
+
+        [Parameter()]
+        [ValidateSet('No-Referrer', 'No-Referrer-When-Downgrade', 'Origin', 'Origin-When-Cross-Origin', 'Unsafe-URL')]
+        [string]
+        $ReferrerPolicy,
+
+        [Parameter()]
+        [string]
+        $Integrity
     )
 
-    Set-PodeWebState -Name 'custom-css' -Value  (@(Get-PodeWebState -Name 'custom-css') + (Add-PodeWebAppPath -Url $Url))
+    # build stylesheet entry and add to state
+    $value = @{
+        Url            = (Add-PodeWebAppPath -Url $Url)
+        Blocking       = "$($Blocking)".ToLowerInvariant()
+        CrossOrigin    = "$($CrossOrigin)".ToLowerInvariant()
+        FetchPriority  = "$($FetchPriority)".ToLowerInvariant()
+        ReferrerPolicy = "$($ReferrerPolicy)".ToLowerInvariant()
+        Integrity      = $Integrity
+    }
+
+    Set-PodeWebState -Name 'custom-css' -Value  (@(Get-PodeWebState -Name 'custom-css') + $value)
 }
 
 function Import-PodeWebJavaScript {
@@ -155,10 +189,64 @@ function Import-PodeWebJavaScript {
     param(
         [Parameter(Mandatory = $true)]
         [string]
-        $Url
+        $Url,
+
+        [Parameter()]
+        [ValidateSet('Head', 'Body')]
+        [string]
+        $Location = 'Body',
+
+        [Parameter()]
+        [ValidateSet('Render')]
+        [string[]]
+        $Blocking,
+
+        [Parameter()]
+        [ValidateSet('Anonymous', 'Use-Credentials')]
+        [string]
+        $CrossOrigin,
+
+        [Parameter()]
+        [ValidateSet('Auto', 'High', 'Low')]
+        [string]
+        $FetchPriority = 'Auto',
+
+        [Parameter()]
+        [ValidateSet('No-Referrer', 'No-Referrer-When-Downgrade', 'Origin', 'Origin-When-Cross-Origin', 'Same-Origin', 'Strict-Origin', 'Strict-Origin-When-Cross-Origin', 'Unsafe-URL')]
+        [string]
+        $ReferrerPolicy,
+
+        [Parameter()]
+        [string]
+        $Integrity,
+
+        [switch]
+        $Async,
+
+        [switch]
+        $Defer
     )
 
-    Set-PodeWebState -Name 'custom-js' -Value  (@(Get-PodeWebState -Name 'custom-js') + (Add-PodeWebAppPath -Url $Url))
+    # ensure not blocking in body
+    if (($Blocking -icontains 'Render') -and ($Location -ieq 'Body')) {
+        throw "When using 'Render' blocking, the location must be 'Head' for JavaScript imports."
+    }
+
+    # build javascript entry
+    $value = @{
+        Url            = (Add-PodeWebAppPath -Url $Url)
+        Location       = $Location
+        Blocking       = "$($Blocking)".ToLowerInvariant()
+        CrossOrigin    = "$($CrossOrigin)".ToLowerInvariant()
+        FetchPriority  = "$($FetchPriority)".ToLowerInvariant()
+        ReferrerPolicy = "$($ReferrerPolicy)".ToLowerInvariant()
+        Integrity      = $Integrity
+        Async          = $Async.IsPresent
+        Defer          = $Defer.IsPresent
+    }
+
+    # add to state
+    Set-PodeWebState -Name 'custom-js' -Value  (@(Get-PodeWebState -Name 'custom-js') + $value)
 }
 
 function Set-PodeWebSocial {

--- a/src/Templates/Views/shared/custom_scripts.pode
+++ b/src/Templates/Views/shared/custom_scripts.pode
@@ -1,0 +1,44 @@
+$(
+    $scripts = Get-PodeWebState -Name 'custom-js'
+    foreach ($js in $scripts) {
+        if ($js.Location -ine $data.Location) {
+            continue
+        }
+
+        $blocking = ''
+        if ($js.Blocking) {
+            $blocking = "blocking='$($js.Blocking -join ', ')'"
+        }
+
+        $crossOrigin = ''
+        if ($js.CrossOrigin) {
+            $crossOrigin = "crossorigin='$($js.CrossOrigin)'"
+        }
+
+        $fetchPriority = ''
+        if ($js.FetchPriority) {
+            $fetchPriority = "fetchpriority='$($js.FetchPriority)'"
+        }
+
+        $referrerPolicy = ''
+        if ($js.ReferrerPolicy) {
+            $referrerPolicy = "referrerpolicy='$($js.ReferrerPolicy)'"
+        }
+
+        $integrity = ''
+        if ($js.Integrity) {
+            $integrity = "integrity='$($js.Integrity)'"
+        }
+
+        "<script
+            src='$($js.Url)'
+            $(if ($js.Async) { 'async' })
+            $(if ($js.Defer) { 'defer' })
+            $blocking
+            $crossOrigin
+            $fetchPriority
+            $referrerPolicy
+            $integrity
+        ></script>"
+    }
+)

--- a/src/Templates/Views/shared/head.pode
+++ b/src/Templates/Views/shared/head.pode
@@ -28,9 +28,46 @@
 
     $(
         # custom stylesheets
-        $styles = @(Get-PodeWebState -Name 'custom-css')
+        $styles = Get-PodeWebState -Name 'custom-css'
         foreach ($style in $styles) {
-            "<link class='pode-custom-css' rel='stylesheet' href='$($style)'>"
+            $blocking = ''
+            if ($style.Blocking) {
+                $blocking = "blocking='$($style.Blocking -join ', ')'"
+            }
+
+            $crossOrigin = ''
+            if ($style.CrossOrigin) {
+                $crossOrigin = "crossorigin='$($style.CrossOrigin)'"
+            }
+
+            $fetchPriority = ''
+            if ($style.FetchPriority) {
+                $fetchPriority = "fetchpriority='$($style.FetchPriority)'"
+            }
+
+            $referrerPolicy = ''
+            if ($style.ReferrerPolicy) {
+                $referrerPolicy = "referrerpolicy='$($style.ReferrerPolicy)'"
+            }
+
+            $integrity = ''
+            if ($style.Integrity) {
+                $integrity = "integrity='$($style.Integrity)'"
+            }
+
+            "<link
+                rel='stylesheet'
+                href='$($style.Url)'
+                $blocking
+                $crossOrigin
+                $fetchPriority
+                $referrerPolicy
+                $integrity
+            />"
         }
     )
+
+    $(Use-PodeWebPartialView -Path 'shared/custom_scripts' -Data @{
+        Location = 'Head'
+    })
 </head>

--- a/src/Templates/Views/shared/scripts.pode
+++ b/src/Templates/Views/shared/scripts.pode
@@ -12,9 +12,6 @@
 <script src="$($data.AppPath)/pode.web-static/scripts/default.js"></script>
 <script src="$($data.AppPath)/pode.web-static/scripts/templates.js"></script>
 
-$(
-    $scripts = @(Get-PodeWebState -Name 'custom-js')
-    foreach ($js in $scripts) {
-        "<script src='$($js)'></script>"
-    }
-)
+$(Use-PodeWebPartialView -Path 'shared/custom_scripts' -Data @{
+    Location = 'Body'
+})


### PR DESCRIPTION
### Description of the Change
* Added a new `-Location [Head|Body]` parameter to `Import-PodeWebJavaScript` to define where the file should be imported. The default remains as Body.
* Added the following additional parameters for `Import-PodeWebJavaScript`: Blocking, CrossOrigin, FetchPriority, ReferrerPolicy, Integrity, Async, and Defer
* Added the following additional parameters for `Import-PodeWebStylesheet`: Blocking, CrossOrigin, FetchPriority, ReferrerPolicy, Integrity

### Related Issue
Resolves #497 