### PR TITLE
Cascading Null Icons in Element Initialization, Closes #673 bug

### DIFF
--- a/src/Public/Elements.ps1
+++ b/src/Public/Elements.ps1
@@ -1440,6 +1440,7 @@ function New-PodeWebHeader {
 
     $Id = Get-PodeWebElementId -Tag Header -Id $Id
 
+    if ($null -eq $Icon) { $Icon = 'text' }
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -2123,6 +2124,7 @@ function New-PodeWebButton {
 
     $Id = Get-PodeWebElementId -Tag Btn -Id $Id -Name $Name
 
+    if ($null -eq $Icon) { $Icon = 'gesture-tap' }
     $element = @{
         Operation        = 'New'
         ComponentType    = 'Element'
@@ -3141,6 +3143,7 @@ function Initialize-PodeWebTableColumn {
         $Name = $Key
     }
 
+    if ($null -eq $Icon) { $Icon = 'table-column' }
     return @{
         Key       = $Key
         Width     = (ConvertTo-PodeWebSize -Value $Width -Default 'auto' -Type '%')
@@ -3233,6 +3236,7 @@ function Add-PodeWebTableButton {
         }
     }
 
+    if ($null -eq $Icon) { $Icon = 'table-cog' }
     $Table.Buttons += @{
         Name        = $Name
         DisplayName = (Protect-PodeWebValue -Value $DisplayName -Default $Name -Encode)
@@ -3664,6 +3668,7 @@ function New-PodeWebTile {
         $RefreshInterval = 60
     }
 
+    if ($null -eq $Icon) { $Icon = 'view-dashboard-outline' }
     $element = @{
         Operation        = 'New'
         ComponentType    = 'Element'
@@ -3830,6 +3835,7 @@ function New-PodeWebFileStream {
         $Interval = 10
     }
 
+    if ($null -eq $Icon) { $Icon = 'file-document-outline' }
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -4321,6 +4327,7 @@ function New-PodeWebTab {
         throw 'A Tab can only contain other elements'
     }
 
+    if ($null -eq $Icon) { $Icon = 'tab' }
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -4376,6 +4383,7 @@ function New-PodeWebCard {
         throw 'Card Buttons can only contain Buttons'
     }
 
+    if ($null -eq $Icon) { $Icon = 'card-text-outline' }
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -4549,6 +4557,7 @@ function New-PodeWebModal {
         $ButtonType = @('Close')
     }
 
+    if ($null -eq $Icon) { $Icon = 'application-outline' }
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -4828,6 +4837,7 @@ function New-PodeWebStep {
         }
     }
 
+    if ($null -eq $Icon) { $Icon = 'chevron-right-circle-outline' }
     return @{
         Operation     = 'New'
         ComponentType = 'Element'
@@ -4987,6 +4997,7 @@ function New-PodeWebBellow {
         throw 'A Bellow can only contain other elements'
     }
 
+    if ($null -eq $Icon) { $Icon = 'chevron-down' }
     return @{
         Operation     = 'New'
         ComponentType = 'Element'

--- a/src/Templates/Public/scripts/default.js
+++ b/src/Templates/Public/scripts/default.js
@@ -1008,7 +1008,8 @@ function buildTableHeader(column, direction, hidden) {
     value += ">";
 
     if (column.Icon) {
-        value += `<span class='mdi mdi-${column.Icon.toLowerCase()} mRight04'></span>`;
+        var iconName = typeof column.Icon === 'string' ? column.Icon : column.Icon.Name;
+        value += `<span class='mdi mdi-${iconName.toLowerCase()} mRight04'></span>`;
     }
 
     value += `${column.Name}</th>`;


### PR DESCRIPTION
# Cascading Null Icons in Element Initialization
### Closes 673 Bug  
### Description

  When -Icon is not provided to any of the 11 affected elements, $null propagates
  silently through `Protect-PodeWebIconType` and into the client-side `buildTableHeader`,
  where calling `.toLowerCase()` on a null icon crashes the render.

  The root cause is a cascade of nested `$null` icon values — not immediately obvious
  until you add a throw at each `Protect-PodeWebIconType` callsite and watch them all
  fail.

  ### Examples

  **Add**
     `$null` guard with a sane default icon

```powershell
if ($null -eq $Icon) { $Icon = 'text' }`
```

  **Add**

_string_ at 11 callsites in Elements.ps1
    **_Header, Button, Table Column, Table Button. Tile, File Stream, Tab, Card, Modal, Step, Bellow_**

  **Refactor** 

`buildTableHeader` in default.js to handle both string and 
        `New-PodeWebIcon` hashtable values for column.Icon

 ```javascript
    if (column.Icon) {
        var iconName = typeof column.Icon === 'string' ? column.Icon : column.Icon.Name;
        value += `<span class='mdi mdi-${iconName.toLowerCase()} mRight04'></span>`;
    }
```
  Related Issue

  https://github.com/Badgerati/Pode.Web/issues/673