### PR TITLE
696 bug -Icon parameter needs renamed to -AvatarUrl in full_custom_auth.ps1 and full_iis.ps1

### DIFF
--- a/examples/full_custom_auth.ps1
+++ b/examples/full_custom_auth.ps1
@@ -149,8 +149,8 @@ Start-PodeServer -StatusPageExceptions Show {
     )
 
     $section3 = New-PodeWebCard -Name 'Comments' -Icon 'comment' -Content @(
-        New-PodeWebComment -Icon '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
-        New-PodeWebComment -Icon '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
+        New-PodeWebComment -AvatarUrl '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
+        New-PodeWebComment -AvatarUrl '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
     )
 
     $codeEditor = New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor' -AsCard

--- a/examples/full_iis.ps1
+++ b/examples/full_iis.ps1
@@ -106,8 +106,8 @@ Start-PodeServer -StatusPageExceptions Show {
     )
 
     $section3 = New-PodeWebCard -Name 'Comments' -Icon 'comment' -Content @(
-        New-PodeWebComment -Icon '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
-        New-PodeWebComment -Icon '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
+        New-PodeWebComment -AvatarUrl '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
+        New-PodeWebComment -AvatarUrl '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
     )
 
     $codeEditor = New-PodeWebCodeEditor -Language PowerShell -Name 'Code Editor' -AsCard


### PR DESCRIPTION
### Description
**_Icon_** parameter needs renamed to `-AvatarUrl` in `full_custom_auth.ps1` and `full_iis.ps1`

### https://github.com/Badgerati/Pode.Web/issues/696
bug 🐛

Status: Open.
#696 In Badgerati/Pode.Web;· [andmigque](https://github.com/Badgerati/Pode.Web/issues?q=is%3Aissue%20state%3Aopen%20author%3Aandmigque) opened 34 minutes ago

### Examples

```powershell
    New-PodeWebComment -AvatarUrl '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum'
    New-PodeWebComment -AvatarUrl '/pode.web-static/images/icon.png' -Username 'Badgerati' -Message 'Lorem ipsum' -TimeStamp ([datetime]::Now)
```
### Additional Context
    Left -Address as *. I change to localhost locally to avoid admin during test.
    full_iis.ps1 example did not run for me as I do not yet have IIS setup. Will get IIS squared away for future testing.

### Description of the Change
A clear and concise description of what has been changed.

### Related Issue
A link/reference to the GitHub issue.

### Examples
If relevant, include any examples of using what you have changed.

### Additional Context
Add any other context or screenshots about the pull request request here.
