### PR TITLE
Fixes Autocomplete dropdown appearing behind Modals

### DIFF
--- a/examples/modals.ps1
+++ b/examples/modals.ps1
@@ -9,11 +9,11 @@ Start-PodeServer -Browse {
     # set the use of templates, and set a login page
     Initialize-PodeWebTemplates -Title 'Modals Example' -Theme Dark
 
-    # home page with link togglging
+    # home page with link toggling
     Add-PodeWebPage -Name 'Home' -Path '/' -HomePage -Title 'Homepage' -ScriptBlock {
         # modal 1 - form
         New-PodeWebModal -Name 'Form Modal' -AsForm -Content @(
-            New-PodeWebTextbox -Name 'Name1' -Type Text
+            New-PodeWebTextbox -Name 'Name1' -Type Text -AutoComplete { return @('John', 'Jane', 'Jack', 'Jill', 'James', 'Judy', 'Jerry', 'Jasmine', 'Joan', 'Jacob', 'Julia', 'Jordan') }
             New-PodeWebTextbox -Name 'Comment1' -Multiline
         ) -ScriptBlock {
             Show-PodeWebToast -Title $WebEvent.Data.Name1 -Message $WebEvent.Data.Comment1

--- a/src/Templates/Public/styles/default.css
+++ b/src/Templates/Public/styles/default.css
@@ -387,6 +387,7 @@ a.disabled {
     border-width: 2px;
     margin-top: -1px;
     border-radius: 5px;
+    z-index: 9999;
 }
 
 table .btn-icon-only {


### PR DESCRIPTION
### Description of the Change
Applies a z-index to the AutoComplete dropdown, so they don't appear behind Modals for Textboxes

### Related Issue
Resolves #701